### PR TITLE
EVM proposals support specifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ templates/
 CLAUDE.md
 
 .vscode/
+.specify/state/
 
 crates/server/bench/results/*
 !crates/server/bench/results/.gitkeep

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,0 +1,1 @@
+../../speckit/constitution.md

--- a/.specify/scripts/bash/check-prerequisites.sh
+++ b/.specify/scripts/bash/check-prerequisites.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+source "${SCRIPT_DIR}/common.sh"
+
+json_output=false
+paths_only=false
+require_tasks=false
+include_tasks=false
+feature_arg=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --json)
+      json_output=true
+      ;;
+    --paths-only)
+      paths_only=true
+      ;;
+    --require-tasks)
+      require_tasks=true
+      ;;
+    --include-tasks)
+      include_tasks=true
+      ;;
+    --feature)
+      feature_arg="${2:-}"
+      shift
+      ;;
+    --help|-h)
+      cat <<'EOF'
+Usage: check-prerequisites.sh [--json] [--paths-only] [--require-tasks] [--include-tasks] [--feature KEY]
+EOF
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+feature_key="$(resolve_feature_key "${feature_arg}")"
+feature_dir="$(feature_dir_from_key "${feature_key}")"
+spec_file="${feature_dir}/spec.md"
+plan_file="${feature_dir}/plan.md"
+research_file="${feature_dir}/research.md"
+data_model_file="${feature_dir}/data-model.md"
+quickstart_file="${feature_dir}/quickstart.md"
+tasks_file="${feature_dir}/tasks.md"
+contracts_dir="${feature_dir}/contracts"
+checklists_dir="${feature_dir}/checklists"
+
+if [ ! -f "${spec_file}" ]; then
+  echo "Missing spec file for active feature: ${spec_file}" >&2
+  exit 1
+fi
+
+if [ "${require_tasks}" = true ] && [ ! -f "${tasks_file}" ]; then
+  echo "Missing tasks.md for active feature. Run the tasks workflow first." >&2
+  exit 1
+fi
+
+set_active_feature "${feature_key}"
+
+available_docs=()
+
+for candidate in \
+  "${spec_file}" \
+  "${plan_file}" \
+  "${research_file}" \
+  "${data_model_file}" \
+  "${quickstart_file}" \
+  "${tasks_file}"; do
+  if [ -f "${candidate}" ]; then
+    available_docs+=("$(basename "${candidate}")")
+  fi
+done
+
+if [ -d "${contracts_dir}" ]; then
+  available_docs+=("contracts")
+fi
+
+if [ "${include_tasks}" = true ] && [ -d "${checklists_dir}" ] && find "${checklists_dir}" -type f -name '*.md' -print -quit | grep -q .; then
+  available_docs+=("checklists")
+fi
+
+branch_name="$(suggested_branch_name "${feature_key}")"
+
+if [ "${json_output}" = true ]; then
+  cat <<EOF
+{
+  "FEATURE_KEY": "$(json_escape "${feature_key}")",
+  "FEATURE_DIR": "$(json_escape "$(abs_path "${feature_dir}")")",
+  "FEATURE_SPEC": "$(json_escape "$(abs_path "${spec_file}")")",
+  "IMPL_PLAN": "$(json_escape "$(abs_path "${plan_file}")")",
+  "TASKS": "$(json_escape "$(abs_path "${tasks_file}")")",
+  "RESEARCH": "$(json_escape "$(abs_path "${research_file}")")",
+  "DATA_MODEL": "$(json_escape "$(abs_path "${data_model_file}")")",
+  "QUICKSTART": "$(json_escape "$(abs_path "${quickstart_file}")")",
+  "CONTRACTS_DIR": "$(json_escape "$(abs_path "${contracts_dir}")")",
+  "CHECKLISTS_DIR": "$(json_escape "$(abs_path "${checklists_dir}")")",
+  "BRANCH": "$(json_escape "${branch_name}")",
+  "AVAILABLE_DOCS": $(json_array "${available_docs[@]}")
+}
+EOF
+  exit 0
+fi
+
+if [ "${paths_only}" = true ]; then
+  cat <<EOF
+FEATURE_DIR=$(abs_path "${feature_dir}")
+FEATURE_SPEC=$(abs_path "${spec_file}")
+IMPL_PLAN=$(abs_path "${plan_file}")
+TASKS=$(abs_path "${tasks_file}")
+EOF
+  exit 0
+fi
+
+cat <<EOF
+Feature workspace: $(abs_path "${feature_dir}")
+Spec: $(abs_path "${spec_file}")
+Plan: $(abs_path "${plan_file}")
+Tasks: $(abs_path "${tasks_file}")
+Available docs: ${available_docs[*]}
+EOF

--- a/.specify/scripts/bash/common.sh
+++ b/.specify/scripts/bash/common.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root() {
+  git rev-parse --show-toplevel 2>/dev/null || pwd -P
+}
+
+readonly ROOT="$(repo_root)"
+readonly SPECIFY_DIR="${ROOT}/.specify"
+readonly SCRIPTS_DIR="${SPECIFY_DIR}/scripts/bash"
+readonly MEMORY_DIR="${SPECIFY_DIR}/memory"
+readonly STATE_DIR="${SPECIFY_DIR}/state"
+readonly SPECKIT_DIR="${ROOT}/speckit"
+readonly FEATURES_DIR="${SPECKIT_DIR}/features"
+readonly ACTIVE_FEATURE_FILE="${STATE_DIR}/active-feature"
+
+ensure_engine_dirs() {
+  mkdir -p "${SCRIPTS_DIR}" "${MEMORY_DIR}" "${STATE_DIR}" "${FEATURES_DIR}"
+}
+
+today_iso() {
+  date +%F
+}
+
+current_branch() {
+  git rev-parse --abbrev-ref HEAD 2>/dev/null || true
+}
+
+feature_dir_from_key() {
+  printf '%s/%s\n' "${FEATURES_DIR}" "$1"
+}
+
+feature_exists() {
+  [ -d "$(feature_dir_from_key "$1")" ]
+}
+
+normalize_feature_from_branch() {
+  local branch="${1:-}"
+  branch="${branch#codex/}"
+  if [[ "${branch}" =~ ^[0-9]{3}-[a-z0-9][a-z0-9-]*$ ]] && feature_exists "${branch}"; then
+    printf '%s\n' "${branch}"
+  fi
+}
+
+read_active_feature_file() {
+  if [ -f "${ACTIVE_FEATURE_FILE}" ]; then
+    tr -d '[:space:]' < "${ACTIVE_FEATURE_FILE}"
+  fi
+}
+
+single_feature_key() {
+  local matches=()
+  local path
+  while IFS= read -r path; do
+    matches+=("$(basename "${path}")")
+  done < <(find "${FEATURES_DIR}" -mindepth 1 -maxdepth 1 -type d | sort)
+
+  if [ "${#matches[@]}" -eq 1 ]; then
+    printf '%s\n' "${matches[0]}"
+  fi
+}
+
+resolve_feature_key() {
+  ensure_engine_dirs
+
+  local explicit="${1:-}"
+  local key=""
+
+  if [ -n "${explicit}" ]; then
+    key="${explicit}"
+  fi
+
+  if [ -z "${key}" ]; then
+    key="$(normalize_feature_from_branch "$(current_branch)")"
+  fi
+
+  if [ -z "${key}" ]; then
+    key="$(read_active_feature_file)"
+  fi
+
+  if [ -z "${key}" ]; then
+    key="$(single_feature_key)"
+  fi
+
+  if [ -z "${key}" ]; then
+    echo "No active feature workspace found. Create one first or pass --feature <key>." >&2
+    return 1
+  fi
+
+  if ! feature_exists "${key}"; then
+    echo "Feature workspace not found: ${key}" >&2
+    return 1
+  fi
+
+  printf '%s\n' "${key}"
+}
+
+set_active_feature() {
+  ensure_engine_dirs
+  printf '%s\n' "$1" > "${ACTIVE_FEATURE_FILE}"
+}
+
+abs_path() {
+  local target="$1"
+  if [ -d "${target}" ]; then
+    (cd "${target}" && pwd -P)
+    return
+  fi
+
+  local dir
+  local base
+  dir="$(dirname "${target}")"
+  base="$(basename "${target}")"
+  printf '%s/%s\n' "$(cd "${dir}" && pwd -P)" "${base}"
+}
+
+json_escape() {
+  local s="${1:-}"
+  s=${s//\\/\\\\}
+  s=${s//\"/\\\"}
+  s=${s//$'\n'/\\n}
+  s=${s//$'\r'/\\r}
+  s=${s//$'\t'/\\t}
+  printf '%s' "${s}"
+}
+
+json_array() {
+  local out="["
+  local first=1
+  local item
+
+  for item in "$@"; do
+    if [ "${first}" -eq 0 ]; then
+      out+=", "
+    fi
+    first=0
+    out+="\"$(json_escape "${item}")\""
+  done
+
+  out+="]"
+  printf '%s' "${out}"
+}
+
+slugify() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-{2,}/-/g'
+}
+
+humanize_feature_key() {
+  local key="${1#*-}"
+  printf '%s' "${key}" | tr '-' ' ' | awk '{for (i = 1; i <= NF; i++) {$i = toupper(substr($i, 1, 1)) substr($i, 2)}}1'
+}
+
+extract_feature_title() {
+  local spec_file="$1"
+  if [ -f "${spec_file}" ]; then
+    awk -F': ' '/^# Feature Specification:/ {print $2; exit}' "${spec_file}"
+  fi
+}
+
+escape_sed() {
+  local s="${1:-}"
+  s=${s//\\/\\\\}
+  printf '%s' "${s}" | sed -e 's/[\/&|]/\\&/g'
+}
+
+render_basic_template() {
+  local template="$1"
+  local dest="$2"
+  local feature_title="$3"
+  local feature_key="$4"
+  local date="$5"
+  local input="$6"
+
+  sed \
+    -e "s/\[FEATURE NAME\]/$(escape_sed "${feature_title}")/g" \
+    -e "s/\[FEATURE\]/$(escape_sed "${feature_title}")/g" \
+    -e "s/\[###-feature-name\]/$(escape_sed "${feature_key}")/g" \
+    -e "s/\[DATE\]/$(escape_sed "${date}")/g" \
+    -e "s|\$ARGUMENTS|$(escape_sed "${input}")|g" \
+    "${template}" > "${dest}"
+}
+
+next_feature_number_for_short_name() {
+  local short_name="$1"
+  local max=0
+  local dir
+  local base
+  local num
+
+  while IFS= read -r dir; do
+    base="$(basename "${dir}")"
+    num="${base%%-*}"
+    if [ "${num}" -gt "${max}" ]; then
+      max="${num}"
+    fi
+  done < <(find "${FEATURES_DIR}" -mindepth 1 -maxdepth 1 -type d -name "[0-9][0-9][0-9]-${short_name}" | sort)
+
+  printf '%s\n' "$((max + 1))"
+}
+
+format_feature_number() {
+  printf '%03d' "$1"
+}
+
+suggested_branch_name() {
+  local feature_key="$1"
+  local branch
+  branch="$(current_branch)"
+
+  if [ "${branch}" = "codex/${feature_key}" ] || [ "${branch}" = "${feature_key}" ]; then
+    printf '%s\n' "${branch}"
+    return
+  fi
+
+  printf '%s\n' "${feature_key}"
+}

--- a/.specify/scripts/bash/create-new-feature.sh
+++ b/.specify/scripts/bash/create-new-feature.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+source "${SCRIPT_DIR}/common.sh"
+
+json_output=false
+feature_number=""
+short_name=""
+feature_arg=""
+description_parts=()
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --json)
+      json_output=true
+      ;;
+    --number)
+      feature_number="${2:-}"
+      shift
+      ;;
+    --short-name)
+      short_name="${2:-}"
+      shift
+      ;;
+    --feature)
+      feature_arg="${2:-}"
+      shift
+      ;;
+    --help|-h)
+      cat <<'EOF'
+Usage: create-new-feature.sh [--json] [--number N] [--short-name NAME] "Feature description"
+EOF
+      exit 0
+      ;;
+    *)
+      description_parts+=("$1")
+      ;;
+  esac
+  shift
+done
+
+description="${description_parts[*]}"
+
+if [ -z "${description}" ]; then
+  echo "Feature description is required." >&2
+  exit 1
+fi
+
+ensure_engine_dirs
+
+if [ -z "${short_name}" ]; then
+  short_name="$(slugify "${description}")"
+fi
+
+if [ -z "${short_name}" ]; then
+  echo "Unable to derive a short feature name." >&2
+  exit 1
+fi
+
+if [ -z "${feature_number}" ]; then
+  feature_number="$(next_feature_number_for_short_name "${short_name}")"
+fi
+
+if ! [[ "${feature_number}" =~ ^[0-9]+$ ]]; then
+  echo "Feature number must be numeric." >&2
+  exit 1
+fi
+
+feature_key="$(format_feature_number "${feature_number}")-${short_name}"
+if [ -n "${feature_arg}" ]; then
+  feature_key="${feature_arg}"
+fi
+
+feature_dir="$(feature_dir_from_key "${feature_key}")"
+spec_file="${feature_dir}/spec.md"
+
+if [ -e "${feature_dir}" ]; then
+  echo "Feature workspace already exists: ${feature_dir}" >&2
+  exit 1
+fi
+
+mkdir -p "${feature_dir}/checklists"
+
+render_basic_template \
+  "${ROOT}/.specify/templates/spec-template.md" \
+  "${spec_file}" \
+  "${description}" \
+  "${feature_key}" \
+  "$(today_iso)" \
+  "${description}"
+
+set_active_feature "${feature_key}"
+branch_name="$(suggested_branch_name "${feature_key}")"
+
+if [ "${json_output}" = true ]; then
+  cat <<EOF
+{
+  "FEATURE_KEY": "$(json_escape "${feature_key}")",
+  "FEATURE_DIR": "$(json_escape "$(abs_path "${feature_dir}")")",
+  "SPEC_FILE": "$(json_escape "$(abs_path "${spec_file}")")",
+  "BRANCH_NAME": "$(json_escape "${branch_name}")"
+}
+EOF
+  exit 0
+fi
+
+cat <<EOF
+Feature workspace created: $(abs_path "${feature_dir}")
+Spec file: $(abs_path "${spec_file}")
+Suggested branch: ${branch_name}
+EOF

--- a/.specify/scripts/bash/setup-plan.sh
+++ b/.specify/scripts/bash/setup-plan.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+source "${SCRIPT_DIR}/common.sh"
+
+json_output=false
+feature_arg=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --json)
+      json_output=true
+      ;;
+    --feature)
+      feature_arg="${2:-}"
+      shift
+      ;;
+    --help|-h)
+      cat <<'EOF'
+Usage: setup-plan.sh [--json] [--feature KEY]
+EOF
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+feature_key="$(resolve_feature_key "${feature_arg}")"
+feature_dir="$(feature_dir_from_key "${feature_key}")"
+spec_file="${feature_dir}/spec.md"
+plan_file="${feature_dir}/plan.md"
+
+if [ ! -f "${spec_file}" ]; then
+  echo "Missing spec file for active feature. Create or generate spec.md first." >&2
+  exit 1
+fi
+
+if [ ! -f "${plan_file}" ]; then
+  feature_title="$(extract_feature_title "${spec_file}")"
+  if [ -z "${feature_title}" ]; then
+    feature_title="$(humanize_feature_key "${feature_key}")"
+  fi
+
+  render_basic_template \
+    "${ROOT}/.specify/templates/plan-template.md" \
+    "${plan_file}" \
+    "${feature_title}" \
+    "${feature_key}" \
+    "$(today_iso)" \
+    "Feature specification in ${feature_key}"
+
+  tmp_file="$(mktemp)"
+  sed 's|\[link\]|[spec.md](./spec.md)|g' "${plan_file}" > "${tmp_file}"
+  mv "${tmp_file}" "${plan_file}"
+fi
+
+set_active_feature "${feature_key}"
+branch_name="$(suggested_branch_name "${feature_key}")"
+
+if [ "${json_output}" = true ]; then
+  cat <<EOF
+{
+  "FEATURE_KEY": "$(json_escape "${feature_key}")",
+  "FEATURE_SPEC": "$(json_escape "$(abs_path "${spec_file}")")",
+  "IMPL_PLAN": "$(json_escape "$(abs_path "${plan_file}")")",
+  "SPECS_DIR": "$(json_escape "$(abs_path "${feature_dir}")")",
+  "BRANCH": "$(json_escape "${branch_name}")"
+}
+EOF
+  exit 0
+fi
+
+cat <<EOF
+Feature workspace: $(abs_path "${feature_dir}")
+Plan file: $(abs_path "${plan_file}")
+Suggested branch: ${branch_name}
+EOF

--- a/.specify/scripts/bash/update-agent-context.sh
+++ b/.specify/scripts/bash/update-agent-context.sh
@@ -34,8 +34,8 @@ case "${agent_name}" in
     ;;
 esac
 
-active_technologies=$'- Rust monorepo centered on crates/server, crates/client, and crates/miden-multisig-client\n- TypeScript SDK packages: packages/psm-client and packages/miden-multisig-client\n- Dual transport surface: HTTP + gRPC with semantic parity requirements\n- Examples as validation surfaces: examples/demo, examples/web, examples/rust'
-commands=$'- `cargo test -p private-state-manager-server`\n- `cargo test -p private-state-manager-client`\n- `cargo test -p miden-multisig-client`\n- `cd packages/psm-client && npm test`\n- `cd packages/miden-multisig-client && npm test`'
+active_technologies=$'- Rust monorepo centered on crates/server, crates/client, and crates/miden-multisig-client\n- TypeScript SDK packages: packages/guardian-client and packages/miden-multisig-client\n- Dual transport surface: HTTP + gRPC with semantic parity requirements\n- Examples as validation surfaces: examples/demo, examples/web, examples/rust'
+commands=$'- `cargo test -p private-state-manager-server`\n- `cargo test -p private-state-manager-client`\n- `cargo test -p miden-multisig-client`\n- `cd packages/guardian-client && npm test`\n- `cd packages/miden-multisig-client && npm test`'
 recent_changes=$'- Constitution v1.0.0: bottom-up propagation, transport parity, append-only integrity, explicit auth, evidence-driven validation.\n- Feature workspaces live under `speckit/features/`.\n- Branch creation is manual; scripts only record the suggested feature branch.'
 
 if [ -n "${plan_file}" ] && [ -f "${plan_file}" ]; then
@@ -46,7 +46,7 @@ if [ -n "${plan_file}" ] && [ -f "${plan_file}" ]; then
 fi
 
 cat > "${target_file}" <<EOF
-# Private State Manager Agent Context
+# Guardian Agent Context
 
 Auto-generated from the active feature plan.
 
@@ -61,7 +61,7 @@ ${active_technologies}
 
 \`\`\`text
 crates/{server,client,shared,miden-multisig-client,miden-rpc-client,miden-keystore}
-packages/{psm-client,miden-multisig-client}
+packages/{guardian-client,miden-multisig-client}
 examples/{demo,web,rust}
 speckit/features/${feature_key:-[###-feature-name]}
 \`\`\`

--- a/.specify/scripts/bash/update-agent-context.sh
+++ b/.specify/scripts/bash/update-agent-context.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+source "${SCRIPT_DIR}/common.sh"
+
+agent_name="${1:-claude}"
+ensure_engine_dirs
+
+feature_key=""
+if feature_key="$(resolve_feature_key 2>/dev/null)"; then
+  set_active_feature "${feature_key}"
+fi
+
+feature_title="No active feature"
+plan_file=""
+if [ -n "${feature_key}" ]; then
+  plan_file="$(feature_dir_from_key "${feature_key}")/plan.md"
+  feature_title="$(humanize_feature_key "${feature_key}")"
+fi
+
+case "${agent_name}" in
+  claude)
+    mkdir -p "${ROOT}/.claude"
+    target_file="${ROOT}/.claude/spec-kit-context.md"
+    ;;
+  cursor)
+    mkdir -p "${ROOT}/.cursor"
+    target_file="${ROOT}/.cursor/spec-kit-context.md"
+    ;;
+  *)
+    mkdir -p "${ROOT}/.specify/agent-context"
+    target_file="${ROOT}/.specify/agent-context/${agent_name}.md"
+    ;;
+esac
+
+active_technologies=$'- Rust monorepo centered on crates/server, crates/client, and crates/miden-multisig-client\n- TypeScript SDK packages: packages/psm-client and packages/miden-multisig-client\n- Dual transport surface: HTTP + gRPC with semantic parity requirements\n- Examples as validation surfaces: examples/demo, examples/web, examples/rust'
+commands=$'- `cargo test -p private-state-manager-server`\n- `cargo test -p private-state-manager-client`\n- `cargo test -p miden-multisig-client`\n- `cd packages/psm-client && npm test`\n- `cd packages/miden-multisig-client && npm test`'
+recent_changes=$'- Constitution v1.0.0: bottom-up propagation, transport parity, append-only integrity, explicit auth, evidence-driven validation.\n- Feature workspaces live under `speckit/features/`.\n- Branch creation is manual; scripts only record the suggested feature branch.'
+
+if [ -n "${plan_file}" ] && [ -f "${plan_file}" ]; then
+  summary_line="$(awk 'BEGIN{found=0} /^## Summary/{found=1; next} found && NF {print; exit}' "${plan_file}")"
+  if [ -n "${summary_line}" ]; then
+    recent_changes+=$'\n- Active plan summary: '"${summary_line}"
+  fi
+fi
+
+cat > "${target_file}" <<EOF
+# Private State Manager Agent Context
+
+Auto-generated from the active feature plan.
+
+**Updated**: $(today_iso)  
+**Active Feature**: ${feature_title} (\`${feature_key:-none}\`)
+
+## Active Technologies
+
+${active_technologies}
+
+## Project Structure
+
+\`\`\`text
+crates/{server,client,shared,miden-multisig-client,miden-rpc-client,miden-keystore}
+packages/{psm-client,miden-multisig-client}
+examples/{demo,web,rust}
+speckit/features/${feature_key:-[###-feature-name]}
+\`\`\`
+
+## Validation Commands
+
+${commands}
+
+## Working Rules
+
+- Preserve HTTP/gRPC semantic parity unless a spec documents intentional divergence.
+- Preserve Rust/TypeScript behavioral parity for equivalent workflows.
+- Propagate lower-layer changes upward through clients, multisig SDKs, and examples.
+- Prefer targeted validation first, then widen only if blast radius grows.
+
+## Current Constraints
+
+${recent_changes}
+EOF
+
+echo "Updated agent context: ${target_file}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ If a behavior changes in a lower layer, verify and propagate impact upward.
 3. Update tests in the layer where behavior changes, plus at least one upstream consumer.
 4. Prefer minimal, surgical edits over broad refactors.
 5. Do not introduce silent behavior drift between Rust and TypeScript clients.
+6. Do not add backward-compatibility layers, migrations, or fallback behavior unless the task explicitly requires them.
 
 ## 4) Contract-Change Workflow (Mandatory)
 
@@ -65,6 +66,7 @@ Use this when changing endpoints, payloads, status enums, signatures, or auth be
 - Maintain storage/metadata backend parity (filesystem/postgres where applicable).
 - Preserve canonicalization semantics (pending/candidate/canonical/discarded lifecycle).
 - Default local development/test backend is `filesystem` unless a task explicitly requires Postgres.
+- Keep shared server layers network-agnostic. Put Miden/EVM-specific logic in `src/network/*`, and dispatch from services/builders via account network config rather than embedding network-specific assumptions in shared modules.
 
 ### Rust PSM Client (`crates/client`)
 
@@ -214,6 +216,8 @@ Apply these rules especially to:
 
 - Keep public APIs explicit and stable unless change is intentional.
 - Prefer typed structures/enums over ad-hoc maps or stringly-typed branching.
+- Prefer mandatory fields in domain and request-facing types over optional ones.
+- If a transport layer forces optionality (for example protobuf message fields), validate at the boundary and convert immediately into required domain types.
 - Model proposal state transitions explicitly (pending/ready/finalized).
 - Ensure Rust and TypeScript behavior remain semantically equivalent for the same workflow.
 
@@ -230,6 +234,8 @@ Apply these rules especially to:
   - Apply the same principle with constructors/associated functions on domain types.
   - Prefer patterns like:
     - `SignatureInputs::from_json(delta_payload_json)` instead of `parse_unique_signature_inputs(...)`
+- When logic does not fit an existing domain type, introduce a focused service struct/enum in an appropriate module instead of scattering one-off free functions.
+- Prefer trait-based mocks at dependency boundaries over enum-level mock variants or test-only branches in shared runtime state.
 
 ### Immutability (TypeScript)
 
@@ -239,6 +245,7 @@ Apply these rules especially to:
 
 ### Additional Style Rules
 
+- Import local types/modules instead of repeating inline fully qualified paths when an alias or direct import makes ownership clear.
 - Hex/Bytes Boundary Rule:
   - Validate and normalize external commitments, pubkeys, signatures, and account IDs at boundaries before domain logic.
   - Enforce expected shape (`0x` prefix, canonical casing, expected length) at parse time.

--- a/speckit/README.md
+++ b/speckit/README.md
@@ -1,0 +1,72 @@
+# Spec Kit Workflow
+
+This repository keeps Spec Kit artifacts under `speckit/` and keeps the helper
+engine under `.specify/`.
+
+## Layout
+
+```text
+speckit/
+├── constitution.md
+├── README.md
+└── features/
+    └── 001-example-feature/
+        ├── spec.md
+        ├── plan.md
+        ├── research.md
+        ├── data-model.md
+        ├── quickstart.md
+        ├── contracts/
+        ├── tasks.md
+        └── checklists/
+```
+
+## Working Model
+
+- `spec/` remains the system and protocol reference.
+- `speckit/constitution.md` defines hard project invariants for feature work.
+- `speckit/features/` holds tracked feature-specific artifacts.
+- `.specify/state/active-feature` is local runtime state and is intentionally not tracked.
+
+## Branching
+
+Branch creation is manual. The helper scripts only suggest a branch name that
+matches the feature key, such as `001-auth-replay-tightening`.
+
+## Core Commands
+
+Create a feature workspace:
+
+```bash
+.specify/scripts/bash/create-new-feature.sh --json --short-name auth-replay-tightening "Tighten replay protection validation for signed requests"
+```
+
+Create or retrieve the plan workspace for the active feature:
+
+```bash
+.specify/scripts/bash/setup-plan.sh --json
+```
+
+Resolve the active feature workspace paths:
+
+```bash
+.specify/scripts/bash/check-prerequisites.sh --json
+```
+
+Update agent guidance from the active feature plan:
+
+```bash
+.specify/scripts/bash/update-agent-context.sh claude
+```
+
+## Active Feature Resolution
+
+The helper scripts resolve the active feature in this order:
+
+1. `--feature <key>` when explicitly provided
+2. Current git branch if it matches an existing feature key
+3. `.specify/state/active-feature`
+4. The only existing feature workspace, when exactly one exists
+
+If multiple workspaces exist and none of the sources above identify one, the
+script stops and asks for `--feature`.

--- a/speckit/constitution.md
+++ b/speckit/constitution.md
@@ -1,26 +1,23 @@
 <!--
 Sync Impact Report
-Version change: none -> 1.0.0
-Modified principles: N/A (initial adoption)
+Version change: 1.0.0 -> 1.1.0
+Modified principles:
+- III. Append-Only Integrity and Explicit Lifecycles (expanded fallback rule)
 Added sections:
-- Purpose
-- Principles
-- System Invariants
-- Governance
+- None
 Removed sections:
 - None
 Templates requiring updates:
-- ✅ /Users/marcos/repos/private-state-manager/.specify/templates/spec-template.md
-- ✅ /Users/marcos/repos/private-state-manager/.specify/templates/plan-template.md
-- ✅ /Users/marcos/repos/private-state-manager/.specify/templates/tasks-template.md
-- ✅ /Users/marcos/repos/private-state-manager/.specify/templates/checklist-template.md
-- ✅ /Users/marcos/repos/private-state-manager/.specify/templates/agent-file-template.md
+- ✅ .specify/templates/plan-template.md
+- ✅ .specify/templates/spec-template.md
+- ✅ .specify/templates/tasks-template.md
+- ✅ .specify/templates/checklist-template.md
 Follow-up TODOs:
 - Revisit whether observability and offline import/export compatibility should become first-class principles.
 -->
 # Private State Manager Constitution
 
-**Version**: 1.0.0  
+**Version**: 1.1.0  
 **Ratified**: 2026-03-18  
 **Last Amended**: 2026-03-18
 
@@ -57,7 +54,9 @@ Rationale: parity is a core product property, not a cleanup task.
 State, delta, and proposal flows MUST preserve append-only records with explicit
 lifecycle transitions. Features MUST not introduce implicit fallback paths,
 silent state rewrites, or undocumented status changes across pending,
-candidate, canonical, discarded, or proposal states.
+candidate, canonical, discarded, or proposal states. Online and offline flows,
+including any fallback between them, MUST remain explicit in the API flow,
+return types, or user-visible control path.
 
 Rationale: append-only lineage and explicit state machines are the backbone of
 trust, replay safety, and debugging.
@@ -90,6 +89,9 @@ amendment changes them:
 - Delta lineage remains explicit through `prev_commitment` and nonce-based ordering rules.
 - HTTP and gRPC preserve the same core semantics, shapes, and error meanings.
 - Equivalent Rust and TypeScript workflows preserve the same observable behavior.
+- Storage backends such as filesystem and Postgres preserve the same externally
+  observable semantics unless a documented backend-specific limitation is
+  explicitly accepted.
 - Per-account authentication remains explicit and replay-protected.
 - Canonicalization lifecycle remains explicit: pending or candidate data may only
   move to canonical or discarded through documented transitions.

--- a/speckit/constitution.md
+++ b/speckit/constitution.md
@@ -1,0 +1,125 @@
+<!--
+Sync Impact Report
+Version change: none -> 1.0.0
+Modified principles: N/A (initial adoption)
+Added sections:
+- Purpose
+- Principles
+- System Invariants
+- Governance
+Removed sections:
+- None
+Templates requiring updates:
+- ✅ /Users/marcos/repos/private-state-manager/.specify/templates/spec-template.md
+- ✅ /Users/marcos/repos/private-state-manager/.specify/templates/plan-template.md
+- ✅ /Users/marcos/repos/private-state-manager/.specify/templates/tasks-template.md
+- ✅ /Users/marcos/repos/private-state-manager/.specify/templates/checklist-template.md
+- ✅ /Users/marcos/repos/private-state-manager/.specify/templates/agent-file-template.md
+Follow-up TODOs:
+- Revisit whether observability and offline import/export compatibility should become first-class principles.
+-->
+# Private State Manager Constitution
+
+**Version**: 1.0.0  
+**Ratified**: 2026-03-18  
+**Last Amended**: 2026-03-18
+
+## Purpose
+
+This constitution governs how feature work is specified, planned, and delivered
+in Private State Manager. It exists to preserve protocol integrity across the
+server, Rust and TypeScript client layers, multisig SDKs, and validation
+examples in a multi-language codebase.
+
+## Principles
+
+### I. Bottom-Up Change Propagation
+
+Any change MUST be assessed from `crates/server` upward through base clients,
+multisig SDKs, and examples. A lower-layer contract or behavior change is not
+complete until affected upstream consumers have been updated or explicitly
+proven unaffected.
+
+Rationale: the server is the system of record, and silent propagation gaps
+create regressions that only surface after integration.
+
+### II. Transport and Cross-Language Parity
+
+HTTP and gRPC surfaces MUST preserve equivalent semantics for the same workflow.
+Rust and TypeScript clients that model the same workflow MUST remain
+behaviorally aligned. Any intentional divergence MUST be documented in the
+feature spec and plan before implementation begins.
+
+Rationale: parity is a core product property, not a cleanup task.
+
+### III. Append-Only Integrity and Explicit Lifecycles
+
+State, delta, and proposal flows MUST preserve append-only records with explicit
+lifecycle transitions. Features MUST not introduce implicit fallback paths,
+silent state rewrites, or undocumented status changes across pending,
+candidate, canonical, discarded, or proposal states.
+
+Rationale: append-only lineage and explicit state machines are the backbone of
+trust, replay safety, and debugging.
+
+### IV. Explicit Authentication and Stable Boundary Errors
+
+Per-account authentication, replay protection, signature handling, and boundary
+error semantics MUST remain explicit. Changes touching auth, signature schemes,
+status enums, payload shapes, or error surfaces are high-risk and MUST update
+tests in the changed layer plus at least one upstream consumer.
+
+Rationale: auth and error drift produce the most expensive cross-layer failures.
+
+### V. Evidence-Driven Delivery
+
+Every feature MUST define independently testable user stories, a targeted
+validation plan, and any required docs or example updates when behavior changes.
+High-risk areas, including auth, signatures, proposal lifecycle, canonical
+status transitions, Rust/TypeScript parity, and offline import/export
+compatibility, MUST receive updated validation before work is considered done.
+
+Rationale: feature completion is based on evidence, not implementation effort.
+
+## System Invariants
+
+The following invariants are non-negotiable unless an explicit constitution
+amendment changes them:
+
+- State, delta, and proposal records remain append-only within per-account namespaces.
+- Delta lineage remains explicit through `prev_commitment` and nonce-based ordering rules.
+- HTTP and gRPC preserve the same core semantics, shapes, and error meanings.
+- Equivalent Rust and TypeScript workflows preserve the same observable behavior.
+- Per-account authentication remains explicit and replay-protected.
+- Canonicalization lifecycle remains explicit: pending or candidate data may only
+  move to canonical or discarded through documented transitions.
+- Discarded deltas MUST NOT appear in default user-facing retrieval flows.
+- Proposal identifiers remain deterministic, duplicate proposal signatures are
+  rejected, and matching proposals are deleted when the corresponding delta
+  becomes canonical.
+- Local development and test work default to the filesystem backend unless a
+  task explicitly requires Postgres.
+
+## Governance
+
+### Amendment Process
+
+Changes to this constitution MUST be made in `speckit/constitution.md` and MUST
+be accompanied by any required template updates under `.specify/templates/`.
+Constitution changes are separate from feature implementation changes unless the
+feature itself is explicitly revising project governance.
+
+### Versioning Policy
+
+Constitution versioning follows semantic versioning:
+
+- MAJOR: removals or redefinitions that change governance expectations
+- MINOR: new principles, sections, or materially expanded rules
+- PATCH: clarifications, wording fixes, or non-semantic refinements
+
+### Compliance Review
+
+Feature specifications, plans, tasks, and analysis outputs MUST treat this
+constitution as authoritative. If a feature cannot satisfy a principle, the
+work MUST stop and either simplify the design or amend the constitution
+explicitly before implementation continues.

--- a/speckit/constitution.md
+++ b/speckit/constitution.md
@@ -15,7 +15,7 @@ Templates requiring updates:
 Follow-up TODOs:
 - Revisit whether observability and offline import/export compatibility should become first-class principles.
 -->
-# Private State Manager Constitution
+# Guardian Constitution
 
 **Version**: 1.1.0  
 **Ratified**: 2026-03-18  
@@ -24,7 +24,7 @@ Follow-up TODOs:
 ## Purpose
 
 This constitution governs how feature work is specified, planned, and delivered
-in Private State Manager. It exists to preserve protocol integrity across the
+in Guardian. It exists to preserve protocol integrity across the
 server, Rust and TypeScript client layers, multisig SDKs, and validation
 examples in a multi-language codebase.
 

--- a/speckit/features/001-evm-proposal-support/checklists/requirements.md
+++ b/speckit/features/001-evm-proposal-support/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Requirements Checklist: Add generic EVM proposal sharing and signing support
+
+**Purpose**: Validate that the feature requirements are complete, clear, and
+ready for planning and implementation  
+**Created**: 2026-03-18  
+**Feature**: [spec.md](/Users/marcos/repos/private-state-manager/speckit/features/001-evm-proposal-support/spec.md)
+
+## Requirement Completeness
+
+- [x] CHK001 Are the affected layers explicitly identified when lower-layer behavior changes? [Coverage] [Context] [Contract / Transport Impact]
+- [x] CHK002 Are in-scope and out-of-scope boundaries documented? [Completeness] [Scope]
+- [x] CHK003 Are upstream consumer validation expectations defined when contracts change? [Coverage] [User Scenarios & Testing] [Contract / Transport Impact]
+
+## Contract & Parity Clarity
+
+- [x] CHK004 Are HTTP and gRPC changes or non-changes stated explicitly? [Clarity] [User Scenarios & Testing] [Contract / Transport Impact]
+- [x] CHK005 Are Rust and TypeScript client impacts stated explicitly? [Clarity] [Context] [Contract / Transport Impact]
+- [x] CHK006 Are storage backend parity expectations or limitations stated explicitly? [Clarity] [Data / Lifecycle Impact]
+- [x] CHK007 Are error-shape and auth expectations specific enough to verify? [Measurability] [Functional Requirements] [Contract / Transport Impact] [Edge Cases]
+
+## State, Auth, and Lifecycle Coverage
+
+- [x] CHK008 Are state, delta, proposal, or canonicalization lifecycle impacts documented when relevant? [Coverage] [Scope] [Data / Lifecycle Impact]
+- [x] CHK009 Is fallback behavior defined explicitly when online/offline or alternate-path execution exists? [Clarity] [Contract / Transport Impact] [Functional Requirements]
+- [x] CHK010 Are replay protection, signer handling, or duplicate-signature edge cases addressed when relevant? [Edge Case] [User Story 2] [Functional Requirements] [Edge Cases]
+- [x] CHK011 Are append-only or namespace invariants preserved or intentionally changed with justification? [Consistency] [Data / Lifecycle Impact]
+
+## Validation & Documentation Readiness
+
+- [x] CHK012 Are acceptance scenarios independently testable per user story? [Acceptance Criteria] [User Scenarios & Testing]
+- [x] CHK013 Are targeted test commands or validation surfaces identified? [Completeness] [User Scenarios & Testing] [Contract / Transport Impact]
+- [x] CHK014 Are docs/examples updates called out when external behavior changes? [Coverage] [Data / Lifecycle Impact]
+
+## Notes
+
+- The spec is ready to move into planning with the remaining team questions kept
+  explicitly in `Open Questions For Team`.

--- a/speckit/features/001-evm-proposal-support/checklists/requirements.md
+++ b/speckit/features/001-evm-proposal-support/checklists/requirements.md
@@ -33,5 +33,5 @@ ready for planning and implementation
 
 ## Notes
 
-- The spec is ready to move into planning with the remaining team questions kept
-  explicitly in `Open Questions For Team`.
+- The spec is ready to move into planning with deferred follow-up items kept in
+  `Deferred Topics`.

--- a/speckit/features/001-evm-proposal-support/contracts/grpc-contract.md
+++ b/speckit/features/001-evm-proposal-support/contracts/grpc-contract.md
@@ -44,6 +44,9 @@ message ConfigureRequest {
 }
 ```
 
+For EVM accounts, `account_id` uses the canonical form
+`evm:<chain_id>:<normalized_contract_address>`.
+
 ### 3. Extend `AuthConfig`
 
 ```proto
@@ -56,9 +59,40 @@ message AuthConfig {
 }
 
 message EvmEcdsaAuth {
-  repeated string cosigner_commitments = 1;
+  repeated string signers = 1;
 }
 ```
+
+For EVM accounts, `signers` are normalized EOA addresses. V1 does not support
+ERC-1271 or generic ERC-7913 verifier-key signers.
+
+## Request Authentication
+
+Transport metadata remains:
+
+- `x-pubkey`
+- `x-signature`
+- `x-timestamp`
+
+For EVM accounts, `x-pubkey` keeps its legacy name and carries the normalized
+signer address. EVM request auth uses EIP-712 over a server-reconstructed typed
+message:
+
+```text
+Domain:
+  name = "Private State Manager Request"
+  version = "1"
+  chainId = network_config.chain_id
+  verifyingContract = network_config.contract_address
+
+AuthRequest(
+  string accountId,
+  uint64 timestampMs,
+  bytes32 payloadHash
+)
+```
+
+For gRPC, `payloadHash = keccak256(protobuf_request_bytes)`.
 
 ## Proposal RPC Direction
 
@@ -73,9 +107,43 @@ The outer RPC names stay stable. The inner `delta_payload` JSON becomes
 network-aware:
 
 - Miden keeps its current `tx_summary`-driven JSON shape.
-- EVM uses normalized JSON representing the executable proposal payload plus
-  signature entries.
-- The exact EVM inner JSON fields remain pending the contract-team answer.
+- EVM uses the exact normalized JSON shape:
+
+```json
+{
+  "kind": "evm",
+  "mode": "0x...",
+  "execution_calldata": "0x...",
+  "signatures": []
+}
+```
+
+- EVM `mode` encodes ERC-7579 execution and v1 supports only single-call and
+  batch-call modes with default exec type and zero selector/mode payload.
+- EVM proposal creation rejects non-empty `signatures`.
+- EVM proposal `nonce` remains a PSM-local ordering field only.
+
+## EVM Proposal Signature Meaning
+
+EVM proposal cosigners sign a PSM-defined EIP-712 coordination message:
+
+```text
+Domain:
+  name = "Private State Manager EVM Proposal"
+  version = "1"
+  chainId = network_config.chain_id
+  verifyingContract = network_config.contract_address
+
+PsmEvmProposal(
+  bytes32 mode,
+  bytes32 executionCalldataHash
+)
+```
+
+Where `executionCalldataHash = keccak256(execution_calldata)`.
+
+The signer address is recovered from the ECDSA signature and recorded as the
+normalized EOA `signer_id`.
 
 ## Unsupported EVM RPC Behavior
 
@@ -92,14 +160,29 @@ Canonicalization-related flows also remain unsupported for EVM accounts.
 ## Response Semantics
 
 - `PushDeltaProposalResponse.commitment` remains the outward proposal identifier.
-- For EVM v1, that identifier is a deterministic hash-based PSM value.
+- For EVM v1, that identifier is
+  `keccak256(abi.encode(chain_id, contract_address, mode, keccak256(execution_calldata)))`.
 - HTTP and gRPC must produce the same proposal identifier for equivalent
   normalized EVM proposals.
+- The identifier excludes local proposal nonce, collected signatures, and
+  timestamps.
+- Re-submitting the same EVM proposal is idempotent and returns the existing
+  pending proposal.
 
-## Remaining Team Inputs
+## Stable Application Error Codes
 
-- exact multisig contract reads required over RPC
-- final EVM proposal payload structure
-- exact signed-bytes definition for EVM cosigners
-- final lifecycle behavior for pending proposals
-- final RPC failure and endpoint-rotation policy
+Both transports should expose the same application-level error codes alongside
+their native HTTP or gRPC status:
+
+- `unsupported_for_network`
+- `invalid_network_config`
+- `rpc_unavailable`
+- `rpc_validation_failed`
+- `signer_not_authorized`
+- `invalid_evm_proposal`
+- `invalid_proposal_signature`
+- `proposal_already_signed`
+
+## Deferred Topics
+
+- RPC endpoint replacement or rotation policy is deferred in v1.

--- a/speckit/features/001-evm-proposal-support/contracts/grpc-contract.md
+++ b/speckit/features/001-evm-proposal-support/contracts/grpc-contract.md
@@ -1,0 +1,105 @@
+# gRPC Contract Draft: Add generic EVM proposal sharing and signing support
+
+This document captures the expected gRPC contract direction before the final
+proto edits are made.
+
+## Goals
+
+- keep the existing service shape and method names in v1
+- extend `ConfigureRequest` with account-level `network_config`
+- keep proposal create/list/get/sign available through current RPC names
+- preserve Miden behavior and make unsupported EVM delta/state flows explicit
+
+## Proposed Proto Changes
+
+### 1. Add `NetworkConfig`
+
+```proto
+message NetworkConfig {
+  oneof config {
+    MidenNetworkConfig miden = 1;
+    EvmNetworkConfig evm = 2;
+  }
+}
+
+message MidenNetworkConfig {
+  string network_type = 1; // local | devnet | testnet
+}
+
+message EvmNetworkConfig {
+  uint64 chain_id = 1;
+  string contract_address = 2;
+  string rpc_endpoint = 3;
+}
+```
+
+### 2. Extend `ConfigureRequest`
+
+```proto
+message ConfigureRequest {
+  string account_id = 1;
+  AuthConfig auth = 2;
+  string initial_state = 3;
+  NetworkConfig network_config = 4;
+}
+```
+
+### 3. Extend `AuthConfig`
+
+```proto
+message AuthConfig {
+  oneof auth_type {
+    MidenFalconRpoAuth miden_falcon_rpo = 1;
+    MidenEcdsaAuth miden_ecdsa = 2;
+    EvmEcdsaAuth evm_ecdsa = 3;
+  }
+}
+
+message EvmEcdsaAuth {
+  repeated string cosigner_commitments = 1;
+}
+```
+
+## Proposal RPC Direction
+
+For v1, keep these methods:
+
+- `PushDeltaProposal`
+- `GetDeltaProposals`
+- `GetDeltaProposal`
+- `SignDeltaProposal`
+
+The outer RPC names stay stable. The inner `delta_payload` JSON becomes
+network-aware:
+
+- Miden keeps its current `tx_summary`-driven JSON shape.
+- EVM uses normalized JSON representing the executable proposal payload plus
+  signature entries.
+- The exact EVM inner JSON fields remain pending the contract-team answer.
+
+## Unsupported EVM RPC Behavior
+
+These methods remain available for Miden but must return explicit unsupported
+behavior for EVM accounts in this feature:
+
+- `PushDelta`
+- `GetDelta`
+- `GetDeltaSince`
+- `GetState`
+
+Canonicalization-related flows also remain unsupported for EVM accounts.
+
+## Response Semantics
+
+- `PushDeltaProposalResponse.commitment` remains the outward proposal identifier.
+- For EVM v1, that identifier is a deterministic hash-based PSM value.
+- HTTP and gRPC must produce the same proposal identifier for equivalent
+  normalized EVM proposals.
+
+## Remaining Team Inputs
+
+- exact multisig contract reads required over RPC
+- final EVM proposal payload structure
+- exact signed-bytes definition for EVM cosigners
+- final lifecycle behavior for pending proposals
+- final RPC failure and endpoint-rotation policy

--- a/speckit/features/001-evm-proposal-support/contracts/grpc-contract.md
+++ b/speckit/features/001-evm-proposal-support/contracts/grpc-contract.md
@@ -80,7 +80,7 @@ message:
 
 ```text
 Domain:
-  name = "Private State Manager Request"
+  name = "Guardian Request"
   version = "1"
   chainId = network_config.chain_id
   verifyingContract = network_config.contract_address
@@ -121,15 +121,15 @@ network-aware:
 - EVM `mode` encodes ERC-7579 execution and v1 supports only single-call and
   batch-call modes with default exec type and zero selector/mode payload.
 - EVM proposal creation rejects non-empty `signatures`.
-- EVM proposal `nonce` remains a PSM-local ordering field only.
+- EVM proposal `nonce` remains a Guardian-local ordering field only.
 
 ## EVM Proposal Signature Meaning
 
-EVM proposal cosigners sign a PSM-defined EIP-712 coordination message:
+EVM proposal cosigners sign a Guardian-defined EIP-712 coordination message:
 
 ```text
 Domain:
-  name = "Private State Manager EVM Proposal"
+  name = "Guardian EVM Proposal"
   version = "1"
   chainId = network_config.chain_id
   verifyingContract = network_config.contract_address

--- a/speckit/features/001-evm-proposal-support/contracts/http-openapi.yaml
+++ b/speckit/features/001-evm-proposal-support/contracts/http-openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.1.0
 info:
-  title: Private State Manager EVM Proposal Support Draft
+  title: Guardian EVM Proposal Support Draft
   version: 0.1.0-draft
   description: >
     Draft HTTP contract changes for account-level network configuration and EVM
@@ -289,7 +289,7 @@ components:
         nonce:
           type: integer
           minimum: 0
-          description: PSM-local ordering field. For EVM it is not part of proposal identity.
+          description: Guardian-local ordering field. For EVM it is not part of proposal identity.
         delta_payload:
           oneOf:
             - $ref: '#/components/schemas/MidenProposalPayload'

--- a/speckit/features/001-evm-proposal-support/contracts/http-openapi.yaml
+++ b/speckit/features/001-evm-proposal-support/contracts/http-openapi.yaml
@@ -1,0 +1,442 @@
+openapi: 3.1.0
+info:
+  title: Private State Manager EVM Proposal Support Draft
+  version: 0.1.0-draft
+  description: >
+    Draft HTTP contract changes for account-level network configuration and EVM
+    proposal support. EVM executable payload details remain intentionally opaque
+    until the contract team finalizes the multisig contract shape.
+paths:
+  /configure:
+    post:
+      summary: Configure an account with per-account network settings
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConfigureRequest'
+      responses:
+        '200':
+          description: Account configured
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConfigureResponse'
+        '400':
+          description: Validation or authorization failure
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /delta/proposal:
+    post:
+      summary: Create a pending proposal for the configured account network
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeltaProposalRequest'
+      responses:
+        '200':
+          description: Proposal stored
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeltaProposalResponse'
+        '400':
+          description: Validation, authorization, or unsupported-operation failure
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    get:
+      summary: List pending proposals for an account
+      parameters:
+        - in: query
+          name: account_id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Pending proposals
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProposalsResponse'
+        '400':
+          description: Authorization or unsupported-operation failure
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    put:
+      summary: Append a signer signature to a pending proposal
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SignProposalRequest'
+      responses:
+        '200':
+          description: Proposal updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeltaObject'
+        '400':
+          description: Authorization, duplicate-signature, or unsupported-operation failure
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /delta/proposal/single:
+    get:
+      summary: Get a specific pending proposal
+      parameters:
+        - in: query
+          name: account_id
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: commitment
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Proposal found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeltaObject'
+        '404':
+          description: Proposal not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /delta:
+    post:
+      summary: Push a canonicalizing delta
+      description: Unsupported for EVM accounts in this feature.
+  /delta/since:
+    get:
+      summary: Get merged deltas since a nonce
+      description: Unsupported for EVM accounts in this feature.
+  /state:
+    get:
+      summary: Get current state
+      description: Unsupported for EVM accounts in this feature.
+components:
+  schemas:
+    ConfigureRequest:
+      type: object
+      required:
+        - account_id
+        - auth
+        - network_config
+        - initial_state
+      properties:
+        account_id:
+          type: string
+        auth:
+          $ref: '#/components/schemas/AuthConfig'
+        network_config:
+          $ref: '#/components/schemas/NetworkConfig'
+        initial_state:
+          description: >
+            Existing network-specific account initialization payload. Miden keeps
+            its current shape; EVM may use a minimal placeholder object in v1.
+          oneOf:
+            - type: object
+            - type: string
+    ConfigureResponse:
+      type: object
+      required:
+        - success
+        - message
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        ack_pubkey:
+          type: string
+        ack_commitment:
+          type: string
+    ErrorResponse:
+      type: object
+      required:
+        - success
+        - error
+      properties:
+        success:
+          type: boolean
+          enum: [false]
+        error:
+          type: string
+    NetworkConfig:
+      oneOf:
+        - $ref: '#/components/schemas/MidenNetworkConfig'
+        - $ref: '#/components/schemas/EvmNetworkConfig'
+    MidenNetworkConfig:
+      type: object
+      required:
+        - kind
+        - network_type
+      properties:
+        kind:
+          type: string
+          enum: [miden]
+        network_type:
+          type: string
+          enum: [local, devnet, testnet]
+    EvmNetworkConfig:
+      type: object
+      required:
+        - kind
+        - chain_id
+        - contract_address
+        - rpc_endpoint
+      properties:
+        kind:
+          type: string
+          enum: [evm]
+        chain_id:
+          type: integer
+          minimum: 1
+        contract_address:
+          type: string
+        rpc_endpoint:
+          type: string
+          format: uri
+    AuthConfig:
+      oneOf:
+        - $ref: '#/components/schemas/MidenFalconRpoAuth'
+        - $ref: '#/components/schemas/MidenEcdsaAuth'
+        - $ref: '#/components/schemas/EvmEcdsaAuth'
+    MidenFalconRpoAuth:
+      type: object
+      required: [MidenFalconRpo]
+      properties:
+        MidenFalconRpo:
+          type: object
+          required: [cosigner_commitments]
+          properties:
+            cosigner_commitments:
+              type: array
+              items:
+                type: string
+    MidenEcdsaAuth:
+      type: object
+      required: [MidenEcdsa]
+      properties:
+        MidenEcdsa:
+          type: object
+          required: [cosigner_commitments]
+          properties:
+            cosigner_commitments:
+              type: array
+              items:
+                type: string
+    EvmEcdsaAuth:
+      type: object
+      required: [EvmEcdsa]
+      properties:
+        EvmEcdsa:
+          type: object
+          required: [cosigner_commitments]
+          properties:
+            cosigner_commitments:
+              type: array
+              items:
+                type: string
+              description: >
+                Persisted signer snapshot. RPC remains the source of truth for
+                authorization on each relevant action.
+    DeltaProposalRequest:
+      type: object
+      required:
+        - account_id
+        - nonce
+        - delta_payload
+      properties:
+        account_id:
+          type: string
+        nonce:
+          type: integer
+          minimum: 0
+        delta_payload:
+          oneOf:
+            - $ref: '#/components/schemas/MidenProposalPayload'
+            - $ref: '#/components/schemas/EvmProposalPayload'
+    MidenProposalPayload:
+      type: object
+      required:
+        - tx_summary
+        - signatures
+      properties:
+        tx_summary:
+          type: object
+          required: [data]
+          properties:
+            data:
+              type: string
+        signatures:
+          type: array
+          items:
+            $ref: '#/components/schemas/SubmittedSignature'
+        metadata:
+          $ref: '#/components/schemas/ProposalMetadata'
+    EvmProposalPayload:
+      type: object
+      required:
+        - kind
+        - proposal
+        - signatures
+      properties:
+        kind:
+          type: string
+          enum: [evm]
+        proposal:
+          type: object
+          additionalProperties: true
+          description: >
+            Normalized executable EVM proposal payload. Exact fields remain TBD
+            pending the contract-team answer.
+        signatures:
+          type: array
+          items:
+            $ref: '#/components/schemas/SubmittedSignature'
+        metadata:
+          $ref: '#/components/schemas/ProposalMetadata'
+    ProposalMetadata:
+      type: object
+      additionalProperties: true
+    SubmittedSignature:
+      type: object
+      required:
+        - signer_id
+        - signature
+      properties:
+        signer_id:
+          type: string
+        signature:
+          $ref: '#/components/schemas/ProposalSignature'
+    ProposalSignature:
+      oneOf:
+        - type: object
+          required: [scheme, signature]
+          properties:
+            scheme:
+              type: string
+              enum: [falcon]
+            signature:
+              type: string
+        - type: object
+          required: [scheme, signature]
+          properties:
+            scheme:
+              type: string
+              enum: [ecdsa]
+            signature:
+              type: string
+            public_key:
+              type: string
+    DeltaProposalResponse:
+      type: object
+      required:
+        - delta
+        - commitment
+      properties:
+        delta:
+          $ref: '#/components/schemas/DeltaObject'
+        commitment:
+          type: string
+          description: Deterministic hash-based proposal identifier
+    ProposalsResponse:
+      type: object
+      required: [proposals]
+      properties:
+        proposals:
+          type: array
+          items:
+            $ref: '#/components/schemas/DeltaObject'
+    SignProposalRequest:
+      type: object
+      required:
+        - account_id
+        - commitment
+        - signature
+      properties:
+        account_id:
+          type: string
+        commitment:
+          type: string
+        signature:
+          $ref: '#/components/schemas/ProposalSignature'
+    DeltaObject:
+      type: object
+      required:
+        - account_id
+        - nonce
+        - prev_commitment
+        - delta_payload
+        - status
+      properties:
+        account_id:
+          type: string
+        nonce:
+          type: integer
+        prev_commitment:
+          type: string
+        new_commitment:
+          type: string
+        delta_payload:
+          type: object
+          additionalProperties: true
+        ack_sig:
+          type: string
+        ack_pubkey:
+          type: string
+        ack_scheme:
+          type: string
+        status:
+          $ref: '#/components/schemas/DeltaStatus'
+    DeltaStatus:
+      oneOf:
+        - type: object
+          required: [status, timestamp, proposer_id, cosigner_sigs]
+          properties:
+            status:
+              type: string
+              enum: [pending]
+            timestamp:
+              type: string
+            proposer_id:
+              type: string
+            cosigner_sigs:
+              type: array
+              items:
+                type: object
+                required: [signer_id, signature, timestamp]
+                properties:
+                  signer_id:
+                    type: string
+                  signature:
+                    $ref: '#/components/schemas/ProposalSignature'
+                  timestamp:
+                    type: string
+        - type: object
+          required: [status, timestamp]
+          properties:
+            status:
+              type: string
+              enum: [candidate, canonical, discarded]
+            timestamp:
+              type: string

--- a/speckit/features/001-evm-proposal-support/contracts/http-openapi.yaml
+++ b/speckit/features/001-evm-proposal-support/contracts/http-openapi.yaml
@@ -4,8 +4,8 @@ info:
   version: 0.1.0-draft
   description: >
     Draft HTTP contract changes for account-level network configuration and EVM
-    proposal support. EVM executable payload details remain intentionally opaque
-    until the contract team finalizes the multisig contract shape.
+    proposal support based on OpenZeppelin ERC7579Multisig as the signer and
+    threshold read model.
 paths:
   /configure:
     post:
@@ -144,6 +144,9 @@ components:
       properties:
         account_id:
           type: string
+          description: >
+            Canonical account identifier. For EVM this is
+            `evm:<chain_id>:<normalized_contract_address>`.
         auth:
           $ref: '#/components/schemas/AuthConfig'
         network_config:
@@ -151,7 +154,8 @@ components:
         initial_state:
           description: >
             Existing network-specific account initialization payload. Miden keeps
-            its current shape; EVM may use a minimal placeholder object in v1.
+            its current shape; EVM uses an empty object placeholder in v1 and
+            the server derives signer snapshot and threshold from RPC.
           oneOf:
             - type: object
             - type: string
@@ -173,11 +177,20 @@ components:
       type: object
       required:
         - success
+        - code
         - error
       properties:
         success:
           type: boolean
           enum: [false]
+        code:
+          type: string
+          description: >
+            Stable application error code. Expected EVM-related values include
+            `unsupported_for_network`, `invalid_network_config`,
+            `rpc_unavailable`, `rpc_validation_failed`,
+            `signer_not_authorized`, `invalid_evm_proposal`,
+            `invalid_proposal_signature`, and `proposal_already_signed`.
         error:
           type: string
     NetworkConfig:
@@ -212,6 +225,7 @@ components:
           minimum: 1
         contract_address:
           type: string
+          description: Normalized `0x`-prefixed lowercase 20-byte hex address.
         rpc_endpoint:
           type: string
           format: uri
@@ -250,15 +264,16 @@ components:
       properties:
         EvmEcdsa:
           type: object
-          required: [cosigner_commitments]
+          required: [signers]
           properties:
-            cosigner_commitments:
+            signers:
               type: array
               items:
                 type: string
               description: >
-                Persisted signer snapshot. RPC remains the source of truth for
-                authorization on each relevant action.
+                Persisted signer snapshot as normalized EOA addresses. RPC
+                remains the source of truth for authorization on each relevant
+                action.
     DeltaProposalRequest:
       type: object
       required:
@@ -268,9 +283,13 @@ components:
       properties:
         account_id:
           type: string
+          description: >
+            Canonical account identifier. For EVM this is
+            `evm:<chain_id>:<normalized_contract_address>`.
         nonce:
           type: integer
           minimum: 0
+          description: PSM-local ordering field. For EVM it is not part of proposal identity.
         delta_payload:
           oneOf:
             - $ref: '#/components/schemas/MidenProposalPayload'
@@ -297,24 +316,29 @@ components:
       type: object
       required:
         - kind
-        - proposal
+        - mode
+        - execution_calldata
         - signatures
       properties:
         kind:
           type: string
           enum: [evm]
-        proposal:
-          type: object
-          additionalProperties: true
+        mode:
+          type: string
           description: >
-            Normalized executable EVM proposal payload. Exact fields remain TBD
-            pending the contract-team answer.
+            `0x`-prefixed 32-byte ERC-7579 mode. V1 supports only single-call
+            and batch-call execution with default exec type and zero
+            selector/mode payload.
+        execution_calldata:
+          type: string
+          description: >
+            `0x`-prefixed ERC-7579 execution calldata bytes corresponding to the
+            selected `mode`.
         signatures:
           type: array
           items:
             $ref: '#/components/schemas/SubmittedSignature'
-        metadata:
-          $ref: '#/components/schemas/ProposalMetadata'
+          description: Must be empty on proposal create; the server appends signatures later.
     ProposalMetadata:
       type: object
       additionalProperties: true
@@ -326,6 +350,9 @@ components:
       properties:
         signer_id:
           type: string
+          description: >
+            Signer identity. For EVM this is the normalized EOA address derived
+            from the signature.
         signature:
           $ref: '#/components/schemas/ProposalSignature'
     ProposalSignature:
@@ -346,8 +373,13 @@ components:
               enum: [ecdsa]
             signature:
               type: string
+              description: >
+                ECDSA signature. For EVM proposal signing, the signer address is
+                recovered from this signature against the EIP-712 proposal
+                message.
             public_key:
               type: string
+              description: Optional legacy field; not required for EVM proposal signing.
     DeltaProposalResponse:
       type: object
       required:
@@ -358,7 +390,9 @@ components:
           $ref: '#/components/schemas/DeltaObject'
         commitment:
           type: string
-          description: Deterministic hash-based proposal identifier
+          description: >
+            Deterministic hash-based proposal identifier derived from
+            `(chain_id, contract_address, mode, keccak256(execution_calldata))`.
     ProposalsResponse:
       type: object
       required: [proposals]
@@ -376,6 +410,9 @@ components:
       properties:
         account_id:
           type: string
+          description: >
+            Canonical account identifier. For EVM this is
+            `evm:<chain_id>:<normalized_contract_address>`.
         commitment:
           type: string
         signature:
@@ -395,17 +432,22 @@ components:
           type: integer
         prev_commitment:
           type: string
+          description: Unused for EVM proposal records in v1.
         new_commitment:
           type: string
+          description: Unused for EVM proposal records in v1.
         delta_payload:
           type: object
           additionalProperties: true
         ack_sig:
           type: string
+          description: Unused for EVM proposal records in v1.
         ack_pubkey:
           type: string
+          description: Unused for EVM proposal records in v1.
         ack_scheme:
           type: string
+          description: Unused for EVM proposal records in v1.
         status:
           $ref: '#/components/schemas/DeltaStatus'
     DeltaStatus:

--- a/speckit/features/001-evm-proposal-support/data-model.md
+++ b/speckit/features/001-evm-proposal-support/data-model.md
@@ -6,7 +6,7 @@ Persisted per account in filesystem and Postgres metadata stores.
 
 | Field | Type | Notes |
 |-------|------|-------|
-| `account_id` | `String` | Existing account identifier |
+| `account_id` | `String` | Existing account identifier; for EVM this is canonical `evm:<chain_id>:<normalized_contract_address>` |
 | `auth` | `Auth` | Persisted auth policy and signer snapshot |
 | `network_config` | `NetworkConfig` | New per-account network selection and config |
 | `created_at` | `String` | Existing RFC3339 timestamp |
@@ -19,6 +19,8 @@ Persisted per account in filesystem and Postgres metadata stores.
 - `network_config` is required.
 - Missing `network_config` is invalid rather than implicitly mapped to a legacy
   server-global Miden setting.
+- For `network_config.kind = "evm"`, `account_id` must match the canonical
+  identity derived from `chain_id + contract_address`.
 - Filesystem and Postgres metadata encodings must remain semantically
   equivalent.
 
@@ -45,26 +47,28 @@ Tagged per-account network configuration.
 ### Validation Rules
 
 - `chain_id` must be a positive integer.
-- `contract_address` must be normalized and validated at the boundary.
+- `contract_address` must be a normalized `0x`-prefixed 20-byte lowercase hex
+  address and validated at the boundary.
 - `rpc_endpoint` must be a valid URL string and is treated as trusted account
   configuration in v1.
 
 ## 3. Auth
 
-Persisted auth policy plus signer commitment snapshot.
+Persisted auth policy plus signer snapshot.
 
 | Variant | Fields | Notes |
 |---------|--------|-------|
 | `MidenFalconRpo` | `cosigner_commitments: Vec<String>` | Existing Miden Falcon path |
 | `MidenEcdsa` | `cosigner_commitments: Vec<String>` | Existing Miden ECDSA path |
-| `EvmEcdsa` | `cosigner_commitments: Vec<String>` | New EVM ECDSA path; commitments may be refreshed from RPC |
+| `EvmEcdsa` | `signers: Vec<String>` | New EVM ECDSA path; normalized EOA address snapshot refreshed from RPC |
 
 ### Validation Rules
 
 - Request-signature verification must be separated from signer authorization.
 - EVM authorization uses RPC as the source of truth on every relevant action.
-- Stored `cosigner_commitments` for EVM may be used as a snapshot or cache, but
-  not as the only authority source.
+- Stored EVM `signers` may be used as a snapshot or cache, but not as the only
+  authority source.
+- EVM `signers` are normalized EOA addresses only in v1.
 
 ## 4. Proposal Record
 
@@ -74,7 +78,7 @@ radius, but proposal semantics become network-aware.
 | Field | Type | Notes |
 |-------|------|-------|
 | `account_id` | `String` | Existing account namespace |
-| `nonce` | `u64` | Ordering field; remains explicit |
+| `nonce` | `u64` | Ordering field; for EVM this is PSM-local ordering only |
 | `commitment` | `String` | Deterministic proposal identifier; currently carried as response `commitment` |
 | `delta_payload` | `serde_json::Value` / JSON object | Network-specific proposal payload plus signatures/metadata |
 | `status` | `DeltaStatus` | Pending proposal state remains shared |
@@ -84,9 +88,29 @@ radius, but proposal semantics become network-aware.
 ### Interpretation Rules
 
 - For Miden proposals, current `tx_summary`-driven semantics remain unchanged.
-- For EVM proposals, the inner payload becomes network-specific and is
-  normalized by the EVM proposal strategy before hashing or persistence.
-- The exact normalized EVM payload fields are still pending team confirmation.
+- For EVM proposals, the inner payload is the normalized ERC-7579 execution
+  shape described below and is normalized before hashing or persistence.
+- For EVM proposals, `prev_commitment`, `new_commitment`, `ack_sig`,
+  `ack_pubkey`, and `ack_scheme` remain unused in v1.
+
+### `EvmProposalPayload`
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `kind` | `"evm"` | Discriminator |
+| `mode` | `String` | `0x`-prefixed 32-byte hex ERC-7579 mode |
+| `execution_calldata` | `String` | `0x`-prefixed hex bytes for ERC-7579 execution calldata |
+| `signatures` | `Vec<SubmittedSignature>` | Empty on create; appended by sign flow |
+
+### EVM Proposal Validation Rules
+
+- EVM proposal payloads model ERC-7579 `execute(mode, executionCalldata)` only.
+- Supported v1 modes are single-call and batch-call with default exec type and
+  zero selector/mode payload.
+- Delegatecall, try-mode, and custom selector/payload modes are unsupported in
+  v1.
+- `signatures` must be empty when the proposal is first created.
+- EVM submitted signatures carry `signer_id` as a normalized EOA address.
 
 ## 5. Proposal Identifier
 
@@ -98,10 +122,15 @@ Derived value, not an independently configured field.
 
 ### Validation Rules
 
+- The identifier is a `0x`-prefixed lowercase 32-byte hex value derived from
+  `keccak256(abi.encode(chain_id, contract_address, mode,
+  keccak256(execution_calldata)))`.
 - The identifier must be derived from normalized inputs, not raw incoming JSON.
 - HTTP and gRPC must yield the same identifier for semantically equivalent
   proposal payloads.
 - Rust and TypeScript must model the same identifier semantics.
+- The identifier excludes the local proposal nonce, collected signatures, and
+  timestamps.
 
 ## 6. Network Capabilities
 
@@ -133,3 +162,8 @@ Internal design model for network-specific behavior.
 - Candidate, canonical, discarded, or auto-reconciled proposal transitions are
   out of scope for this feature.
 - Unsupported lifecycle requests must fail explicitly.
+- Re-submitting the same normalized EVM proposal is idempotent and returns the
+  existing pending proposal.
+- Pending EVM proposals stay pending until a future explicit cleanup or
+  reconciliation feature is added, subject to the per-account pending-proposal
+  cap.

--- a/speckit/features/001-evm-proposal-support/data-model.md
+++ b/speckit/features/001-evm-proposal-support/data-model.md
@@ -1,0 +1,135 @@
+# Data Model: Add generic EVM proposal sharing and signing support
+
+## 1. AccountMetadata
+
+Persisted per account in filesystem and Postgres metadata stores.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `account_id` | `String` | Existing account identifier |
+| `auth` | `Auth` | Persisted auth policy and signer snapshot |
+| `network_config` | `NetworkConfig` | New per-account network selection and config |
+| `created_at` | `String` | Existing RFC3339 timestamp |
+| `updated_at` | `String` | Existing RFC3339 timestamp |
+| `has_pending_candidate` | `bool` | Existing canonicalization flag |
+| `last_auth_timestamp` | `Option<i64>` | Existing replay-protection CAS field |
+
+### Validation Rules
+
+- `network_config` is required.
+- Missing `network_config` is invalid rather than implicitly mapped to a legacy
+  server-global Miden setting.
+- Filesystem and Postgres metadata encodings must remain semantically
+  equivalent.
+
+## 2. NetworkConfig
+
+Tagged per-account network configuration.
+
+### `MidenNetworkConfig`
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `kind` | `"miden"` | Discriminator |
+| `network_type` | `MidenNetworkType` | `local`, `devnet`, or `testnet` |
+
+### `EvmNetworkConfig`
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `kind` | `"evm"` | Discriminator |
+| `chain_id` | `u64` | Part of canonical account identity |
+| `contract_address` | `String` | Normalized hex address; part of canonical account identity |
+| `rpc_endpoint` | `String` | Required RPC authority for signer validation |
+
+### Validation Rules
+
+- `chain_id` must be a positive integer.
+- `contract_address` must be normalized and validated at the boundary.
+- `rpc_endpoint` must be a valid URL string and is treated as trusted account
+  configuration in v1.
+
+## 3. Auth
+
+Persisted auth policy plus signer commitment snapshot.
+
+| Variant | Fields | Notes |
+|---------|--------|-------|
+| `MidenFalconRpo` | `cosigner_commitments: Vec<String>` | Existing Miden Falcon path |
+| `MidenEcdsa` | `cosigner_commitments: Vec<String>` | Existing Miden ECDSA path |
+| `EvmEcdsa` | `cosigner_commitments: Vec<String>` | New EVM ECDSA path; commitments may be refreshed from RPC |
+
+### Validation Rules
+
+- Request-signature verification must be separated from signer authorization.
+- EVM authorization uses RPC as the source of truth on every relevant action.
+- Stored `cosigner_commitments` for EVM may be used as a snapshot or cache, but
+  not as the only authority source.
+
+## 4. Proposal Record
+
+V1 keeps the current proposal transport/storage envelope to constrain blast
+radius, but proposal semantics become network-aware.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `account_id` | `String` | Existing account namespace |
+| `nonce` | `u64` | Ordering field; remains explicit |
+| `commitment` | `String` | Deterministic proposal identifier; currently carried as response `commitment` |
+| `delta_payload` | `serde_json::Value` / JSON object | Network-specific proposal payload plus signatures/metadata |
+| `status` | `DeltaStatus` | Pending proposal state remains shared |
+| `proposer_id` | `String` | Stored inside pending status |
+| `cosigner_sigs` | `Vec<CosignerSignature>` | Stored inside pending status |
+
+### Interpretation Rules
+
+- For Miden proposals, current `tx_summary`-driven semantics remain unchanged.
+- For EVM proposals, the inner payload becomes network-specific and is
+  normalized by the EVM proposal strategy before hashing or persistence.
+- The exact normalized EVM payload fields are still pending team confirmation.
+
+## 5. Proposal Identifier
+
+Derived value, not an independently configured field.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `proposal_id` | `String` | Deterministic hash-based identifier |
+
+### Validation Rules
+
+- The identifier must be derived from normalized inputs, not raw incoming JSON.
+- HTTP and gRPC must yield the same identifier for semantically equivalent
+  proposal payloads.
+- Rust and TypeScript must model the same identifier semantics.
+
+## 6. Network Capabilities
+
+Internal design model for network-specific behavior.
+
+| Capability | Purpose |
+|------------|---------|
+| `AccountConfigCapability` | Validate account configuration and initial signer state |
+| `SignerAuthorityCapability` | Resolve or verify authorized signers for an account |
+| `ProposalCapability` | Normalize proposal payloads, compute proposal identifiers, and validate proposal-specific operations |
+| `DeltaStateCapability` | Handle state, delta, and canonicalization operations where supported |
+
+### Capability Rules
+
+- Miden implements all capabilities needed by existing flows.
+- EVM v1 implements account configuration, signer authority, and proposal
+  capabilities only.
+- Unsupported EVM delta/state capabilities return explicit errors.
+
+## 7. State Transitions
+
+### Miden
+
+- Existing pending -> candidate -> canonical/discarded lifecycle remains intact.
+
+### EVM v1
+
+- `pending` is the only supported proposal state.
+- Candidate, canonical, discarded, or auto-reconciled proposal transitions are
+  out of scope for this feature.
+- Unsupported lifecycle requests must fail explicitly.

--- a/speckit/features/001-evm-proposal-support/data-model.md
+++ b/speckit/features/001-evm-proposal-support/data-model.md
@@ -78,7 +78,7 @@ radius, but proposal semantics become network-aware.
 | Field | Type | Notes |
 |-------|------|-------|
 | `account_id` | `String` | Existing account namespace |
-| `nonce` | `u64` | Ordering field; for EVM this is PSM-local ordering only |
+| `nonce` | `u64` | Ordering field; for EVM this is Guardian-local ordering only |
 | `commitment` | `String` | Deterministic proposal identifier; currently carried as response `commitment` |
 | `delta_payload` | `serde_json::Value` / JSON object | Network-specific proposal payload plus signatures/metadata |
 | `status` | `DeltaStatus` | Pending proposal state remains shared |

--- a/speckit/features/001-evm-proposal-support/plan.md
+++ b/speckit/features/001-evm-proposal-support/plan.md
@@ -9,21 +9,21 @@ Introduce account-level `network_config` so Miden and EVM accounts can coexist
 in the same server, then refactor proposal and auth flows to route through
 network-specific capabilities instead of the current server-global network
 client. The implementation starts in `crates/server`, propagates contract
-changes into `crates/client` and `packages/psm-client`, preserves current Miden
+changes into `crates/client` and `packages/guardian-client`, preserves current Miden
 behavior, and makes unsupported EVM delta/state/canonicalization flows fail
 explicitly until a later lifecycle feature is defined.
 
 ## Technical Context
 
 **Language/Version**: Rust workspace crates + TypeScript packages; Miden `0.13.x` compatibility remains required  
-**Primary Dependencies**: `axum`, `tonic`/`prost`, `tokio`, `serde_json`, current metadata/storage backends, `private_state_manager_shared`, TS `packages/psm-client`; EVM RPC integration stays behind a server adapter boundary while the concrete contract-read surface is finalized  
+**Primary Dependencies**: `axum`, `tonic`/`prost`, `tokio`, `serde_json`, current metadata/storage backends, `private_state_manager_shared`, TS `packages/guardian-client`; EVM RPC integration stays behind a server adapter boundary while the concrete contract-read surface is finalized  
 **Storage**: Filesystem by default; Postgres metadata/storage parity remains required  
-**Testing**: Targeted Rust server/client tests, HTTP/gRPC adapter tests, TS `packages/psm-client` tests, backend parity tests, and conditional example smoke checks if the base-client surface reaches examples  
+**Testing**: Targeted Rust server/client tests, HTTP/gRPC adapter tests, TS `packages/guardian-client` tests, backend parity tests, and conditional example smoke checks if the base-client surface reaches examples  
 **Target Platform**: Rust server, Rust gRPC client, and TypeScript HTTP client  
 **Project Type**: Multi-language monorepo  
 **Performance Goals**: One signer-authority RPC read per authenticated EVM action is acceptable in v1; avoid backend-specific behavioral drift or unbounded proposal scans  
 **Constraints**: Preserve existing Miden behavior, keep HTTP/gRPC and Rust/TS parity, keep fallback behavior explicit, require explicit `network_config` without backward-compatibility fallbacks, keep append-only proposal storage semantics, and avoid broad API replacement while the EVM contract shape is still settling  
-**Scale/Scope**: `crates/server` (builder, main, network, metadata, services, api, proto, tests), `crates/client` (proto + request/response support), `packages/psm-client` (types, conversion, HTTP client, tests); multisig SDKs and examples are assessed but expected to remain unchanged in v1 unless lower-layer contract changes force propagation
+**Scale/Scope**: `crates/server` (builder, main, network, metadata, services, api, proto, tests), `crates/client` (proto + request/response support), `packages/guardian-client` (types, conversion, HTTP client, tests); multisig SDKs and examples are assessed but expected to remain unchanged in v1 unless lower-layer contract changes force propagation
 
 Implementation guidance: perform the account/network refactor as one unified
 network-aware architecture, optionally guarded by a rollout switch that rejects
@@ -98,7 +98,7 @@ service path behind a deep feature flag.
 - Extend HTTP and gRPC configure requests with `network_config`.
 - Extend auth config support to include an EVM ECDSA variant while keeping the
   overall auth model extensible.
-- Update `crates/client` and `packages/psm-client` request/response types,
+- Update `crates/client` and `packages/guardian-client` request/response types,
   conversion layers, and tests to reflect the new account-configuration and
   proposal semantics.
 - Assess multisig SDKs and examples after server/base-client design is settled;
@@ -139,7 +139,7 @@ crates/
 └── miden-keystore/
 
 packages/
-├── psm-client/
+├── guardian-client/
 └── miden-multisig-client/
 
 examples/
@@ -159,7 +159,7 @@ spec/
 - `crates/server/src/api/` and `crates/server/proto/`: carry the network-aware contract changes through HTTP and gRPC.
 - `crates/server/src/error.rs`: add explicit unsupported-operation errors for network/capability mismatches.
 - `crates/client/`: mirror gRPC contract changes and keep request-auth behavior aligned.
-- `packages/psm-client/src/`: update request/response types, conversion, and HTTP behavior for network-aware accounts and EVM proposals.
+- `packages/guardian-client/src/`: update request/response types, conversion, and HTTP behavior for network-aware accounts and EVM proposals.
 - `examples/` and multisig SDKs: assess impact after base-layer changes; keep out of scope unless propagation is required.
 
 ## Validation Plan
@@ -168,7 +168,7 @@ spec/
   `cargo test -p private-state-manager-server`
   `cargo test -p private-state-manager-client`
 - Targeted TypeScript tests:
-  `cd packages/psm-client && npm test`
+  `cd packages/guardian-client && npm test`
 - Server-specific regression targets:
   - account metadata serialization for filesystem and Postgres
   - `configure_account` for Miden and EVM
@@ -178,9 +178,9 @@ spec/
   - HTTP and gRPC adapter parity for configure and proposal flows
 - Upstream validation:
   - at least one Rust client path in `crates/client`
-  - at least one TypeScript client path in `packages/psm-client`
+  - at least one TypeScript client path in `packages/guardian-client`
 - Example validation when affected:
-  `cargo run -p psm-demo`
+  `cargo run -p guardian-demo`
   `cd examples/web && npm run dev`
 - Broader validation to run if blast radius grows:
   `cargo test --workspace`

--- a/speckit/features/001-evm-proposal-support/plan.md
+++ b/speckit/features/001-evm-proposal-support/plan.md
@@ -25,6 +25,11 @@ explicitly until a later lifecycle feature is defined.
 **Constraints**: Preserve existing Miden behavior, keep HTTP/gRPC and Rust/TS parity, keep fallback behavior explicit, require explicit `network_config` without backward-compatibility fallbacks, keep append-only proposal storage semantics, and avoid broad API replacement while the EVM contract shape is still settling  
 **Scale/Scope**: `crates/server` (builder, main, network, metadata, services, api, proto, tests), `crates/client` (proto + request/response support), `packages/psm-client` (types, conversion, HTTP client, tests); multisig SDKs and examples are assessed but expected to remain unchanged in v1 unless lower-layer contract changes force propagation
 
+Implementation guidance: perform the account/network refactor as one unified
+network-aware architecture, optionally guarded by a rollout switch that rejects
+new EVM account configuration until enabled. Avoid a long-lived forked EVM
+service path behind a deep feature flag.
+
 ## Constitution Check
 
 *GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
@@ -99,14 +104,11 @@ explicitly until a later lifecycle feature is defined.
 - Assess multisig SDKs and examples after server/base-client design is settled;
   update them only if the lower-layer contract change becomes observable there.
 
-### Open Blockers Carried Into Implementation
+### Deferred Topics
 
-- Final RPC-readable contract shape for signer set, threshold, nonce, and
-  related reads.
-- Final EVM proposal payload shape.
-- Final signed-bytes definition for EVM cosigners.
-- Final decision on whether pending-only is sufficient or a sync path is needed.
-- Final RPC mutability and failure policy for EVM accounts.
+- RPC endpoint replacement or rotation policy for EVM accounts.
+- Future sync/reconciliation or execution-tracking behavior for pending EVM
+  proposals.
 
 ## Project Structure
 

--- a/speckit/features/001-evm-proposal-support/plan.md
+++ b/speckit/features/001-evm-proposal-support/plan.md
@@ -1,0 +1,205 @@
+# Implementation Plan: Add generic EVM proposal sharing and signing support
+
+**Feature Key**: `001-evm-proposal-support` | **Branch**: `001-evm-proposal-support` (manual) | **Date**: 2026-03-18 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/speckit/features/001-evm-proposal-support/spec.md`
+
+## Summary
+
+Introduce account-level `network_config` so Miden and EVM accounts can coexist
+in the same server, then refactor proposal and auth flows to route through
+network-specific capabilities instead of the current server-global network
+client. The implementation starts in `crates/server`, propagates contract
+changes into `crates/client` and `packages/psm-client`, preserves current Miden
+behavior, and makes unsupported EVM delta/state/canonicalization flows fail
+explicitly until a later lifecycle feature is defined.
+
+## Technical Context
+
+**Language/Version**: Rust workspace crates + TypeScript packages; Miden `0.13.x` compatibility remains required  
+**Primary Dependencies**: `axum`, `tonic`/`prost`, `tokio`, `serde_json`, current metadata/storage backends, `private_state_manager_shared`, TS `packages/psm-client`; EVM RPC integration stays behind a server adapter boundary while the concrete contract-read surface is finalized  
+**Storage**: Filesystem by default; Postgres metadata/storage parity remains required  
+**Testing**: Targeted Rust server/client tests, HTTP/gRPC adapter tests, TS `packages/psm-client` tests, backend parity tests, and conditional example smoke checks if the base-client surface reaches examples  
+**Target Platform**: Rust server, Rust gRPC client, and TypeScript HTTP client  
+**Project Type**: Multi-language monorepo  
+**Performance Goals**: One signer-authority RPC read per authenticated EVM action is acceptable in v1; avoid backend-specific behavioral drift or unbounded proposal scans  
+**Constraints**: Preserve existing Miden behavior, keep HTTP/gRPC and Rust/TS parity, keep fallback behavior explicit, require explicit `network_config` without backward-compatibility fallbacks, keep append-only proposal storage semantics, and avoid broad API replacement while the EVM contract shape is still settling  
+**Scale/Scope**: `crates/server` (builder, main, network, metadata, services, api, proto, tests), `crates/client` (proto + request/response support), `packages/psm-client` (types, conversion, HTTP client, tests); multisig SDKs and examples are assessed but expected to remain unchanged in v1 unless lower-layer contract changes force propagation
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- [x] Bottom-up impact assessed: server -> clients -> multisig -> examples
+- [x] HTTP and gRPC semantics remain aligned, or intentional divergence is documented
+- [x] Rust and TypeScript behavior remain aligned, or intentional divergence is documented
+- [x] Storage backend semantics remain aligned, or a backend-specific limitation is documented
+- [x] Append-only, canonicalization, auth, and proposal invariants remain preserved
+- [x] Fallback behavior remains explicit; no silent online/offline degradation is introduced
+- [x] High-risk areas have an explicit test and validation plan
+- [x] At least one upstream consumer validation path is defined for lower-layer changes
+
+## Refactor Strategy
+
+### Workstream 1: Account-Level Network Configuration
+
+- Add persisted `network_config` to account metadata so account behavior no
+  longer depends on one server-global network selection.
+- Model `network_config` as a tagged enum with at least `miden` and `evm`
+  variants.
+- Preserve current Miden semantics by moving existing server-global Miden
+  selection into account metadata for newly configured accounts.
+
+### Workstream 2: Capability-Oriented Network Dispatch
+
+- Replace the single `AppState.network_client` dependency with an account-aware
+  network registry or resolver.
+- Split current network responsibilities into focused capabilities:
+  - account configuration validation
+  - signer authority refresh/authorization
+  - proposal normalization and proposal-id generation
+  - delta/state/canonicalization operations
+- Keep Miden as the reference implementation of the full capability set.
+- Add an EVM implementation that only supports the v1 proposal/account
+  capabilities and returns explicit unsupported errors for delta/state
+  capabilities.
+
+### Workstream 3: Auth And Authorization Decoupling
+
+- Separate cryptographic request verification from signer authorization source
+  lookup. The current `Auth::verify` path couples those concerns too tightly for
+  RPC-backed EVM signer validation.
+- Preserve request-auth headers and replay protection as they work today.
+- For EVM v1, verify the request signature cryptographically, derive the signer
+  commitment, then validate signer authorization through RPC on every relevant
+  action.
+- Keep a cached signer snapshot in metadata only as persisted state or
+  optimization, not as the sole source of truth for EVM authorization.
+
+### Workstream 4: Proposal-Service Refactor
+
+- Keep the existing proposal endpoints and base-client method names in v1 to
+  constrain blast radius.
+- Move Miden-specific proposal normalization and deterministic proposal-id logic
+  out of `push_delta_proposal` and into network-specific proposal strategies.
+- Route `push_delta_proposal`, `get_delta_proposals`, `get_delta_proposal`, and
+  `sign_delta_proposal` through the account-level network capability layer.
+- Make EVM proposal identifiers deterministic hash-based values generated from a
+  normalized proposal identity input set.
+- Keep EVM proposals pending-only in v1 and defer lifecycle reconciliation until
+  the contract team defines whether sync/execution tracking belongs in scope.
+
+### Workstream 5: Contract And Client Propagation
+
+- Extend HTTP and gRPC configure requests with `network_config`.
+- Extend auth config support to include an EVM ECDSA variant while keeping the
+  overall auth model extensible.
+- Update `crates/client` and `packages/psm-client` request/response types,
+  conversion layers, and tests to reflect the new account-configuration and
+  proposal semantics.
+- Assess multisig SDKs and examples after server/base-client design is settled;
+  update them only if the lower-layer contract change becomes observable there.
+
+### Open Blockers Carried Into Implementation
+
+- Final RPC-readable contract shape for signer set, threshold, nonce, and
+  related reads.
+- Final EVM proposal payload shape.
+- Final signed-bytes definition for EVM cosigners.
+- Final decision on whether pending-only is sufficient or a sync path is needed.
+- Final RPC mutability and failure policy for EVM accounts.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+speckit/features/001-evm-proposal-support/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── grpc-contract.md
+│   └── http-openapi.yaml
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+crates/
+├── server/
+├── client/
+├── shared/
+├── miden-multisig-client/
+├── miden-rpc-client/
+└── miden-keystore/
+
+packages/
+├── psm-client/
+└── miden-multisig-client/
+
+examples/
+├── demo/
+├── web/
+└── rust/
+
+spec/
+└── system and protocol reference docs
+```
+
+**Structure Decision**:
+
+- `crates/server/src/metadata/`: add `network_config` to persisted account metadata and backend serialization.
+- `crates/server/src/network/`: replace server-global network handling with account-level dispatch and add EVM-specific implementation modules.
+- `crates/server/src/services/`: refactor account resolution, configure-account, and proposal services around network capabilities.
+- `crates/server/src/api/` and `crates/server/proto/`: carry the network-aware contract changes through HTTP and gRPC.
+- `crates/server/src/error.rs`: add explicit unsupported-operation errors for network/capability mismatches.
+- `crates/client/`: mirror gRPC contract changes and keep request-auth behavior aligned.
+- `packages/psm-client/src/`: update request/response types, conversion, and HTTP behavior for network-aware accounts and EVM proposals.
+- `examples/` and multisig SDKs: assess impact after base-layer changes; keep out of scope unless propagation is required.
+
+## Validation Plan
+
+- Targeted Rust tests:
+  `cargo test -p private-state-manager-server`
+  `cargo test -p private-state-manager-client`
+- Targeted TypeScript tests:
+  `cd packages/psm-client && npm test`
+- Server-specific regression targets:
+  - account metadata serialization for filesystem and Postgres
+  - `configure_account` for Miden and EVM
+  - `resolve_account` request verification and EVM signer re-validation
+  - proposal create/get/list/sign for Miden and EVM
+  - explicit unsupported EVM `push_delta`, `get_delta`, `get_delta_since`, `get_state`, and canonicalization paths
+  - HTTP and gRPC adapter parity for configure and proposal flows
+- Upstream validation:
+  - at least one Rust client path in `crates/client`
+  - at least one TypeScript client path in `packages/psm-client`
+- Example validation when affected:
+  `cargo run -p psm-demo`
+  `cd examples/web && npm run dev`
+- Broader validation to run if blast radius grows:
+  `cargo test --workspace`
+
+## Post-Design Constitution Check
+
+- The plan preserves bottom-up propagation by making the server change first and
+  explicitly tracking Rust and TypeScript client propagation.
+- HTTP and gRPC stay aligned by sharing the same account-level network concepts
+  and explicit unsupported-operation semantics.
+- Storage backend parity is preserved because `network_config` and proposal
+  persistence changes are designed for both filesystem and Postgres metadata
+  backends.
+- Append-only proposal behavior is preserved by keeping pending proposal storage
+  and signature appends explicit, while unsupported EVM lifecycle transitions
+  return explicit errors instead of implicit fallbacks.
+
+## Complexity Tracking
+
+> Fill only when a constitution gate requires an explicit justification.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| Reuse existing delta-proposal endpoints for EVM | Keeps the initial blast radius inside the current server/client layers while the EVM contract shape is still being settled | Introducing a brand-new proposal API would require a broader migration across server, Rust client, TS client, and examples before the contract team has finalized payload and signing semantics |

--- a/speckit/features/001-evm-proposal-support/quickstart.md
+++ b/speckit/features/001-evm-proposal-support/quickstart.md
@@ -1,8 +1,8 @@
 # Quickstart: Add generic EVM proposal sharing and signing support
 
 This quickstart is a validation-oriented walkthrough for the planned feature.
-It focuses on the safe refactor path that can proceed before the final EVM
-contract details are settled.
+It focuses on the agreed v1 shape for network-aware EVM proposal sharing and
+signing.
 
 ## 1. Configure a Miden account
 
@@ -18,10 +18,10 @@ Expected request shape:
 
 ```json
 {
-  "account_id": "evm-account-placeholder",
+  "account_id": "evm:1:0x0000000000000000000000000000000000000000",
   "auth": {
     "EvmEcdsa": {
-      "cosigner_commitments": []
+      "signers": []
     }
   },
   "network_config": {
@@ -37,29 +37,47 @@ Expected request shape:
 Expected result:
 
 - account configuration succeeds only if RPC-backed signer validation succeeds
+- `account_id` matches the canonical `chain_id + contract_address` identity
+- the server derives the EVM signer snapshot and threshold view from RPC
 - account metadata persists `network_config`
 - request-auth headers and replay protection still apply
+- for EVM accounts, request auth uses EIP-712 over a server-reconstructed
+  `AuthRequest(accountId, timestampMs, payloadHash)` message
 
 ## 3. Create an EVM proposal
+
+Expected request shape:
+
+```json
+{
+  "account_id": "evm:1:0x0000000000000000000000000000000000000000",
+  "nonce": 1,
+  "delta_payload": {
+    "kind": "evm",
+    "mode": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "execution_calldata": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "signatures": []
+  }
+}
+```
 
 Expected result:
 
 - proposal create routes through the EVM proposal capability
 - signer authority is re-validated through RPC
+- payload is validated as an ERC-7579 `execute(mode, executionCalldata)` shape
+- non-empty submitted signature arrays are rejected on create
 - proposal is stored as `pending`
 - response returns a deterministic hash-based proposal identifier
-
-Note:
-
-- the exact inner EVM proposal payload remains pending the contract-team answer
-- contract drafts currently treat the EVM executable payload as a normalized
-  object placeholder
+- repeated create of the same normalized proposal is idempotent
 
 ## 4. List, get, and sign an EVM proposal
 
 Expected result:
 
 - list/get/sign routes stay aligned between HTTP and gRPC
+- proposal signatures use EIP-712 over `(mode, keccak256(execution_calldata))`
+- signer identities are normalized EOA addresses
 - repeated signatures by the same signer are rejected explicitly
 - request auth remains explicit and replay-protected
 

--- a/speckit/features/001-evm-proposal-support/quickstart.md
+++ b/speckit/features/001-evm-proposal-support/quickstart.md
@@ -1,0 +1,88 @@
+# Quickstart: Add generic EVM proposal sharing and signing support
+
+This quickstart is a validation-oriented walkthrough for the planned feature.
+It focuses on the safe refactor path that can proceed before the final EVM
+contract details are settled.
+
+## 1. Configure a Miden account
+
+Expected result:
+
+- request includes `network_config.kind = "miden"`
+- existing Miden auth and state validation still work
+- account metadata persists Miden-specific network configuration
+
+## 2. Configure an EVM account
+
+Expected request shape:
+
+```json
+{
+  "account_id": "evm-account-placeholder",
+  "auth": {
+    "EvmEcdsa": {
+      "cosigner_commitments": []
+    }
+  },
+  "network_config": {
+    "kind": "evm",
+    "chain_id": 1,
+    "contract_address": "0x0000000000000000000000000000000000000000",
+    "rpc_endpoint": "https://rpc.example"
+  },
+  "initial_state": {}
+}
+```
+
+Expected result:
+
+- account configuration succeeds only if RPC-backed signer validation succeeds
+- account metadata persists `network_config`
+- request-auth headers and replay protection still apply
+
+## 3. Create an EVM proposal
+
+Expected result:
+
+- proposal create routes through the EVM proposal capability
+- signer authority is re-validated through RPC
+- proposal is stored as `pending`
+- response returns a deterministic hash-based proposal identifier
+
+Note:
+
+- the exact inner EVM proposal payload remains pending the contract-team answer
+- contract drafts currently treat the EVM executable payload as a normalized
+  object placeholder
+
+## 4. List, get, and sign an EVM proposal
+
+Expected result:
+
+- list/get/sign routes stay aligned between HTTP and gRPC
+- repeated signatures by the same signer are rejected explicitly
+- request auth remains explicit and replay-protected
+
+## 5. Verify unsupported EVM flows
+
+Expected result:
+
+- `push_delta`
+- `get_delta`
+- `get_delta_since`
+- `get_state`
+- canonicalization paths
+
+all return explicit unsupported errors for EVM accounts and do not fall back to
+Miden behavior.
+
+## 6. Run validation
+
+```bash
+cargo test -p private-state-manager-server
+cargo test -p private-state-manager-client
+cd packages/psm-client && npm test
+```
+
+Run example smoke checks only if the base-client changes propagate into example
+surfaces.

--- a/speckit/features/001-evm-proposal-support/quickstart.md
+++ b/speckit/features/001-evm-proposal-support/quickstart.md
@@ -99,7 +99,7 @@ Miden behavior.
 ```bash
 cargo test -p private-state-manager-server
 cargo test -p private-state-manager-client
-cd packages/psm-client && npm test
+cd packages/guardian-client && npm test
 ```
 
 Run example smoke checks only if the base-client changes propagate into example

--- a/speckit/features/001-evm-proposal-support/research.md
+++ b/speckit/features/001-evm-proposal-support/research.md
@@ -1,0 +1,110 @@
+# Research: Add generic EVM proposal sharing and signing support
+
+## Decision 1: Move network selection from server-global configuration to persisted account metadata
+
+- Decision: network selection becomes per-account `network_config` stored in
+  account metadata.
+- Rationale: the current `AppState.network_client` and `NetworkType` setup only
+  supports one network behavior per server process, which prevents Miden and EVM
+  accounts from coexisting safely.
+- Alternatives considered:
+- Keep a server-global network type and switch behavior from request payloads.
+    Rejected because it leaks global assumptions into per-account workflows.
+  - Keep separate servers per network. Rejected because the feature explicitly
+    requires mixed-account support in one system.
+  - Add a backward-compatibility fallback for missing `network_config`.
+    Rejected because the project decision for this feature is to require
+    explicit account-level network configuration.
+
+## Decision 2: Introduce account-level network dispatch through focused capabilities
+
+- Decision: replace the single network client abstraction with account-aware
+  dispatch and smaller network capabilities.
+- Rationale: the current `NetworkClient` trait is dominated by Miden
+  delta/state/canonicalization concerns. EVM v1 only needs account validation,
+  signer authorization, and proposal support.
+- Alternatives considered:
+  - Extend the existing `NetworkClient` trait with EVM methods. Rejected because
+    it would turn unsupported EVM behavior into a large trait full of dead or
+    dummy methods.
+  - Add EVM branches directly inside services. Rejected because it would embed
+    network-specific business logic back into transport-oriented service code.
+
+## Decision 3: Separate cryptographic request verification from signer authorization
+
+- Decision: split request-signature verification from signer authorization source
+  lookup, especially for EVM.
+- Rationale: current `Auth::verify` depends on stored cosigner commitments, but
+  EVM v1 requires signer authority to be re-validated from RPC on every relevant
+  action. Those are different responsibilities and need different data sources.
+- Alternatives considered:
+  - Treat stored auth commitments as the EVM source of truth. Rejected because
+    signer changes on-chain would drift silently.
+  - Refresh auth only during account configuration. Rejected because it does not
+    satisfy the requirement to re-check signer authority on each relevant action.
+
+## Decision 4: Keep proposal endpoints stable in v1 and move network-specific proposal logic behind strategies
+
+- Decision: keep the current proposal endpoints and client method names in v1,
+  while moving proposal normalization and proposal-id generation behind
+  network-specific strategy interfaces.
+- Rationale: this preserves the current surface area and lets the refactor focus
+  on account/network behavior instead of replacing the full proposal API.
+- Alternatives considered:
+  - Introduce a brand-new proposal domain and endpoints now. Rejected because it
+    expands blast radius before the EVM proposal contract shape is fully known.
+
+## Decision 5: Use RPC-only signer validation in v1 and treat the RPC endpoint as part of account trust configuration
+
+- Decision: EVM signer validation in v1 depends only on the configured RPC
+  endpoint. No indexer is used in this feature.
+- Rationale: this matches the current product decision and avoids a second
+  external dependency while the contract/read model is still forming.
+- Alternatives considered:
+  - Use an indexer as the primary or fallback authority. Rejected because the
+    product direction for v1 moved away from indexers.
+  - Allow silent fallback from RPC to another authority. Rejected by the
+    constitution's no-silent-fallback rule.
+
+## Decision 6: Make unsupported EVM delta/state/canonicalization flows fail explicitly
+
+- Decision: `push_delta`, `get_delta`, `get_delta_since`, `get_state`, and
+  canonicalization-related behavior remain unsupported for EVM accounts in v1
+  and must return explicit errors.
+- Rationale: the feature scope is intentionally limited to account configuration
+  plus proposal sharing/signing, and silent degradation would create ambiguous
+  semantics.
+- Alternatives considered:
+  - Reuse Miden state/delta flows for EVM accounts. Rejected because EVM does
+    not share Miden state or canonicalization semantics.
+  - Return empty values or no-ops. Rejected because it hides unsupported
+    behavior instead of surfacing it.
+
+## Decision 7: Use a hash-based proposal identifier and defer only the normalized input set
+
+- Decision: the EVM proposal identifier is a deterministic hash-based PSM value.
+- Rationale: this gives cross-language determinism and avoids collisions that
+  raw concatenation could allow once the executable payload becomes richer than
+  `chain_id + address + nonce`.
+- Alternatives considered:
+  - Concatenate `chain_id + contract_address + nonce`. Rejected because it is
+    too weak once multiple draft payload shapes or resubmissions exist.
+
+## Decision 8: Plan around pending-only EVM proposals until lifecycle reconciliation is explicitly designed
+
+- Decision: the refactor plan treats EVM proposals as pending-only in v1 and
+  reserves sync or execution tracking for a follow-up once the contract team
+  defines the readable on-chain state.
+- Rationale: execution-state reconciliation is a separate design problem and is
+  not needed to start the account/network refactor.
+- Alternatives considered:
+  - Force a sync operation into v1 now. Rejected because the contract-readable
+    state needed for correct reconciliation is not agreed yet.
+
+## Remaining External Inputs
+
+- Exact multisig contract shape and RPC-readable methods
+- Exact EVM proposal payload shape
+- Exact signed-bytes definition for cosigners
+- Final pending-only versus sync lifecycle decision
+- Final policy for RPC endpoint failure, rotation, and security constraints

--- a/speckit/features/001-evm-proposal-support/research.md
+++ b/speckit/features/001-evm-proposal-support/research.md
@@ -82,7 +82,7 @@
 
 ## Decision 7: Use a hash-based proposal identifier and defer only the normalized input set
 
-- Decision: the EVM proposal identifier is a deterministic hash-based PSM value.
+- Decision: the EVM proposal identifier is a deterministic hash-based Guardian value.
 - Rationale: this gives cross-language determinism and avoids collisions that
   raw concatenation could allow once the executable payload becomes richer than
   `chain_id + address + nonce`.

--- a/speckit/features/001-evm-proposal-support/research.md
+++ b/speckit/features/001-evm-proposal-support/research.md
@@ -101,10 +101,8 @@
   - Force a sync operation into v1 now. Rejected because the contract-readable
     state needed for correct reconciliation is not agreed yet.
 
-## Remaining External Inputs
+## Deferred Topics
 
-- Exact multisig contract shape and RPC-readable methods
-- Exact EVM proposal payload shape
-- Exact signed-bytes definition for cosigners
-- Final pending-only versus sync lifecycle decision
-- Final policy for RPC endpoint failure, rotation, and security constraints
+- RPC endpoint replacement or rotation policy remains deferred in v1.
+- On-chain execution reuse and explicit proposal reconciliation remain deferred
+  follow-up features.

--- a/speckit/features/001-evm-proposal-support/spec.md
+++ b/speckit/features/001-evm-proposal-support/spec.md
@@ -8,7 +8,7 @@
 
 ## Context
 
-Private State Manager currently assumes a Miden-centric account and proposal
+Guardian currently assumes a Miden-centric account and proposal
 model. This feature introduces per-account network configuration so the system
 can support both existing Miden accounts and new EVM accounts without moving
 network selection to a server-global setting.
@@ -27,14 +27,14 @@ in v1 unless they surface the new EVM proposal workflow.
 
 ### Session 2026-03-18
 
-- Q: What is the canonical identity of an EVM account in PSM? -> A: `chain_id + contract_address`
+- Q: What is the canonical identity of an EVM account in Guardian? -> A: `chain_id + contract_address`
 - Q: Which EVM account configuration fields are initially expected? -> A: start with `chain_id`, `contract_address`, and required `rpc_endpoint`
 - Q: What EVM scope is desired for v1? -> A: proposal sharing and signing only; delta/state/canonicalization support for EVM is not in v1
 - Q: How should signer authority be validated for EVM accounts? -> A: re-check signer authority on every relevant action
 - Q: Which auth/signature model should EVM v1 use? -> A: keep the auth model extensible, but implement ECDSA only for EVM in v1
 - Q: How should per-account network configuration be represented? -> A: prefer a `network_config` model rather than unrelated top-level fields
 - Q: Should v1 use an indexer for EVM signer validation? -> A: no; use direct RPC reads only in v1 and require `rpc_endpoint`
-- Q: How should the EVM proposal identifier be represented? -> A: use a deterministic hash-based PSM proposal identifier rather than raw concatenation
+- Q: How should the EVM proposal identifier be represented? -> A: use a deterministic hash-based Guardian proposal identifier rather than raw concatenation
 - Q: Should this feature preserve backward compatibility for accounts missing `network_config`? -> A: no; missing `network_config` is invalid and new account configuration must be explicit
 
 ### Session 2026-04-09
@@ -45,9 +45,9 @@ in v1 unless they surface the new EVM proposal workflow.
 - Q: Which ERC-7579 modes are supported in v1? -> A: single-call and batch-call only, with default exec type and zero selector/mode payload; delegatecall, try-mode, and custom selector/payload are out of scope
 - Q: What signer types should EVM v1 support? -> A: normalized EOA addresses only
 - Q: What transport auth shape should EVM v1 use? -> A: keep `x-pubkey`, `x-signature`, and `x-timestamp`, but verify EVM requests using EIP-712 over a server-reconstructed payload; `x-pubkey` remains the legacy header name and carries the normalized signer address for EVM
-- Q: What exact bytes should EVM proposal cosigners sign? -> A: a PSM-defined EIP-712 coordination message over `(mode, keccak256(execution_calldata))`; execution is out of scope and the signature is not required to be directly reusable on-chain in v1
+- Q: What exact bytes should EVM proposal cosigners sign? -> A: a Guardian-defined EIP-712 coordination message over `(mode, keccak256(execution_calldata))`; execution is out of scope and the signature is not required to be directly reusable on-chain in v1
 - Q: Is the proposal create path allowed to include already-collected EVM signatures? -> A: no; create rejects non-empty signature arrays and signatures are appended only through `sign_delta_proposal`
-- Q: What does the EVM proposal `nonce` mean? -> A: it is PSM-local ordering only, not an on-chain multisig nonce and not part of the proposal identifier
+- Q: What does the EVM proposal `nonce` mean? -> A: it is Guardian-local ordering only, not an on-chain multisig nonce and not part of the proposal identifier
 - Q: How should duplicate EVM proposal creation behave? -> A: same computed proposal identifier is idempotent and returns the existing pending proposal
 - Q: What do legacy delta fields mean for EVM proposals? -> A: `prev_commitment`, `new_commitment`, `ack_sig`, `ack_pubkey`, and `ack_scheme` are explicitly unused for EVM v1 proposals
 - Q: How should pending EVM proposals age out in v1? -> A: they stay pending until a future explicit cleanup/reconciliation feature, subject to the existing pending-proposal cap
@@ -88,7 +88,7 @@ in v1 unless they surface the new EVM proposal workflow.
 ### User Story 1 - Configure Network-Aware Accounts (Priority: P1)
 
 As an operator, I can configure an account with explicit per-account network
-settings so PSM knows whether the account follows Miden or EVM behavior and can
+settings so Guardian knows whether the account follows Miden or EVM behavior and can
 preserve the correct validation rules for that account.
 
 **Why this priority**: Every later EVM flow depends on account-level network
@@ -129,7 +129,7 @@ signatures are rejected.
 
 1. **Given** an EVM account with valid signer authority, **When** an authorized
    caller creates a proposal, **Then** the proposal is stored as pending with a
-   deterministic hash-based PSM proposal identifier.
+   deterministic hash-based Guardian proposal identifier.
 2. **Given** a pending EVM proposal, **When** an authorized cosigner signs it,
    **Then** the signature is appended and the updated pending proposal is
    returned.
@@ -203,20 +203,20 @@ silent fallback semantics.
   a server-reconstructed request message derived from the canonical account ID,
   request timestamp, and request payload hash, while preserving the existing
   `x-pubkey`, `x-signature`, and `x-timestamp` transport fields.
-- **FR-007b**: EVM proposal cosigning MUST use a PSM-defined EIP-712
+- **FR-007b**: EVM proposal cosigning MUST use a Guardian-defined EIP-712
   coordination message over the normalized proposal payload and MUST remain
   separate from any future on-chain execution signature format.
 - **FR-008**: EVM proposal identifiers MUST be deterministic hash-based values
   derived from the normalized tuple `(chain_id, contract_address, mode,
   keccak256(execution_calldata))`.
 - **FR-008a**: EVM proposal identifiers MUST exclude collected signatures,
-  timestamps, and the PSM-local proposal nonce.
+  timestamps, and the Guardian-local proposal nonce.
 - **FR-009**: Unsupported EVM flows, including `push_delta`, `get_delta`,
   `get_delta_since`, `get_state`, and canonicalization-related behavior, MUST
   fail explicitly rather than reusing Miden semantics or silently degrading.
 - **FR-010**: Existing Miden proposal behavior MUST remain unaffected by EVM
   support.
-- **FR-011**: The EVM proposal `nonce` field MUST remain a PSM-local ordering
+- **FR-011**: The EVM proposal `nonce` field MUST remain a Guardian-local ordering
   field and MUST NOT be interpreted as an on-chain multisig nonce.
 - **FR-012**: Re-submitting an EVM proposal whose normalized identity matches an
   existing pending proposal MUST be idempotent and return the existing proposal.
@@ -273,7 +273,7 @@ silent fallback semantics.
 - EVM proposals are pending-only proposals in v1 and model ERC-7579
   `execute(mode, executionCalldata)` requests rather than Miden `tx_summary`
   payloads.
-- EVM proposal records use a deterministic PSM-defined hash identifier derived
+- EVM proposal records use a deterministic Guardian-defined hash identifier derived
   from normalized proposal contents rather than raw field concatenation.
 - EVM proposal signatures append to pending proposal records within the
   account/network namespace; v1 does not redefine append-only proposal storage
@@ -331,11 +331,11 @@ silent fallback semantics.
 ## Assumptions
 
 - The first EVM target is OpenZeppelin `ERC7579Multisig` as the signer and
-  threshold read model for PSM account validation.
+  threshold read model for Guardian account validation.
 - EVM signer validation is re-checked on every relevant action.
 - ECDSA is the only implemented EVM signature scheme in v1, but the model is
   intentionally extensible.
-- EVM request authentication and EVM proposal cosigning both use PSM-defined
+- EVM request authentication and EVM proposal cosigning both use Guardian-defined
   EIP-712 typed messages reconstructed by the server from the received request
   and proposal payloads.
 - EVM signer identities are normalized EOA addresses only in v1.

--- a/speckit/features/001-evm-proposal-support/spec.md
+++ b/speckit/features/001-evm-proposal-support/spec.md
@@ -37,6 +37,22 @@ in v1 unless they surface the new EVM proposal workflow.
 - Q: How should the EVM proposal identifier be represented? -> A: use a deterministic hash-based PSM proposal identifier rather than raw concatenation
 - Q: Should this feature preserve backward compatibility for accounts missing `network_config`? -> A: no; missing `network_config` is invalid and new account configuration must be explicit
 
+### Session 2026-04-09
+
+- Q: What canonical API account identifier should EVM use? -> A: derive and enforce `evm:<chain_id>:<normalized_contract_address>`
+- Q: Which EVM multisig contract model should v1 target? -> A: OpenZeppelin `ERC7579Multisig` as the signer/threshold read model
+- Q: What EVM proposal shape should v1 support? -> A: only ERC-7579 `execute(mode, executionCalldata)` coordination payloads
+- Q: Which ERC-7579 modes are supported in v1? -> A: single-call and batch-call only, with default exec type and zero selector/mode payload; delegatecall, try-mode, and custom selector/payload are out of scope
+- Q: What signer types should EVM v1 support? -> A: normalized EOA addresses only
+- Q: What transport auth shape should EVM v1 use? -> A: keep `x-pubkey`, `x-signature`, and `x-timestamp`, but verify EVM requests using EIP-712 over a server-reconstructed payload; `x-pubkey` remains the legacy header name and carries the normalized signer address for EVM
+- Q: What exact bytes should EVM proposal cosigners sign? -> A: a PSM-defined EIP-712 coordination message over `(mode, keccak256(execution_calldata))`; execution is out of scope and the signature is not required to be directly reusable on-chain in v1
+- Q: Is the proposal create path allowed to include already-collected EVM signatures? -> A: no; create rejects non-empty signature arrays and signatures are appended only through `sign_delta_proposal`
+- Q: What does the EVM proposal `nonce` mean? -> A: it is PSM-local ordering only, not an on-chain multisig nonce and not part of the proposal identifier
+- Q: How should duplicate EVM proposal creation behave? -> A: same computed proposal identifier is idempotent and returns the existing pending proposal
+- Q: What do legacy delta fields mean for EVM proposals? -> A: `prev_commitment`, `new_commitment`, `ack_sig`, `ack_pubkey`, and `ack_scheme` are explicitly unused for EVM v1 proposals
+- Q: How should pending EVM proposals age out in v1? -> A: they stay pending until a future explicit cleanup/reconciliation feature, subject to the existing pending-proposal cap
+- Q: What implementation approach is preferred? -> A: one unified network-aware implementation with an optional rollout gate for EVM, not a long-lived forked feature path
+
 ## Scope *(mandatory)*
 
 ### In Scope
@@ -157,25 +173,59 @@ silent fallback semantics.
 - **FR-002**: The system MUST continue to support existing Miden accounts after
   the introduction of per-account network configuration.
 - **FR-003**: The system MUST support an EVM account identity model based on
-  `chain_id + contract_address`.
+  the canonical string `evm:<chain_id>:<normalized_contract_address>`.
+- **FR-003a**: For EVM accounts, `account_id` and `network_config` MUST agree
+  on the same normalized `chain_id + contract_address` identity.
 - **FR-004**: The system MUST persist EVM-specific account configuration through
   a `network_config`-style model rather than ad-hoc unrelated fields.
 - **FR-005**: The system MUST support EVM proposal creation, listing, retrieval,
   and signature collection in v1.
+- **FR-005a**: EVM proposal payloads in v1 MUST represent ERC-7579
+  `execute(mode, executionCalldata)` requests and MUST NOT introduce a separate
+  EVM proposal domain model.
+- **FR-005b**: EVM proposal payloads in v1 MUST support only single-call and
+  batch-call execution with default exec type and zero selector/mode payload;
+  delegatecall, try-mode, and custom selector/payload combinations MUST fail
+  explicitly.
+- **FR-005c**: EVM proposal creation MUST reject non-empty submitted signature
+  arrays; signatures are collected only through the sign-proposal flow.
 - **FR-006**: The system MUST re-validate signer authority for EVM accounts on
   all relevant account and proposal actions.
 - **FR-006a**: EVM signer validation in v1 MUST use direct RPC reads against the
   configured RPC endpoint and MUST fail explicitly when signer validation cannot
   be completed.
+- **FR-006b**: EVM signer identities in v1 MUST be normalized EOA addresses;
+  ERC-1271 contract signers and generic ERC-7913 verifier-key signers are out
+  of scope for this feature.
 - **FR-007**: The system MUST keep the auth/signature model extensible across
   networks while implementing ECDSA-only signing for EVM in v1.
+- **FR-007a**: Authenticated EVM API requests MUST use EIP-712 signatures over
+  a server-reconstructed request message derived from the canonical account ID,
+  request timestamp, and request payload hash, while preserving the existing
+  `x-pubkey`, `x-signature`, and `x-timestamp` transport fields.
+- **FR-007b**: EVM proposal cosigning MUST use a PSM-defined EIP-712
+  coordination message over the normalized proposal payload and MUST remain
+  separate from any future on-chain execution signature format.
 - **FR-008**: EVM proposal identifiers MUST be deterministic hash-based values
-  derived from a PSM-defined normalized proposal identity scheme.
+  derived from the normalized tuple `(chain_id, contract_address, mode,
+  keccak256(execution_calldata))`.
+- **FR-008a**: EVM proposal identifiers MUST exclude collected signatures,
+  timestamps, and the PSM-local proposal nonce.
 - **FR-009**: Unsupported EVM flows, including `push_delta`, `get_delta`,
   `get_delta_since`, `get_state`, and canonicalization-related behavior, MUST
   fail explicitly rather than reusing Miden semantics or silently degrading.
 - **FR-010**: Existing Miden proposal behavior MUST remain unaffected by EVM
   support.
+- **FR-011**: The EVM proposal `nonce` field MUST remain a PSM-local ordering
+  field and MUST NOT be interpreted as an on-chain multisig nonce.
+- **FR-012**: Re-submitting an EVM proposal whose normalized identity matches an
+  existing pending proposal MUST be idempotent and return the existing proposal.
+- **FR-013**: HTTP and gRPC error surfaces MUST expose stable application error
+  codes for EVM-specific failures in addition to transport-native status
+  information.
+- **FR-014**: EVM proposal records MUST leave `prev_commitment`,
+  `new_commitment`, `ack_sig`, `ack_pubkey`, and `ack_scheme` unused in v1
+  rather than assigning Miden-specific semantics to them.
 
 ### Contract / Transport Impact
 
@@ -185,14 +235,27 @@ silent fallback semantics.
   for EVM proposal create/list/get/sign flows.
 - Rust and TypeScript base clients will need corresponding request/response
   support for network-aware account configuration and EVM proposal workflows.
-- Auth headers and gRPC metadata remain explicit; EVM v1 uses ECDSA signatures,
-  while the overall auth model remains extensible.
+- Auth headers and gRPC metadata remain explicit; EVM v1 uses ECDSA signatures
+  over EIP-712 typed messages while the overall auth model remains extensible.
+- For EVM accounts, the existing transport fields `x-pubkey`, `x-signature`,
+  and `x-timestamp` remain in place; `x-pubkey` keeps its legacy name and
+  carries the normalized signer address.
+- EVM request-auth payload binding is transport-specific but semantically
+  aligned:
+  - HTTP uses `keccak256` of canonical JSON request bytes.
+  - gRPC uses `keccak256` of protobuf-encoded request bytes.
+- The supported HTTP route shape remains the current `/delta`, `/delta/since`,
+  `/delta/proposal`, `/delta/proposal/single`, `/state`, and `/configure`
+  surface rather than introducing a second parallel HTTP contract for EVM.
 - EVM signer validation depends on the configured RPC endpoint rather than an
   indexer in v1.
 - At least one upstream client surface must validate the new network-aware
   account configuration and EVM proposal flows once the server contract changes.
 - Fallback behavior remains explicit: unsupported EVM delta/state flows must not
   silently fall back to Miden or to partially supported online/offline logic.
+- Stable application error codes are required for unsupported-network,
+  RPC-validation, signer-authorization, invalid-payload, and duplicate-signature
+  failures.
 
 ### Data / Lifecycle Impact
 
@@ -200,13 +263,30 @@ silent fallback semantics.
   represent at least Miden and EVM account settings.
 - The EVM account configuration is expected to include `chain_id`,
   `contract_address`, and `rpc_endpoint`.
-- EVM proposals are pending proposals in v1. Terminal lifecycle handling beyond
-  pending status is not yet defined for v1.
+- EVM account configuration uses the canonical account identity
+  `evm:<chain_id>:<normalized_contract_address>`.
+- EVM configure requests use an empty-object `initial_state` placeholder in v1;
+  the server derives the signer snapshot and threshold view from RPC rather than
+  requiring a Miden-style initial state payload.
+- The EVM signer/threshold read model is based on OpenZeppelin
+  `ERC7579Multisig`, using RPC reads for the signer slice and current threshold.
+- EVM proposals are pending-only proposals in v1 and model ERC-7579
+  `execute(mode, executionCalldata)` requests rather than Miden `tx_summary`
+  payloads.
 - EVM proposal records use a deterministic PSM-defined hash identifier derived
   from normalized proposal contents rather than raw field concatenation.
 - EVM proposal signatures append to pending proposal records within the
   account/network namespace; v1 does not redefine append-only proposal storage
   semantics.
+- EVM proposal identifiers exclude local ordering nonce, collected signatures,
+  and timestamps.
+- EVM proposal `nonce` remains local ordering only and may differ between
+  otherwise identical create attempts without changing proposal identity.
+- Repeated create attempts for the same normalized EVM proposal are idempotent.
+- EVM proposal records leave Miden-specific delta fields unset/unused in v1.
+- Pending EVM proposals stay pending until a future explicit cleanup or
+  reconciliation feature is defined, subject to the existing per-account
+  pending-proposal limit.
 - Backend parity applies because the same network-aware account metadata and
   proposal semantics must persist consistently across filesystem and Postgres.
 - If the new EVM workflow is surfaced through higher-level SDKs or example
@@ -217,11 +297,18 @@ silent fallback semantics.
 
 - EVM account configuration provides an invalid `chain_id`, invalid contract
   address, or malformed network config.
+- EVM account configuration provides a non-canonical `account_id` that does not
+  match `chain_id + contract_address`.
 - Signer authority changes between account configuration and later proposal
   actions.
 - The configured RPC endpoint is unavailable or returns state that does not
   match the expected signer set.
 - Duplicate proposal signatures are submitted by the same signer.
+- A create request submits a non-empty EVM signature list.
+- A create request uses an unsupported ERC-7579 mode such as delegatecall,
+  try-mode, or non-zero selector/mode payload.
+- Equivalent EVM proposals are re-submitted with different local ordering
+  nonces.
 - Deterministic proposal identity diverges across transports or languages unless
   proposal inputs are normalized identically before hashing.
 - Miden and EVM accounts coexist on the same server and must not leak network
@@ -243,43 +330,49 @@ silent fallback semantics.
 
 ## Assumptions
 
-- The first EVM target is a generic EVM multisig model with a normalized signer
-  and threshold view rather than a contract-specific execution model.
+- The first EVM target is OpenZeppelin `ERC7579Multisig` as the signer and
+  threshold read model for PSM account validation.
 - EVM signer validation is re-checked on every relevant action.
 - ECDSA is the only implemented EVM signature scheme in v1, but the model is
   intentionally extensible.
-- The EVM proposal identifier is a deterministic PSM-defined hash, but the
-  exact normalized input set still needs team confirmation.
+- EVM request authentication and EVM proposal cosigning both use PSM-defined
+  EIP-712 typed messages reconstructed by the server from the received request
+  and proposal payloads.
+- EVM signer identities are normalized EOA addresses only in v1.
+- EVM proposal identifiers are fixed by the normalized tuple `(chain_id,
+  contract_address, mode, keccak256(execution_calldata))`.
 - A future explicit sync or reconciliation flow may be added to resolve EVM
-  proposal status, but execution tracking is not part of this feature unless the
-  team decides otherwise.
+  proposal status, but execution tracking is not part of this feature.
 - The desired architectural direction is to remove server-global network
   selection, persist account-specific network configuration in metadata, and
   keep network-specific validation logic behind network-specific implementations.
 - No backward-compatibility fallback is required for accounts missing
   `network_config`; explicit configuration is required in this feature.
+- `rpc_endpoint` is trusted per-account configuration in v1; endpoint
+  replacement policy is deferred.
 
 ## Dependencies
 
-- Team decisions on the EVM contract shape and RPC-readable signer validation shape.
+- OpenZeppelin `ERC7579Multisig` and its corresponding ERC-7579 mode encoding
+  rules as the EVM signer/threshold and execution-shape reference.
 - Updates to the server contract, Rust client, and TypeScript client.
 - A network-aware configuration model that can safely support both existing
   Miden accounts and new EVM accounts.
 
-## Open Questions For Team
+## Deferred Topics
 
-1. Is there already a target multisig contract definition for v1? If so, which
-   read methods or verified contract shape will PSM rely on through RPC to fetch
-   signer set, threshold, nonce, and any other required account state?
-2. What exact proposal payload shape defines an EVM proposal in v1? Is it a
-   regular transaction payload, EIP-712 typed data, or another structured form?
-3. What exact bytes or structured fields do EVM cosigners sign in v1?
-4. Without execution tracking, should v1 keep EVM proposals pending
-   indefinitely, or should it include an explicit sync or reconciliation
-   operation based on RPC-readable contract state?
-5. What is the intended RPC failure and mutability policy for EVM accounts? If
-   the configured RPC endpoint fails or becomes invalid, can users update it,
-   and if so what security constraints must apply?
+- RPC endpoint replacement or rotation policy is deferred; v1 treats
+  `rpc_endpoint` as trusted immutable account configuration.
+- Proposal execution reuse and explicit reconciliation against on-chain state
+  are deferred follow-up features.
+
+## Delivery Guidance
+
+- Implement the account/network refactor as one unified network-aware
+  architecture rather than forking EVM service logic behind a deep feature flag.
+- A rollout gate may reject new EVM account configuration until the deployment
+  is ready, but the code path should still use the same shared account
+  resolution, auth, and proposal-service architecture as Miden.
 
 ## Recommended Future Revisit
 

--- a/speckit/features/001-evm-proposal-support/spec.md
+++ b/speckit/features/001-evm-proposal-support/spec.md
@@ -1,0 +1,287 @@
+# Feature Specification: Add generic EVM proposal sharing and signing support
+
+**Feature Key**: `001-evm-proposal-support`  
+**Suggested Branch**: `001-evm-proposal-support` (manual creation optional)  
+**Created**: 2026-03-18  
+**Status**: Draft  
+**Input**: User description: "Add generic EVM proposal sharing and signing support"
+
+## Context
+
+Private State Manager currently assumes a Miden-centric account and proposal
+model. This feature introduces per-account network configuration so the system
+can support both existing Miden accounts and new EVM accounts without moving
+network selection to a server-global setting.
+
+For EVM accounts, the initial scope is proposal sharing and cosigner signature
+collection only. The system must support configuring an EVM account, validating
+its signer set through the configured RPC endpoint, creating/listing/getting
+pending proposals, and appending signatures to those proposals. Existing Miden
+flows must continue to behave as they do today.
+
+This change is expected to affect the server contract first, then the Rust and
+TypeScript base clients. Multisig SDK layers and examples may remain unchanged
+in v1 unless they surface the new EVM proposal workflow.
+
+## Clarifications
+
+### Session 2026-03-18
+
+- Q: What is the canonical identity of an EVM account in PSM? -> A: `chain_id + contract_address`
+- Q: Which EVM account configuration fields are initially expected? -> A: start with `chain_id`, `contract_address`, and required `rpc_endpoint`
+- Q: What EVM scope is desired for v1? -> A: proposal sharing and signing only; delta/state/canonicalization support for EVM is not in v1
+- Q: How should signer authority be validated for EVM accounts? -> A: re-check signer authority on every relevant action
+- Q: Which auth/signature model should EVM v1 use? -> A: keep the auth model extensible, but implement ECDSA only for EVM in v1
+- Q: How should per-account network configuration be represented? -> A: prefer a `network_config` model rather than unrelated top-level fields
+- Q: Should v1 use an indexer for EVM signer validation? -> A: no; use direct RPC reads only in v1 and require `rpc_endpoint`
+- Q: How should the EVM proposal identifier be represented? -> A: use a deterministic hash-based PSM proposal identifier rather than raw concatenation
+- Q: Should this feature preserve backward compatibility for accounts missing `network_config`? -> A: no; missing `network_config` is invalid and new account configuration must be explicit
+
+## Scope *(mandatory)*
+
+### In Scope
+
+- Add per-account network configuration so account configuration is no longer
+  modeled as server-global network selection.
+- Support EVM account configuration with network-aware metadata.
+- Support EVM proposal creation, listing, retrieval, and signature collection.
+- Support EVM signer validation through direct RPC reads.
+- Re-validate signer authority for EVM accounts on all relevant account and
+  proposal actions.
+- Preserve existing Miden account and proposal behavior.
+- Return explicit unsupported behavior for EVM flows that remain out of scope in
+  v1.
+
+### Out of Scope
+
+- EVM delta push, state retrieval, merged delta retrieval, and canonicalization.
+- Automatic execution tracking for EVM proposals.
+- Indexer-based EVM validation in v1.
+- Non-ECDSA EVM signing schemes in v1.
+- Broad multisig SDK or example-app support unless required to validate the new
+  lower-layer behavior.
+
+## User Scenarios & Testing *(mandatory)*
+
+- Prioritize stories (P1, P2, P3). Each story must be independently testable and
+  deliver user value.
+- Include transport expectations (HTTP/gRPC) and auth behavior when relevant.
+- Because the server contract changes, at least one upstream client surface must
+  be validated.
+
+### User Story 1 - Configure Network-Aware Accounts (Priority: P1)
+
+As an operator, I can configure an account with explicit per-account network
+settings so PSM knows whether the account follows Miden or EVM behavior and can
+preserve the correct validation rules for that account.
+
+**Why this priority**: Every later EVM flow depends on account-level network
+configuration, and this is the minimum change needed to avoid interfering with
+existing Miden features.  
+**Independent Test**: Configure one Miden account and one EVM account through
+both HTTP and gRPC and verify that the persisted account configuration retains
+the correct network-specific shape and validation behavior.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Miden account configuration request, **When** the account is
+   created, **Then** the persisted account keeps Miden-compatible behavior and
+   no EVM-specific validation is required.
+2. **Given** an EVM account configuration request with the required network
+   fields, **When** the account is created, **Then** the account is persisted
+   with EVM-specific network configuration and can later use EVM proposal
+   workflows.
+3. **Given** an EVM account configuration request missing required network
+   fields, **When** the account is created, **Then** the request fails with an
+   explicit validation error.
+
+---
+
+### User Story 2 - Share And Sign EVM Proposals (Priority: P2)
+
+As an authorized cosigner for an EVM account, I can create, list, retrieve, and
+sign pending proposals so proposal coordination works before any execution
+tracking exists.
+
+**Why this priority**: This is the core feature requested, and it should work
+without requiring the broader EVM delta/canonicalization model in v1.  
+**Independent Test**: Create a pending EVM proposal, retrieve it through both
+transports, append signatures from authorized signers, and verify duplicate
+signatures are rejected.
+
+**Acceptance Scenarios**:
+
+1. **Given** an EVM account with valid signer authority, **When** an authorized
+   caller creates a proposal, **Then** the proposal is stored as pending with a
+   deterministic hash-based PSM proposal identifier.
+2. **Given** a pending EVM proposal, **When** an authorized cosigner signs it,
+   **Then** the signature is appended and the updated pending proposal is
+   returned.
+3. **Given** a pending EVM proposal already signed by a signer, **When** the
+   same signer signs again, **Then** the request fails with an explicit
+   duplicate-signature error.
+4. **Given** equivalent normalized EVM proposal contents for the same account,
+   **When** those contents are submitted through either HTTP or gRPC, **Then**
+   the resulting proposal identifier is the same.
+
+---
+
+### User Story 3 - Fail Explicitly For Unsupported EVM Flows (Priority: P3)
+
+As an integrator, I can distinguish supported EVM proposal workflows from
+unsupported EVM delta/state workflows so the system does not silently fall back
+to Miden assumptions or leave behavior ambiguous.
+
+**Why this priority**: The feature is intentionally partial in v1, so the
+boundaries must be explicit to avoid architectural drift and accidental misuse.  
+**Independent Test**: Call unsupported EVM delta/state/canonicalization flows
+and verify they return explicit unsupported behavior rather than partial or
+silent fallback semantics.
+
+**Acceptance Scenarios**:
+
+1. **Given** an EVM account, **When** an unsupported delta or state workflow is
+   invoked, **Then** the system returns an explicit unsupported error for that
+   account/network combination.
+2. **Given** both Miden and EVM accounts exist, **When** supported flows are
+   invoked on each, **Then** each account follows only its own network rules and
+   no server-global network assumption leaks across accounts.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST support per-account network configuration so each
+  configured account declares its network behavior independently of any
+  server-global network selection.
+- **FR-002**: The system MUST continue to support existing Miden accounts after
+  the introduction of per-account network configuration.
+- **FR-003**: The system MUST support an EVM account identity model based on
+  `chain_id + contract_address`.
+- **FR-004**: The system MUST persist EVM-specific account configuration through
+  a `network_config`-style model rather than ad-hoc unrelated fields.
+- **FR-005**: The system MUST support EVM proposal creation, listing, retrieval,
+  and signature collection in v1.
+- **FR-006**: The system MUST re-validate signer authority for EVM accounts on
+  all relevant account and proposal actions.
+- **FR-006a**: EVM signer validation in v1 MUST use direct RPC reads against the
+  configured RPC endpoint and MUST fail explicitly when signer validation cannot
+  be completed.
+- **FR-007**: The system MUST keep the auth/signature model extensible across
+  networks while implementing ECDSA-only signing for EVM in v1.
+- **FR-008**: EVM proposal identifiers MUST be deterministic hash-based values
+  derived from a PSM-defined normalized proposal identity scheme.
+- **FR-009**: Unsupported EVM flows, including `push_delta`, `get_delta`,
+  `get_delta_since`, `get_state`, and canonicalization-related behavior, MUST
+  fail explicitly rather than reusing Miden semantics or silently degrading.
+- **FR-010**: Existing Miden proposal behavior MUST remain unaffected by EVM
+  support.
+
+### Contract / Transport Impact
+
+- HTTP and gRPC account configuration requests will need to carry per-account
+  network configuration rather than assuming only the current Miden model.
+- HTTP and gRPC proposal requests and responses must remain semantically aligned
+  for EVM proposal create/list/get/sign flows.
+- Rust and TypeScript base clients will need corresponding request/response
+  support for network-aware account configuration and EVM proposal workflows.
+- Auth headers and gRPC metadata remain explicit; EVM v1 uses ECDSA signatures,
+  while the overall auth model remains extensible.
+- EVM signer validation depends on the configured RPC endpoint rather than an
+  indexer in v1.
+- At least one upstream client surface must validate the new network-aware
+  account configuration and EVM proposal flows once the server contract changes.
+- Fallback behavior remains explicit: unsupported EVM delta/state flows must not
+  silently fall back to Miden or to partially supported online/offline logic.
+
+### Data / Lifecycle Impact
+
+- Account metadata will need a network-aware configuration model that can
+  represent at least Miden and EVM account settings.
+- The EVM account configuration is expected to include `chain_id`,
+  `contract_address`, and `rpc_endpoint`.
+- EVM proposals are pending proposals in v1. Terminal lifecycle handling beyond
+  pending status is not yet defined for v1.
+- EVM proposal records use a deterministic PSM-defined hash identifier derived
+  from normalized proposal contents rather than raw field concatenation.
+- EVM proposal signatures append to pending proposal records within the
+  account/network namespace; v1 does not redefine append-only proposal storage
+  semantics.
+- Backend parity applies because the same network-aware account metadata and
+  proposal semantics must persist consistently across filesystem and Postgres.
+- If the new EVM workflow is surfaced through higher-level SDKs or example
+  applications, the corresponding docs and examples must be updated in the same
+  change; otherwise the current Miden-facing examples remain unchanged in v1.
+
+## Edge Cases *(mandatory)*
+
+- EVM account configuration provides an invalid `chain_id`, invalid contract
+  address, or malformed network config.
+- Signer authority changes between account configuration and later proposal
+  actions.
+- The configured RPC endpoint is unavailable or returns state that does not
+  match the expected signer set.
+- Duplicate proposal signatures are submitted by the same signer.
+- Deterministic proposal identity diverges across transports or languages unless
+  proposal inputs are normalized identically before hashing.
+- Miden and EVM accounts coexist on the same server and must not leak network
+  behavior into one another.
+- Backend-specific persistence differences must not change observable EVM
+  account or proposal behavior.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A user can configure both Miden and EVM accounts through HTTP and
+  gRPC, and Miden account behavior remains unchanged after the contract update.
+- **SC-002**: A user can create, list, retrieve, and sign EVM proposals through
+  both transports, and duplicate signatures are rejected explicitly.
+- **SC-003**: Unsupported EVM delta/state/canonicalization flows return explicit
+  unsupported behavior rather than partial success, silent fallback, or Miden
+  semantics.
+
+## Assumptions
+
+- The first EVM target is a generic EVM multisig model with a normalized signer
+  and threshold view rather than a contract-specific execution model.
+- EVM signer validation is re-checked on every relevant action.
+- ECDSA is the only implemented EVM signature scheme in v1, but the model is
+  intentionally extensible.
+- The EVM proposal identifier is a deterministic PSM-defined hash, but the
+  exact normalized input set still needs team confirmation.
+- A future explicit sync or reconciliation flow may be added to resolve EVM
+  proposal status, but execution tracking is not part of this feature unless the
+  team decides otherwise.
+- The desired architectural direction is to remove server-global network
+  selection, persist account-specific network configuration in metadata, and
+  keep network-specific validation logic behind network-specific implementations.
+- No backward-compatibility fallback is required for accounts missing
+  `network_config`; explicit configuration is required in this feature.
+
+## Dependencies
+
+- Team decisions on the EVM contract shape and RPC-readable signer validation shape.
+- Updates to the server contract, Rust client, and TypeScript client.
+- A network-aware configuration model that can safely support both existing
+  Miden accounts and new EVM accounts.
+
+## Open Questions For Team
+
+1. Is there already a target multisig contract definition for v1? If so, which
+   read methods or verified contract shape will PSM rely on through RPC to fetch
+   signer set, threshold, nonce, and any other required account state?
+2. What exact proposal payload shape defines an EVM proposal in v1? Is it a
+   regular transaction payload, EIP-712 typed data, or another structured form?
+3. What exact bytes or structured fields do EVM cosigners sign in v1?
+4. Without execution tracking, should v1 keep EVM proposals pending
+   indefinitely, or should it include an explicit sync or reconciliation
+   operation based on RPC-readable contract state?
+5. What is the intended RPC failure and mutability policy for EVM accounts? If
+   the configured RPC endpoint fails or becomes invalid, can users update it,
+   and if so what security constraints must apply?
+
+## Recommended Future Revisit
+
+- Revisit whether EVM proposals should gain explicit sync or execution-tracking
+  support once the team settles the contract and validation-source design.

--- a/speckit/features/README.md
+++ b/speckit/features/README.md
@@ -1,0 +1,14 @@
+# Feature Workspaces
+
+Each feature workspace lives under `speckit/features/<feature-key>/`.
+
+Typical contents:
+
+- `spec.md`: feature specification
+- `plan.md`: implementation plan
+- `research.md`: planning research notes
+- `data-model.md`: entity and lifecycle notes
+- `quickstart.md`: verification and smoke-check notes
+- `contracts/`: API or protocol artifacts
+- `tasks.md`: implementation task breakdown
+- `checklists/`: requirements quality checklists


### PR DESCRIPTION
Feature spec for adding EVM proposal sharing and signing support to Guardian.

It turns the previous draft into an implementable v1 contract by defining the EVM account model, request auth, proposal payload shape, proposal identity, signer semantics, and rollout approach. The feature remains scoped to account configuration plus proposal create/list/get/sign. Execution, delta/state flows, and reconciliation remain out of scope.