### PR TITLE
Arbitrary proposal sign via path traversal

### DIFF
--- a/crates/server/src/api/grpc.rs
+++ b/crates/server/src/api/grpc.rs
@@ -714,7 +714,8 @@ mod tests {
         let dummy_sig = format!("0x{}", "a".repeat(666));
         let request = state_manager::SignDeltaProposalRequest {
             account_id,
-            commitment: "nonexistent_proposal".to_string(),
+            commitment: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                .to_string(),
             signature: Some(state_manager::ProposalSignature {
                 scheme: "falcon".to_string(),
                 signature: dummy_sig,

--- a/crates/server/src/api/http.rs
+++ b/crates/server/src/api/http.rs
@@ -559,7 +559,8 @@ mod tests {
         let dummy_sig = format!("0x{}", "a".repeat(666));
         let request = SignProposalRequest {
             account_id,
-            commitment: "nonexistent_proposal".to_string(),
+            commitment: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                .to_string(),
             signature: ProposalSignature::Falcon {
                 signature: dummy_sig,
             },

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -19,6 +19,7 @@ pub mod network;
 pub mod services;
 pub mod state_object;
 pub mod storage;
+mod utils;
 
 #[cfg(test)]
 pub mod testing;

--- a/crates/server/src/services/sign_delta_proposal.rs
+++ b/crates/server/src/services/sign_delta_proposal.rs
@@ -3,6 +3,7 @@ use crate::delta_object::{CosignerSignature, DeltaObject, DeltaStatus, ProposalS
 use crate::error::{PsmError, Result};
 use crate::metadata::auth::Credentials;
 use crate::services::resolve_account;
+use crate::utils::normalize_commitment_hex;
 use miden_protocol::crypto::dsa::falcon512_rpo::PublicKey;
 use miden_protocol::utils::Serializable;
 use private_state_manager_shared::DeltaSignature;
@@ -33,18 +34,27 @@ pub async fn sign_delta_proposal(
         credentials,
     } = params;
 
+    let normalized_commitment = normalize_commitment_hex(&commitment)?;
+
     // Resolve account and verify authentication
     let resolved = resolve_account(state, &account_id, &credentials).await?;
 
     // Fetch the proposal by commitment
     let mut delta_proposal = resolved
         .storage
-        .pull_delta_proposal(&account_id, &commitment)
+        .pull_delta_proposal(&account_id, &normalized_commitment)
         .await
         .map_err(|_| PsmError::ProposalNotFound {
             account_id: account_id.clone(),
-            commitment: commitment.clone(),
+            commitment: normalized_commitment.clone(),
         })?;
+
+    if !delta_proposal.account_id.eq_ignore_ascii_case(&account_id) {
+        return Err(PsmError::ProposalNotFound {
+            account_id: account_id.clone(),
+            commitment: normalized_commitment,
+        });
+    }
 
     // Verify is a pending proposal
     let (timestamp, proposer_id, mut cosigner_sigs) = match &delta_proposal.status {
@@ -60,7 +70,7 @@ pub async fn sign_delta_proposal(
         _ => {
             return Err(PsmError::ProposalNotFound {
                 account_id: account_id.clone(),
-                commitment: commitment.clone(),
+                commitment: normalized_commitment.clone(),
             });
         }
     };
@@ -142,7 +152,7 @@ pub async fn sign_delta_proposal(
     // Store the updated proposal
     resolved
         .storage
-        .update_delta_proposal(&commitment, &delta_proposal)
+        .update_delta_proposal(&normalized_commitment, &delta_proposal)
         .await
         .map_err(PsmError::StorageError)?;
 
@@ -230,7 +240,8 @@ mod tests {
         let (state, storage, _network, metadata) = create_test_state();
 
         let account_id = "0x7bfb0f38b0fafa103f86a805594170".to_string();
-        let commitment = "mock_proposal_id".to_string();
+        let commitment =
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string();
 
         let (_proposer_pubkey, proposer_commitment, _proposer_signature, _proposer_timestamp) =
             crate::testing::helpers::generate_falcon_signature(&account_id);
@@ -299,7 +310,8 @@ mod tests {
         let (state, storage, _network, metadata) = create_test_state();
 
         let account_id = "0x7bfb0f38b0fafa103f86a805594170".to_string();
-        let commitment = "mock_proposal_id".to_string();
+        let commitment =
+            "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string();
 
         let (_proposer_pubkey, proposer_commitment, _proposer_signature, _proposer_timestamp) =
             crate::testing::helpers::generate_falcon_signature(&account_id);
@@ -370,7 +382,8 @@ mod tests {
         let (state, storage, _network, metadata) = create_test_state();
 
         let account_id = "0x7bfb0f38b0fafa103f86a805594170".to_string();
-        let commitment = "nonexistent_proposal".to_string();
+        let commitment =
+            "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc".to_string();
 
         let (signer_pubkey, signer_commitment, signer_signature, signer_timestamp) =
             crate::testing::helpers::generate_falcon_signature(&account_id);
@@ -412,7 +425,8 @@ mod tests {
         let (state, storage, _network, metadata) = create_test_state();
 
         let account_id = "0x7bfb0f38b0fafa103f86a805594170".to_string();
-        let commitment = "mock_proposal_id".to_string();
+        let commitment =
+            "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd".to_string();
 
         let (_proposer_pubkey, proposer_commitment, _proposer_signature, _proposer_timestamp) =
             crate::testing::helpers::generate_falcon_signature(&account_id);
@@ -464,7 +478,8 @@ mod tests {
         let (state, _storage, _network, metadata) = create_test_state();
 
         let account_id = "0x7bfb0f38b0fafa103f86a805594170".to_string();
-        let commitment = "mock_proposal_id".to_string();
+        let commitment =
+            "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee".to_string();
 
         let (_proposer_pubkey, proposer_commitment, _proposer_signature, _proposer_timestamp) =
             crate::testing::helpers::generate_falcon_signature(&account_id);
@@ -508,7 +523,8 @@ mod tests {
         let (state, storage, _network, metadata) = create_test_state();
 
         let account_id = "0x7bfb0f38b0fafa103f86a805594170".to_string();
-        let commitment = "mock_proposal_id".to_string();
+        let commitment =
+            "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff".to_string();
 
         let (_proposer_pubkey, proposer_commitment, _proposer_signature, _proposer_timestamp) =
             crate::testing::helpers::generate_falcon_signature(&account_id);
@@ -544,5 +560,79 @@ mod tests {
             PsmError::StorageError(_) => {}
             e => panic!("Expected StorageError, got: {:?}", e),
         }
+    }
+
+    #[tokio::test]
+    async fn test_sign_delta_proposal_invalid_commitment_rejected() {
+        let (state, storage, _network, metadata) = create_test_state();
+
+        let account_id = "0x7bfb0f38b0fafa103f86a805594170".to_string();
+        let (signer_pubkey, signer_commitment, signer_signature, signer_timestamp) =
+            crate::testing::helpers::generate_falcon_signature(&account_id);
+
+        let _metadata = metadata.with_get(Ok(Some(create_account_metadata(
+            account_id.clone(),
+            vec![signer_commitment],
+        ))));
+
+        let params = SignDeltaProposalParams {
+            account_id,
+            commitment: "../../other_account/proposals/abc".to_string(),
+            signature: ProposalSignature::Falcon {
+                signature: format!("0x{}", "a".repeat(666)),
+            },
+            credentials: Credentials::signature(signer_pubkey, signer_signature, signer_timestamp),
+        };
+
+        let result = sign_delta_proposal(&state, params).await;
+        assert!(matches!(result, Err(PsmError::InvalidCommitment(_))));
+        assert!(
+            storage.get_pull_delta_proposal_calls().is_empty(),
+            "storage should not be queried for invalid commitment input"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sign_delta_proposal_rejects_mismatched_account() {
+        let (state, storage, _network, metadata) = create_test_state();
+
+        let account_id = "0x7bfb0f38b0fafa103f86a805594170".to_string();
+        let commitment =
+            "0x1111111111111111111111111111111111111111111111111111111111111111".to_string();
+
+        let (_proposer_pubkey, proposer_commitment, _proposer_signature, _proposer_timestamp) =
+            crate::testing::helpers::generate_falcon_signature(&account_id);
+        let (signer_pubkey, signer_commitment, signer_signature, signer_timestamp) =
+            crate::testing::helpers::generate_falcon_signature(&account_id);
+
+        let _metadata = metadata.with_get(Ok(Some(create_account_metadata(
+            account_id.clone(),
+            vec![proposer_commitment.clone(), signer_commitment],
+        ))));
+
+        let mut pending_proposal =
+            create_pending_proposal(account_id.clone(), 1, proposer_commitment, vec![]);
+        pending_proposal.account_id =
+            "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcd".to_string();
+
+        let _storage = storage.with_pull_delta_proposal(Ok(pending_proposal));
+
+        let params = SignDeltaProposalParams {
+            account_id: account_id.clone(),
+            commitment: commitment.clone(),
+            signature: ProposalSignature::Falcon {
+                signature: format!("0x{}", "a".repeat(666)),
+            },
+            credentials: Credentials::signature(signer_pubkey, signer_signature, signer_timestamp),
+        };
+
+        let result = sign_delta_proposal(&state, params).await;
+        assert!(matches!(
+            result,
+            Err(PsmError::ProposalNotFound {
+                account_id: ref err_account,
+                commitment: ref err_commitment
+            }) if err_account == &account_id && err_commitment == &commitment
+        ));
     }
 }

--- a/crates/server/src/storage/filesystem.rs
+++ b/crates/server/src/storage/filesystem.rs
@@ -1,6 +1,7 @@
 use crate::delta_object::{DeltaObject, DeltaStatus};
 use crate::state_object::StateObject;
 use crate::storage::StorageBackend;
+use crate::utils::normalize_commitment_hex;
 use async_trait::async_trait;
 use std::path::{Path, PathBuf};
 use tokio::fs;
@@ -70,13 +71,27 @@ impl FilesystemService {
     }
 
     /// Get the path for a delta proposal file
-    fn get_delta_proposal_path(&self, account_id: &str, commitment: &str) -> PathBuf {
-        // Remove 0x prefix if present
-        let clean_commitment = commitment.strip_prefix("0x").unwrap_or(commitment);
-        self.app_path
-            .join(account_id)
-            .join("proposals")
-            .join(format!("{clean_commitment}.json"))
+    fn get_delta_proposal_path(
+        &self,
+        account_id: &str,
+        commitment: &str,
+    ) -> Result<PathBuf, String> {
+        let normalized_commitment =
+            normalize_commitment_hex(commitment).map_err(|e| e.to_string())?;
+        let clean_commitment = normalized_commitment
+            .strip_prefix("0x")
+            .unwrap_or(&normalized_commitment);
+        let proposals_dir = self.app_path.join(account_id).join("proposals");
+        let path = proposals_dir.join(format!("{clean_commitment}.json"));
+
+        if path.parent() != Some(proposals_dir.as_path()) {
+            return Err(
+                "Invalid commitment: resolved proposal path escapes proposals directory"
+                    .to_string(),
+            );
+        }
+
+        Ok(path)
     }
 
     async fn list_delta_filenames(&self, account_id: &str) -> Result<Vec<String>, String> {
@@ -256,7 +271,7 @@ impl StorageBackend for FilesystemService {
         commitment: &str,
         proposal: &DeltaObject,
     ) -> Result<(), String> {
-        let path = self.get_delta_proposal_path(&proposal.account_id, commitment);
+        let path = self.get_delta_proposal_path(&proposal.account_id, commitment)?;
 
         // Create parent directory if it doesn't exist
         if let Some(parent) = path.parent() {
@@ -287,7 +302,7 @@ impl StorageBackend for FilesystemService {
         account_id: &str,
         commitment: &str,
     ) -> Result<DeltaObject, String> {
-        let path = self.get_delta_proposal_path(account_id, commitment);
+        let path = self.get_delta_proposal_path(account_id, commitment)?;
 
         let json = fs::read_to_string(&path)
             .await
@@ -353,7 +368,7 @@ impl StorageBackend for FilesystemService {
         account_id: &str,
         commitment: &str,
     ) -> Result<(), String> {
-        let path = self.get_delta_proposal_path(account_id, commitment);
+        let path = self.get_delta_proposal_path(account_id, commitment)?;
 
         // Check if the file exists
         if !path.exists() {
@@ -592,7 +607,7 @@ mod tests {
         let account_id = "0x7bfb0f38b0fafa103f86a805594170";
 
         // Submit multiple proposals
-        let commitments = ["0xaaa", "0xbbb", "0xccc"];
+        let commitments = ["0xaaaa", "0xbbbb", "0xcccc"];
         for (i, commitment) in commitments.iter().enumerate() {
             let proposal = create_test_delta(account_id, (i + 1) as u64);
             storage
@@ -694,7 +709,7 @@ mod tests {
             .expect("Failed to create storage");
 
         let account_id = "0x7bfb0f38b0fafa103f86a805594170";
-        let commitment = "0xnonexistent";
+        let commitment = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
         // Delete nonexistent proposal should succeed (no-op)
         let result = storage.delete_delta_proposal(account_id, commitment).await;
@@ -734,6 +749,24 @@ mod tests {
         assert!(result2.is_ok(), "Pull without prefix should work");
 
         // Cleanup
+        tokio::fs::remove_dir_all(temp_dir).await.ok();
+    }
+
+    #[tokio::test]
+    async fn test_proposal_commitment_rejects_path_traversal() {
+        let temp_dir = env::temp_dir().join(format!("psm_test_{}", uuid::Uuid::new_v4()));
+        let storage = FilesystemService::new(temp_dir.clone())
+            .await
+            .expect("Failed to create storage");
+
+        let account_id = "0x7bfb0f38b0fafa103f86a805594170";
+        let result = storage
+            .pull_delta_proposal(account_id, "../../other_account/proposals/abc")
+            .await;
+
+        assert!(result.is_err(), "Traversal commitment should be rejected");
+        assert!(result.unwrap_err().contains("Invalid commitment"));
+
         tokio::fs::remove_dir_all(temp_dir).await.ok();
     }
 

--- a/crates/server/src/testing/integration/proposals_grpc.rs
+++ b/crates/server/src/testing/integration/proposals_grpc.rs
@@ -236,7 +236,8 @@ async fn test_grpc_sign_delta_proposal_not_found() {
     let dummy_sig = format!("0x{}", "a".repeat(666));
     let sign_proposal_req = SignDeltaProposalRequest {
         account_id: account_id_hex,
-        commitment: "nonexistent_proposal".to_string(),
+        commitment: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            .to_string(),
         signature: Some(ProposalSignature {
             scheme: "falcon".to_string(),
             signature: dummy_sig,

--- a/crates/server/src/testing/integration/proposals_http.rs
+++ b/crates/server/src/testing/integration/proposals_http.rs
@@ -245,7 +245,7 @@ async fn test_sign_delta_proposal_not_found() {
     let dummy_sig = format!("0x{}", "a".repeat(666));
     let sign_body = json!({
         "account_id": account_id_hex,
-        "commitment": "nonexistent_proposal",
+        "commitment": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "signature": {
             "scheme": "falcon",
             "signature": dummy_sig

--- a/crates/server/src/utils/commitment.rs
+++ b/crates/server/src/utils/commitment.rs
@@ -1,0 +1,58 @@
+use crate::error::{PsmError, Result};
+
+pub fn normalize_commitment_hex(commitment: &str) -> Result<String> {
+    let normalized = commitment
+        .strip_prefix("0x")
+        .or_else(|| commitment.strip_prefix("0X"))
+        .unwrap_or(commitment);
+
+    if normalized.is_empty() {
+        return Err(PsmError::InvalidCommitment(
+            "commitment cannot be empty".to_string(),
+        ));
+    }
+
+    if !normalized.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(PsmError::InvalidCommitment(
+            "commitment must be hex-encoded".to_string(),
+        ));
+    }
+
+    Ok(format!("0x{}", normalized))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_commitment_accepts_prefixed_hex() {
+        let normalized = normalize_commitment_hex(
+            "0xAABBCCDDEEFF00112233445566778899AABBCCDDEEFF00112233445566778899",
+        )
+        .expect("valid commitment should normalize");
+        assert_eq!(
+            normalized,
+            "0xAABBCCDDEEFF00112233445566778899AABBCCDDEEFF00112233445566778899"
+        );
+    }
+
+    #[test]
+    fn normalize_commitment_accepts_non_prefixed_hex() {
+        let normalized = normalize_commitment_hex(
+            "AABBCCDDEEFF00112233445566778899AABBCCDDEEFF00112233445566778899",
+        )
+        .expect("valid commitment should normalize");
+        assert_eq!(
+            normalized,
+            "0xAABBCCDDEEFF00112233445566778899AABBCCDDEEFF00112233445566778899"
+        );
+    }
+
+    #[test]
+    fn normalize_commitment_rejects_non_hex() {
+        let err = normalize_commitment_hex("../../other_account/proposals/abc")
+            .expect_err("non-hex commitment must fail");
+        assert!(matches!(err, PsmError::InvalidCommitment(_)));
+    }
+}

--- a/crates/server/src/utils/mod.rs
+++ b/crates/server/src/utils/mod.rs
@@ -1,0 +1,3 @@
+mod commitment;
+
+pub use commitment::normalize_commitment_hex;


### PR DESCRIPTION
PR fixes a path-traversal vulnerability in proposal signing and hardens commitment handling.

- Added strict commitment validation (hex-only, non-empty, normalized 0x prefix) before proposal sign.
- Added check to ensure loaded proposal belongs to the requested account.
- Hardened filesystem proposal path construction to reject invalid/traversal commitments
- Added regression tests for invalid commitments