### PR TITLE
Fix typo in commitment description

### DIFF
--- a/spec/index.md
+++ b/spec/index.md
@@ -63,7 +63,7 @@ Multi-party accounts use delta proposals to coordinate before publishing a canon
 
 ### Commitment
 
-Is the commitment of the state, it's a hash, nonce, or any other identifier that serves as the unique identifier of the current state of the account. It's used to cerifify that the state is not forked or corrupted. Each new delta includes a prev_commitment field that references the commitment of the base state in which the delta is applied.
+Is the commitment of the state, it's a hash, nonce, or any other identifier that serves as the unique identifier of the current state of the account. It's used to certify that the state is not forked or corrupted. Each new delta includes a prev_commitment field that references the commitment of the base state in which the delta is applied.
 
 ### Nonce
 


### PR DESCRIPTION
Corrected a typo in the commitment section regarding the term 'certify'.