### PR TITLE
fix: validate psm commitment in account

### DIFF
--- a/crates/server/src/network/miden/account_inspector.rs
+++ b/crates/server/src/network/miden/account_inspector.rs
@@ -6,6 +6,7 @@ use miden_protocol::utils::Serializable;
 const OZ_MULTISIG_THRESHOLD_CONFIG: &str = "openzeppelin::multisig::threshold_config";
 const OZ_MULTISIG_SIGNER_PUBKEYS: &str = "openzeppelin::multisig::signer_public_keys";
 const OZ_PSM_SELECTOR: &str = "openzeppelin::psm::selector";
+pub const OZ_PSM_PUBLIC_KEY: &str = "openzeppelin::psm::public_key";
 
 // Alternative slot names for miden-standards auth components
 const STD_THRESHOLD_CONFIG: &str =
@@ -150,6 +151,20 @@ impl<'a> MidenAccountInspector<'a> {
         let psm_on = Word::from([1u32, 0, 0, 0]);
         selector_value == psm_on
     }
+
+    /// Extract PSM public key commitment from the OpenZeppelin PSM public key map.
+    /// Requires the exact slot name `openzeppelin::psm::public_key`.
+    pub fn extract_psm_public_key(&self) -> Option<String> {
+        let slot_name = self.find_map_slot_name(&[OZ_PSM_PUBLIC_KEY])?;
+        let key_zero = Word::from([0u32, 0, 0, 0]);
+        let value = self.get_map_item_by_name(&slot_name, key_zero)?;
+
+        if value == Word::default() {
+            return None;
+        }
+
+        Some(format!("0x{}", hex::encode(value.to_bytes())))
+    }
 }
 
 #[cfg(all(test, not(any(feature = "integration", feature = "e2e"))))]
@@ -227,6 +242,49 @@ mod tests {
         assert!(
             inspector.has_psm_auth(),
             "Fixture account should have PSM auth enabled (auth_tx_falcon512_rpo_multisig procedure)"
+        );
+    }
+
+    #[test]
+    fn test_extract_psm_public_key() {
+        let fixture_json: serde_json::Value =
+            serde_json::from_str(crate::testing::fixtures::ACCOUNT_JSON)
+                .expect("Failed to parse fixture");
+
+        let account = Account::from_json(&fixture_json).expect("Failed to deserialize account");
+        let inspector = MidenAccountInspector::new(&account);
+
+        let psm_pubkey = inspector.extract_psm_public_key();
+        assert!(
+            psm_pubkey.is_some(),
+            "Expected PSM public key from openzeppelin::psm::public_key slot"
+        );
+        assert!(
+            psm_pubkey.unwrap().starts_with("0x"),
+            "PSM public key should be hex format"
+        );
+    }
+
+    #[test]
+    fn test_extract_psm_public_key_empty_value() {
+        let fixture_json: serde_json::Value =
+            serde_json::from_str(crate::testing::fixtures::ACCOUNT_JSON)
+                .expect("Failed to parse fixture");
+
+        let mut account = Account::from_json(&fixture_json).expect("Failed to deserialize account");
+        let slot_name =
+            StorageSlotName::new(OZ_PSM_PUBLIC_KEY).expect("Failed to parse PSM public key slot");
+        let key_zero = Word::from([0u32, 0, 0, 0]);
+
+        account
+            .storage_mut()
+            .set_map_item(&slot_name, key_zero, Word::default())
+            .expect("Failed to overwrite PSM public key value");
+
+        let inspector = MidenAccountInspector::new(&account);
+        assert!(
+            inspector.extract_psm_public_key().is_none(),
+            "Expected None for empty/default PSM public key value"
         );
     }
 }

--- a/crates/server/src/network/miden/mod.rs
+++ b/crates/server/src/network/miden/mod.rs
@@ -1,7 +1,7 @@
 pub mod account_inspector;
 
 use crate::metadata::auth::{Auth, Credentials};
-use crate::network::miden::account_inspector::MidenAccountInspector;
+use crate::network::miden::account_inspector::{MidenAccountInspector, OZ_PSM_PUBLIC_KEY};
 use crate::network::{NetworkClient, NetworkType};
 use async_trait::async_trait;
 use miden_protocol::Word;
@@ -370,6 +370,27 @@ impl NetworkClient for MidenNetworkClient {
         }
     }
 
+    fn validate_psm_commitment(
+        &self,
+        state_json: &serde_json::Value,
+        expected_psm_commitment: &str,
+    ) -> Result<(), String> {
+        let account = Account::from_json(state_json)?;
+        let inspector = MidenAccountInspector::new(&account);
+
+        let actual_psm_commitment = inspector
+            .extract_psm_public_key()
+            .ok_or_else(|| format!("Missing required slot '{OZ_PSM_PUBLIC_KEY}'"))?;
+
+        if actual_psm_commitment == expected_psm_commitment {
+            Ok(())
+        } else {
+            Err(format!(
+                "Slot '{OZ_PSM_PUBLIC_KEY}' mismatch: expected {expected_psm_commitment}, got {actual_psm_commitment}"
+            ))
+        }
+    }
+
     async fn should_update_auth(
         &mut self,
         state_json: &serde_json::Value,
@@ -443,6 +464,55 @@ mod tests {
             result
                 .unwrap_err()
                 .contains("Invalid Miden account ID format")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_validate_psm_commitment_success() {
+        let network = NetworkType::MidenTestnet;
+        let client = MidenNetworkClient::from_network(network)
+            .await
+            .expect("Failed to create client");
+
+        let account_json: serde_json::Value =
+            serde_json::from_str(crate::testing::fixtures::ACCOUNT_JSON)
+                .expect("Failed to parse account fixture");
+
+        let account =
+            Account::from_json(&account_json).expect("Failed to deserialize fixture account");
+        let inspector = MidenAccountInspector::new(&account);
+        let expected_psm_commitment = inspector
+            .extract_psm_public_key()
+            .expect("Fixture must contain OpenZeppelin PSM public key slot");
+
+        let result = client.validate_psm_commitment(&account_json, &expected_psm_commitment);
+        assert!(result.is_ok(), "Expected matching PSM commitment to pass");
+    }
+
+    #[tokio::test]
+    async fn test_validate_psm_commitment_mismatch() {
+        let network = NetworkType::MidenTestnet;
+        let client = MidenNetworkClient::from_network(network)
+            .await
+            .expect("Failed to create client");
+
+        let account_json: serde_json::Value =
+            serde_json::from_str(crate::testing::fixtures::ACCOUNT_JSON)
+                .expect("Failed to parse account fixture");
+
+        let result = client.validate_psm_commitment(
+            &account_json,
+            "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        );
+        assert!(
+            result.is_err(),
+            "Expected mismatched PSM commitment to fail"
+        );
+        assert!(
+            result
+                .unwrap_err()
+                .contains("openzeppelin::psm::public_key"),
+            "Error should mention required OpenZeppelin slot name"
         );
     }
 

--- a/crates/server/src/network/mod.rs
+++ b/crates/server/src/network/mod.rs
@@ -59,6 +59,13 @@ pub trait NetworkClient: Send + Sync {
         credential: &Credentials,
     ) -> Result<(), String>;
 
+    /// Validate that account storage is bound to this server's PSM public key commitment.
+    fn validate_psm_commitment(
+        &self,
+        state_json: &serde_json::Value,
+        expected_psm_commitment: &str,
+    ) -> Result<(), String>;
+
     /// Determine if account auth should be updated given the state
     async fn should_update_auth(
         &mut self,

--- a/crates/server/src/services/configure_account.rs
+++ b/crates/server/src/services/configure_account.rs
@@ -44,6 +44,7 @@ pub async fn configure_account(
 
     let commitment = {
         let client = state.network_client.lock().await;
+        let expected_psm_commitment = state.ack.commitment();
 
         // Validates that the credential is valid for the account state.
         client
@@ -55,6 +56,18 @@ pub async fn configure_account(
                     "Failed to validate credential"
                 );
                 PsmError::NetworkError(format!("Failed to validate credential: {e}"))
+            })?;
+
+        client
+            .validate_psm_commitment(&params.initial_state, &expected_psm_commitment)
+            .map_err(|e| {
+                tracing::error!(
+                    account_id = %params.account_id,
+                    expected_psm_commitment = %expected_psm_commitment,
+                    error = %e,
+                    "Unauthorized account configuration: invalid PSM public key binding"
+                );
+                PsmError::AuthorizationFailed(format!("Unauthorized account configuration: {e}"))
             })?;
 
         // Verifies the credential authorization.
@@ -283,5 +296,52 @@ mod tests {
             PsmError::NetworkError(_) => {}
             e => panic!("Expected NetworkError, got: {:?}", e),
         }
+    }
+
+    #[tokio::test]
+    async fn test_configure_account_unauthorized_psm_commitment() {
+        use crate::testing::helpers::generate_falcon_signature;
+
+        let account_id_hex = "0x069cde0ebf59f29063051ad8a3d32d";
+        let (pubkey_hex, commitment_hex, signature_hex, timestamp) =
+            generate_falcon_signature(account_id_hex);
+
+        let network_client = MockNetworkClient::new()
+            .with_validate_credential(Ok(()))
+            .with_validate_psm_commitment(Err(
+                "OpenZeppelin slot 'openzeppelin::psm::public_key' mismatch".to_string(),
+            ));
+
+        let storage_backend = MockStorageBackend::new();
+        let metadata_store = MockMetadataStore::new().with_get(Ok(None));
+
+        let state = create_test_app_state(network_client, storage_backend.clone(), metadata_store);
+
+        let credential = Credentials::signature(pubkey_hex.clone(), signature_hex, timestamp);
+
+        let params = ConfigureAccountParams {
+            account_id: account_id_hex.to_string(),
+            auth: Auth::MidenFalconRpo {
+                cosigner_commitments: vec![commitment_hex],
+            },
+            initial_state: serde_json::json!({"balance": 100}),
+            credential,
+        };
+
+        let result = configure_account(&state, params).await;
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            PsmError::AuthorizationFailed(msg) => {
+                assert!(msg.contains("Unauthorized account configuration"));
+                assert!(msg.contains("openzeppelin::psm::public_key"));
+            }
+            e => panic!("Expected AuthorizationFailed, got: {:?}", e),
+        }
+
+        assert!(
+            storage_backend.get_submit_state_calls().is_empty(),
+            "state should not be persisted on unauthorized configuration"
+        );
     }
 }

--- a/crates/server/src/testing/helpers.rs
+++ b/crates/server/src/testing/helpers.rs
@@ -136,6 +136,14 @@ impl NetworkClient for IntegrationMockNetworkClient {
         Ok(())
     }
 
+    fn validate_psm_commitment(
+        &self,
+        _state_json: &serde_json::Value,
+        _expected_psm_commitment: &str,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+
     async fn should_update_auth(
         &mut self,
         state_json: &serde_json::Value,

--- a/crates/server/src/testing/mocks.rs
+++ b/crates/server/src/testing/mocks.rs
@@ -23,6 +23,7 @@ pub struct MockNetworkClient {
     pub get_state_commitment_responses: Arc<StdMutex<Vec<StdResult<String, String>>>>,
     pub get_state_commitment_calls: Arc<StdMutex<Vec<(String, serde_json::Value)>>>,
     pub validate_credential_responses: Arc<StdMutex<Vec<StdResult<(), String>>>>,
+    pub validate_psm_commitment_responses: Arc<StdMutex<Vec<StdResult<(), String>>>>,
     pub verify_delta_responses: Arc<StdMutex<Vec<StdResult<(), String>>>>,
     pub apply_delta_responses: Arc<StdMutex<Vec<ApplyDeltaResult>>>,
     pub should_update_auth_responses: Arc<StdMutex<Vec<ShouldUpdateAuthResult>>>,
@@ -48,6 +49,14 @@ impl MockNetworkClient {
 
     pub fn with_validate_credential(self, response: StdResult<(), String>) -> Self {
         self.validate_credential_responses
+            .lock()
+            .unwrap()
+            .push(response);
+        self
+    }
+
+    pub fn with_validate_psm_commitment(self, response: StdResult<(), String>) -> Self {
+        self.validate_psm_commitment_responses
             .lock()
             .unwrap()
             .push(response);
@@ -165,6 +174,18 @@ impl NetworkClient for MockNetworkClient {
         _credential: &Credentials,
     ) -> StdResult<(), String> {
         self.validate_credential_responses
+            .lock()
+            .unwrap()
+            .pop()
+            .unwrap_or(Ok(()))
+    }
+
+    fn validate_psm_commitment(
+        &self,
+        _state_json: &serde_json::Value,
+        _expected_psm_commitment: &str,
+    ) -> StdResult<(), String> {
+        self.validate_psm_commitment_responses
             .lock()
             .unwrap()
             .pop()


### PR DESCRIPTION
Adds validation that the account is actually bound to this PSM instance during `configure_account` 

- During `configure_account`, the server now extracts the account’s `openzeppelin::psm::public_key` slot and verifies it matches the servers expected PSM commitment.
  - If the slot is missing or mismatched, configuration is rejected with Unauthorized error
- Includes unit tests for success and unauthorized configure flow.