### PR TITLE
Fix offline use case

### DIFF
--- a/crates/miden-multisig-client/README.md
+++ b/crates/miden-multisig-client/README.md
@@ -4,7 +4,7 @@ High-level Rust SDK built on top of `miden-client` for private multisignature wo
 
 - create multisig accounts, register them with a PSM, and keep state off-chain,
 - propose, sign, and execute transactions with threshold enforcement,
-- fall back to fully offline flows when connectivity is limited,
+- fall back to offline `SwitchPsm` workflows when connectivity is limited,
 - export/import proposals as files for sharing using side channels,
 
 ## How Private Multisigs & PSM Work
@@ -80,12 +80,12 @@ client.execute_proposal(&proposal.id).await?;
 
 ### Fallback to Offline (if PSM unavailable)
 
-If the PSM endpoint can’t be reached, the SDK automatically produces an offline proposal so you can continue via side-channel sharing:
+If the PSM endpoint can’t be reached, the SDK can produce an offline proposal only for `SwitchPsm` transactions:
 
 ```rust
 use miden_multisig_client::{ProposalResult, TransactionType};
 
-let tx = TransactionType::consume_notes(vec![note_id]);
+let tx = TransactionType::switch_psm("https://new-psm.example.com", new_psm_commitment);
 match client.propose_with_fallback(tx).await? {
     ProposalResult::Online(p) => {
         println!("Proposal {} is live on PSM", p.id);
@@ -141,4 +141,3 @@ let spendable = client.list_consumable_notes_filtered(filter).await?;
  Run the Terminal UI demo in [`examples/demo`](../../examples/demo/), which exercises the same APIs for account management, note listing, proposal signing, and offline export/import.
 
 Contributions and bug reports are welcome!
-

--- a/crates/miden-multisig-client/src/client/account.rs
+++ b/crates/miden-multisig-client/src/client/account.rs
@@ -177,33 +177,39 @@ impl MultisigClient {
     }
 
     /// Syncs state with the Miden network.
-    ///
-    /// This follows the same approach as the web client's syncState():
-    /// 1. Sync with Miden network first to ensure we have latest block headers
-    /// 2. Fetch state from PSM
-    /// 3. Compare PSM commitment with local commitment
-    /// 4. If they differ, overwrite local with PSM state
-    /// 5. If account was updated from PSM, sync with network again
     pub async fn sync(&mut self) -> Result<()> {
-        // First, sync with Miden network to get latest block headers.
-        // This is critical - without block headers, transaction execution will fail.
+        self.sync_network_state().await?;
+
+        let account_updated = self.sync_from_psm_internal().await?;
+
+        if account_updated {
+            self.sync_network_state().await?;
+        }
+
+        self.refresh_cached_account_from_store().await
+    }
+
+    /// Syncs only with the Miden network and refreshes local cached account state.
+    pub(crate) async fn sync_network_only(&mut self) -> Result<()> {
+        self.sync_network_state().await?;
+        self.refresh_cached_account_from_store().await
+    }
+
+    /// Syncs account state from PSM into the local miden-client store.
+    pub async fn sync_from_psm(&mut self) -> Result<()> {
+        self.sync_from_psm_internal().await?;
+        Ok(())
+    }
+
+    async fn sync_network_state(&mut self) -> Result<()> {
         self.miden_client
             .sync_state()
             .await
             .map_err(|e| MultisigError::MidenClient(format!("failed to sync state: {:#?}", e)))?;
+        Ok(())
+    }
 
-        // Then sync state from PSM (like web client's syncState)
-        let account_updated = self.sync_from_psm_internal().await?;
-
-        // If PSM updated our account, sync with network again to ensure
-        // block headers are consistent with the new account state.
-        if account_updated {
-            self.miden_client.sync_state().await.map_err(|e| {
-                MultisigError::MidenClient(format!("failed to sync after PSM update: {:#?}", e))
-            })?;
-        }
-
-        // Refresh cached account (commitment/nonce/etc.) from the miden-client store
+    async fn refresh_cached_account_from_store(&mut self) -> Result<()> {
         if let Some(current) = self.account.take() {
             let account_id = current.id();
             let account_record = self
@@ -219,24 +225,9 @@ impl MultisigClient {
             let account: Account = account_record.try_into().map_err(|e| {
                 MultisigError::MidenClient(format!("account record is not full: {}", e))
             })?;
-            let refreshed = MultisigAccount::new(account, &self.psm_endpoint);
-            self.account = Some(refreshed);
+            self.account = Some(MultisigAccount::new(account, &self.psm_endpoint));
         }
 
-        Ok(())
-    }
-
-    /// Syncs account state from PSM into the local miden-client store.
-    ///
-    /// This mirrors the web client's syncState() approach:
-    /// - Fetches full state from PSM
-    /// - Compares PSM commitment with local commitment
-    /// - If they differ and PSM has newer state, overwrites local with PSM state
-    /// - If local is newer (e.g., after execution before PSM canonicalizes), keeps local
-    ///
-    /// This is simpler and more robust than applying incremental deltas.
-    pub async fn sync_from_psm(&mut self) -> Result<()> {
-        self.sync_from_psm_internal().await?;
         Ok(())
     }
 

--- a/crates/miden-multisig-client/src/client/mod.rs
+++ b/crates/miden-multisig-client/src/client/mod.rs
@@ -41,7 +41,7 @@ pub use notes::{ConsumableNote, NoteFilter};
 pub enum ProposalResult {
     /// Proposal successfully created on PSM and ready for cosigners to sign.
     Online(Box<Proposal>),
-    /// Proposal created offline (PSM unavailable). Share with cosigners via file.
+    /// Offline proposal created when PSM is unavailable (`SwitchPsm` transactions only).
     Offline(Box<ExportedProposal>),
 }
 

--- a/crates/miden-multisig-client/src/client/offline.rs
+++ b/crates/miden-multisig-client/src/client/offline.rs
@@ -5,7 +5,6 @@
 
 use std::collections::HashSet;
 
-use miden_protocol::asset::FungibleAsset;
 use miden_protocol::transaction::TransactionSummary;
 use private_state_manager_shared::{FromJson, ToJson};
 
@@ -18,9 +17,11 @@ use crate::proposal::TransactionType;
 impl MultisigClient {
     /// Creates a proposal offline without pushing to PSM.
     ///
-    /// Use this when PSM is unavailable or you want to share proposals via
-    /// side channels. The proposal is returned as an `ExportedProposal` that
-    /// can be serialized to JSON and shared with cosigners.
+    /// Only `SwitchPsm` transactions can be executed fully offline because
+    /// all other transaction types require a PSM acknowledgment signature.
+    ///
+    /// This returns an `ExportedProposal` that can be serialized to JSON and
+    /// shared with cosigners.
     ///
     /// The proposer's signature is automatically included in the exported proposal.
     ///
@@ -41,184 +42,44 @@ impl MultisigClient {
         &mut self,
         transaction_type: TransactionType,
     ) -> Result<ExportedProposal> {
-        // Sync with the network before executing transaction
-        self.sync().await?;
+        self.sync_network_only().await?;
 
         let account = self.require_account()?.clone();
         let account_id = account.id();
         let current_threshold = account.threshold()?;
 
-        // Generate salt for replay protection
         let salt = crate::transaction::generate_salt();
-        let salt_hex = crate::transaction::word_to_hex(&salt);
-
-        // Build transaction request based on type
-        let (tx_request, metadata) = match &transaction_type {
+        let (new_endpoint, new_commitment) = match &transaction_type {
             TransactionType::SwitchPsm {
                 new_endpoint,
                 new_commitment,
-            } => {
-                let tx_request = crate::transaction::build_update_psm_transaction_request(
-                    *new_commitment,
-                    salt,
-                    std::iter::empty(),
-                )?;
-
-                let metadata = ExportedMetadata {
-                    salt_hex: Some(salt_hex.clone()),
-                    new_psm_pubkey_hex: Some(crate::transaction::word_to_hex(new_commitment)),
-                    new_psm_endpoint: Some(new_endpoint.clone()),
-                    ..Default::default()
-                };
-
-                (tx_request, metadata)
-            }
-            TransactionType::P2ID {
-                recipient,
-                faucet_id,
-                amount,
-            } => {
-                let asset = FungibleAsset::new(*faucet_id, *amount).map_err(|e| {
-                    MultisigError::InvalidConfig(format!("failed to create asset: {}", e))
-                })?;
-
-                let tx_request = crate::transaction::build_p2id_transaction_request(
-                    account.id(),
-                    *recipient,
-                    vec![asset.into()],
-                    salt,
-                    std::iter::empty(),
-                )?;
-
-                let metadata = ExportedMetadata {
-                    salt_hex: Some(salt_hex.clone()),
-                    recipient_hex: Some(recipient.to_string()),
-                    faucet_id_hex: Some(faucet_id.to_string()),
-                    amount: Some(*amount),
-                    ..Default::default()
-                };
-
-                (tx_request, metadata)
-            }
-            TransactionType::ConsumeNotes { note_ids } => {
-                let tx_request = crate::transaction::build_consume_notes_transaction_request(
-                    &self.miden_client,
-                    note_ids.clone(),
-                    salt,
-                    std::iter::empty(),
-                )
-                .await?;
-
-                let note_ids_hex: Vec<String> = note_ids.iter().map(|id| id.to_hex()).collect();
-                let metadata = ExportedMetadata {
-                    salt_hex: Some(salt_hex.clone()),
-                    note_ids_hex,
-                    ..Default::default()
-                };
-
-                (tx_request, metadata)
-            }
-            TransactionType::AddCosigner { new_commitment } => {
-                let mut current_signers = account.cosigner_commitments();
-                current_signers.push(*new_commitment);
-                let new_threshold = current_threshold as u64;
-
-                let (tx_request, _) = crate::transaction::build_update_signers_transaction_request(
-                    new_threshold,
-                    &current_signers,
-                    salt,
-                    std::iter::empty(),
-                )?;
-
-                let signer_commitments_hex: Vec<String> = current_signers
-                    .iter()
-                    .map(crate::transaction::word_to_hex)
-                    .collect();
-
-                let metadata = ExportedMetadata {
-                    salt_hex: Some(salt_hex.clone()),
-                    new_threshold: Some(new_threshold),
-                    signer_commitments_hex,
-                    ..Default::default()
-                };
-
-                (tx_request, metadata)
-            }
-            TransactionType::RemoveCosigner { commitment } => {
-                let current_signers = account.cosigner_commitments();
-                let new_signers: Vec<_> = current_signers
-                    .iter()
-                    .filter(|&c| c != commitment)
-                    .copied()
-                    .collect();
-
-                if new_signers.len() == current_signers.len() {
-                    return Err(MultisigError::InvalidConfig(
-                        "commitment to remove not found in signers".to_string(),
-                    ));
-                }
-
-                let new_threshold =
-                    std::cmp::min(current_threshold as u64, new_signers.len() as u64);
-
-                let (tx_request, _) = crate::transaction::build_update_signers_transaction_request(
-                    new_threshold,
-                    &new_signers,
-                    salt,
-                    std::iter::empty(),
-                )?;
-
-                let signer_commitments_hex: Vec<String> = new_signers
-                    .iter()
-                    .map(crate::transaction::word_to_hex)
-                    .collect();
-
-                let metadata = ExportedMetadata {
-                    salt_hex: Some(salt_hex.clone()),
-                    new_threshold: Some(new_threshold),
-                    signer_commitments_hex,
-                    ..Default::default()
-                };
-
-                (tx_request, metadata)
-            }
-            TransactionType::UpdateSigners {
-                new_threshold,
-                signer_commitments,
-            } => {
-                let (tx_request, _) = crate::transaction::build_update_signers_transaction_request(
-                    *new_threshold as u64,
-                    signer_commitments,
-                    salt,
-                    std::iter::empty(),
-                )?;
-
-                let signer_commitments_hex: Vec<String> = signer_commitments
-                    .iter()
-                    .map(crate::transaction::word_to_hex)
-                    .collect();
-
-                let metadata = ExportedMetadata {
-                    salt_hex: Some(salt_hex.clone()),
-                    new_threshold: Some(*new_threshold as u64),
-                    signer_commitments_hex,
-                    ..Default::default()
-                };
-
-                (tx_request, metadata)
+            } => (new_endpoint.clone(), *new_commitment),
+            _ => {
+                return Err(MultisigError::OfflineUnsupportedTransaction(
+                    transaction_type.type_name().to_string(),
+                ));
             }
         };
 
-        // Execute to get the TransactionSummary
+        let tx_request = crate::transaction::build_update_psm_transaction_request(
+            new_commitment,
+            salt,
+            std::iter::empty(),
+        )?;
+        let metadata = ExportedMetadata {
+            salt_hex: Some(crate::transaction::word_to_hex(&salt)),
+            new_psm_pubkey_hex: Some(crate::transaction::word_to_hex(&new_commitment)),
+            new_psm_endpoint: Some(new_endpoint),
+            ..Default::default()
+        };
+
         let tx_summary =
             crate::transaction::execute_for_summary(&mut self.miden_client, account_id, tx_request)
                 .await?;
 
-        // Sign the transaction summary commitment
         let tx_commitment = tx_summary.to_commitment();
         let signature_hex = self.key_manager.sign_hex(tx_commitment);
 
-        // Build the proposal ID from commitment
         let id = format!(
             "0x{}",
             hex::encode(
@@ -229,23 +90,12 @@ impl MultisigClient {
             )
         );
 
-        // Determine transaction type string
-        let tx_type_str = match &transaction_type {
-            TransactionType::P2ID { .. } => "P2ID",
-            TransactionType::ConsumeNotes { .. } => "ConsumeNotes",
-            TransactionType::AddCosigner { .. } => "AddCosigner",
-            TransactionType::RemoveCosigner { .. } => "RemoveCosigner",
-            TransactionType::SwitchPsm { .. } => "SwitchPsm",
-            TransactionType::UpdateSigners { .. } => "UpdateSigners",
-        };
-
-        // Create exported proposal with our signature
         let exported = ExportedProposal {
             version: EXPORT_VERSION,
             account_id: account_id.to_string(),
             id,
             nonce: account.nonce() + 1,
-            transaction_type: tx_type_str.to_string(),
+            transaction_type: transaction_type.type_name().to_string(),
             tx_summary: tx_summary.to_json(),
             signatures: vec![ExportedSignature {
                 signer_commitment: self.key_manager.commitment_hex(),
@@ -262,6 +112,8 @@ impl MultisigClient {
     ///
     /// The signature is added directly to the proposal. After signing,
     /// export the proposal again to share with other cosigners.
+    ///
+    /// Only `SwitchPsm` proposals are supported in this mode.
     ///
     /// # Example
     ///
@@ -289,7 +141,13 @@ impl MultisigClient {
             return Err(MultisigError::AlreadySigned);
         }
 
-        // Parse the transaction summary to get the commitment
+        let parsed = proposal.to_proposal()?;
+        if !parsed.transaction_type.supports_offline_execution() {
+            return Err(MultisigError::OfflineUnsupportedTransaction(
+                parsed.transaction_type.type_name().to_string(),
+            ));
+        }
+
         let tx_summary = TransactionSummary::from_json(&proposal.tx_summary).map_err(|e| {
             MultisigError::InvalidConfig(format!("failed to parse tx_summary: {}", e))
         })?;
@@ -309,11 +167,10 @@ impl MultisigClient {
 
     /// Executes an imported proposal (with all signatures already collected).
     ///
-    /// This builds and submits the transaction directly to the Miden network,
-    /// bypassing PSM entirely. Use this for fully offline workflows.
+    /// This builds and submits the transaction directly to the Miden network
+    /// without contacting PSM.
     ///
-    /// **Note:** This does NOT update PSM. The proposal will remain on PSM
-    /// until it expires or is explicitly deleted.
+    /// Only `SwitchPsm` transactions are supported in this mode.
     ///
     /// # Example
     ///
@@ -322,8 +179,7 @@ impl MultisigClient {
     /// client.execute_imported_proposal(&proposal).await?;
     /// ```
     pub async fn execute_imported_proposal(&mut self, exported: &ExportedProposal) -> Result<()> {
-        // Sync with the network before executing to ensure we have latest state
-        self.sync().await?;
+        self.sync_network_only().await?;
 
         let account = self.require_account()?.clone();
         let account_id = account.id();
@@ -338,6 +194,12 @@ impl MultisigClient {
 
         // Parse the proposal
         let proposal = exported.to_proposal()?;
+        if !proposal.transaction_type.supports_offline_execution() {
+            return Err(MultisigError::OfflineUnsupportedTransaction(
+                proposal.transaction_type.type_name().to_string(),
+            ));
+        }
+
         let tx_summary = TransactionSummary::from_json(&exported.tx_summary).map_err(|e| {
             MultisigError::InvalidConfig(format!("failed to parse tx_summary: {}", e))
         })?;
@@ -356,41 +218,14 @@ impl MultisigClient {
         // Build signature advice from cosigner signatures
         let required_commitments: HashSet<String> =
             account.cosigner_commitments_hex().into_iter().collect();
-        let mut signature_advice = collect_signature_advice(
+        let signature_advice = collect_signature_advice(
             signature_inputs,
             &required_commitments,
             tx_summary_commitment,
         )?;
 
-        // SwitchPsm does NOT require PSM signature
-        let is_switch_psm = matches!(
-            &proposal.transaction_type,
-            TransactionType::SwitchPsm { .. }
-        );
-
-        if !is_switch_psm {
-            // Get PSM ack signature and add to advice
-            let psm_advice = self
-                .get_psm_ack_signature(&account, proposal.nonce, &tx_summary, tx_summary_commitment)
-                .await?;
-            signature_advice.push(psm_advice);
-        }
-
         // Build the final transaction request with all signatures
         let salt = proposal.metadata.salt()?;
-
-        // For signer-update transactions, we must propagate parse errors for signer commitments
-        // rather than silently converting to None. This ensures malformed hex is diagnosed properly.
-        let signer_commitments = if matches!(
-            &proposal.transaction_type,
-            TransactionType::AddCosigner { .. }
-                | TransactionType::RemoveCosigner { .. }
-                | TransactionType::UpdateSigners { .. }
-        ) {
-            Some(proposal.metadata.signer_commitments()?)
-        } else {
-            proposal.metadata.signer_commitments().ok()
-        };
 
         let final_tx_request = build_final_transaction_request(
             &self.miden_client,
@@ -398,8 +233,8 @@ impl MultisigClient {
             account.inner(),
             salt,
             signature_advice,
-            proposal.metadata.new_threshold,
-            signer_commitments.as_deref(),
+            None,
+            None,
         )
         .await?;
 

--- a/crates/miden-multisig-client/src/client/proposals.rs
+++ b/crates/miden-multisig-client/src/client/proposals.rs
@@ -209,13 +209,7 @@ impl MultisigClient {
             tx_summary_commitment,
         )?;
 
-        // SwitchPsm does NOT require PSM signature - skip push_delta for this transaction type
-        let is_switch_psm = matches!(
-            &proposal.transaction_type,
-            TransactionType::SwitchPsm { .. }
-        );
-
-        if !is_switch_psm {
+        if proposal.transaction_type.requires_psm_ack() {
             // Get PSM ack signature and add to advice
             let psm_advice = self
                 .get_psm_ack_signature(
@@ -303,7 +297,8 @@ impl MultisigClient {
     /// Proposes a transaction with automatic fallback to offline mode.
     ///
     /// First attempts to create the proposal via PSM. If PSM is unavailable
-    /// (connection error), automatically falls back to offline proposal creation.
+    /// (connection error), falls back to offline proposal creation only when
+    /// the transaction supports PSM-less execution (`SwitchPsm`).
     ///
     /// This is useful when you want to attempt online coordination but have a
     /// graceful fallback path for offline sharing.
@@ -311,15 +306,16 @@ impl MultisigClient {
     /// # Returns
     ///
     /// - `ProposalResult::Online(Proposal)` if PSM succeeded
-    /// - `ProposalResult::Offline(ExportedProposal)` if PSM failed
+    /// - `ProposalResult::Offline(ExportedProposal)` if PSM failed and transaction is `SwitchPsm`
     ///
     /// # Example
     ///
     /// ```ignore
     /// use miden_multisig_client::{TransactionType, ProposalResult};
     ///
+    /// let tx = TransactionType::switch_psm("https://new-psm.example.com", new_psm_commitment);
     /// let result = client.propose_with_fallback(
-    ///     TransactionType::add_cosigner(new_commitment)
+    ///     tx
     /// ).await?;
     ///
     /// match result {
@@ -339,10 +335,13 @@ impl MultisigClient {
         // Try online first
         match self.propose_transaction(transaction_type.clone()).await {
             Ok(proposal) => Ok(ProposalResult::Online(Box::new(proposal))),
-            Err(MultisigError::PsmConnection(_) | MultisigError::PsmServer(_)) => {
-                // PSM unavailable, fall back to offline
-                let exported = self.create_proposal_offline(transaction_type).await?;
-                Ok(ProposalResult::Offline(Box::new(exported)))
+            Err(error @ (MultisigError::PsmConnection(_) | MultisigError::PsmServer(_))) => {
+                if transaction_type.supports_offline_execution() {
+                    let exported = self.create_proposal_offline(transaction_type).await?;
+                    Ok(ProposalResult::Offline(Box::new(exported)))
+                } else {
+                    Err(error)
+                }
             }
             Err(e) => Err(e),
         }

--- a/crates/miden-multisig-client/src/error.rs
+++ b/crates/miden-multisig-client/src/error.rs
@@ -88,6 +88,10 @@ pub enum MultisigError {
     /// Invalid filter configuration.
     #[error("invalid filter: {0}")]
     InvalidFilter(String),
+
+    /// Transaction type is not supported in offline mode without PSM.
+    #[error("offline mode only supports SwitchPsm transactions, got: {0}")]
+    OfflineUnsupportedTransaction(String),
 }
 
 impl From<private_state_manager_client::ClientError> for MultisigError {

--- a/crates/miden-multisig-client/src/export.rs
+++ b/crates/miden-multisig-client/src/export.rs
@@ -76,14 +76,7 @@ pub struct ExportedMetadata {
 impl ExportedProposal {
     /// Creates an ExportedProposal from a Proposal and account ID.
     pub fn from_proposal(proposal: &Proposal, account_id: AccountId) -> Self {
-        let tx_type_str = match &proposal.transaction_type {
-            TransactionType::P2ID { .. } => "P2ID",
-            TransactionType::ConsumeNotes { .. } => "ConsumeNotes",
-            TransactionType::AddCosigner { .. } => "AddCosigner",
-            TransactionType::RemoveCosigner { .. } => "RemoveCosigner",
-            TransactionType::SwitchPsm { .. } => "SwitchPsm",
-            TransactionType::UpdateSigners { .. } => "UpdateSigners",
-        };
+        let tx_type_str = proposal.transaction_type.type_name();
 
         let signatures_required = proposal.signatures_required();
 

--- a/crates/miden-multisig-client/src/proposal.rs
+++ b/crates/miden-multisig-client/src/proposal.rs
@@ -99,6 +99,28 @@ impl TransactionType {
             signer_commitments,
         }
     }
+
+    /// Returns the canonical transaction type name used in exported proposals.
+    pub fn type_name(&self) -> &'static str {
+        match self {
+            Self::P2ID { .. } => "P2ID",
+            Self::ConsumeNotes { .. } => "ConsumeNotes",
+            Self::AddCosigner { .. } => "AddCosigner",
+            Self::RemoveCosigner { .. } => "RemoveCosigner",
+            Self::SwitchPsm { .. } => "SwitchPsm",
+            Self::UpdateSigners { .. } => "UpdateSigners",
+        }
+    }
+
+    /// Returns true when execution can proceed without a PSM acknowledgment.
+    pub fn supports_offline_execution(&self) -> bool {
+        matches!(self, Self::SwitchPsm { .. })
+    }
+
+    /// Returns true when execution requires a PSM acknowledgment signature.
+    pub fn requires_psm_ack(&self) -> bool {
+        !self.supports_offline_execution()
+    }
 }
 
 /// Metadata needed to reconstruct and finalize a proposal.
@@ -629,6 +651,28 @@ mod tests {
                 new_threshold: threshold,
                 signer_commitments: signers
             }
+        );
+    }
+
+    #[test]
+    fn test_transaction_type_requires_psm_ack() {
+        let recipient = AccountId::from_hex("0x7bfb0f38b0fafa103f86a805594170").unwrap();
+        let faucet_id = AccountId::from_hex("0x7bfb0f38b0fafa103f86a805594171").unwrap();
+
+        assert!(TransactionType::transfer(recipient, faucet_id, 1).requires_psm_ack());
+        assert!(
+            !TransactionType::switch_psm("http://new-psm.example.com", Word::default())
+                .requires_psm_ack()
+        );
+    }
+
+    #[test]
+    fn test_transaction_type_supports_offline_execution() {
+        let note_id = NoteId::from_raw(Word::default());
+        assert!(!TransactionType::consume_notes(vec![note_id]).supports_offline_execution());
+        assert!(
+            TransactionType::switch_psm("http://new-psm.example.com", Word::default())
+                .supports_offline_execution()
         );
     }
 


### PR DESCRIPTION
Restrict Rust multisig offline flow to `SwitchPsm` only and remove misleading offline paths for other proposal types:

- adds a network-only sync for offline operations (no PSM sync)
- simplifies the offline logic, restriced only to PSM switch operations
- centralizes transaction capability checks (`supports_offline_execution` / `requires_psm_ack`), 