### PR TITLE
agents: add general skills for development

### DIFF
--- a/.agents/skills/guardian-auth-signature-flows/SKILL.md
+++ b/.agents/skills/guardian-auth-signature-flows/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: guardian-auth-signature-flows
+description: Implement and debug Guardian authentication and signature flows across server, clients, multisig SDKs, and examples. Use when Codex changes request signing, auth metadata, ack signing, Falcon or ECDSA behavior, key managers, public key handling, or signature encoding and verification.
+---
+
+# Guardian Auth Signature Flows
+
+## Overview
+
+Use this skill for the repo's most fragile crypto-adjacent flows. Keep scheme handling explicit, validate boundary conversions, and verify both Falcon and ECDSA whenever the touched path supports both.
+
+## Read First
+
+Read these files before editing:
+
+- `AGENTS.md`
+- `crates/server/src/ack/*`
+- `crates/server/src/metadata/auth/*`
+- `crates/client/src/auth/*`
+- `crates/client/src/keystore/*`
+- `packages/guardian-client/src/auth-request.ts`
+- `packages/guardian-client/src/conversion.ts`
+- `packages/miden-multisig-client/src/utils/signature.ts`
+- `packages/miden-multisig-client/src/utils/encoding.ts`
+- [`references/auth-surfaces.md`](references/auth-surfaces.md)
+
+Inspect example surfaces too if the changed auth or signature behavior reaches execution or browser signers.
+
+## Workflow
+
+1. Classify the signature path.
+   Determine whether the task affects:
+   - request auth metadata
+   - proposal signatures
+   - guardian ack signing
+   - keystore or signer abstractions
+   - signature encoding or decoding
+   - scheme selection or scheme-specific public key handling
+2. Edit the lowest boundary first.
+   - server verification or signing logic
+   - Rust client auth or signer logic
+   - TS HTTP auth or signature utilities
+3. Verify conversion boundaries explicitly.
+   Normalize external hex, bytes, base64, public keys, and commitments at the boundary module instead of scattering ad hoc conversion logic.
+4. Re-check both schemes when the path supports both.
+   Falcon-only or ECDSA-only paths can stay narrow, but mixed flows must be validated under each scheme.
+5. Expand upward to multisig execution or examples if the changed signature shape is consumed there.
+
+## Guardrails
+
+- Do not branch on free-form error strings in core logic.
+- Do not introduce implicit crypto conversions in feature code.
+- Do not drop public key information for ECDSA flows that require it downstream.
+- Preserve explicit `x-pubkey`, `x-signature`, and `x-timestamp` behavior when touching request signing.
+- Preserve `ack_sig`, `ack_pubkey`, and `ack_scheme` behavior when touching execution or proposal flows.
+- If a path uses both Falcon and ECDSA, test both. Do not infer parity from one scheme.
+
+## Validation
+
+Default targeted checks:
+
+```bash
+cargo test -p guardian-client
+cargo test -p guardian-server
+cd packages/guardian-client && npm test
+```
+
+Expand when the auth or signature change crosses into multisig execution:
+
+- `cargo test -p miden-multisig-client`
+- `cd packages/miden-multisig-client && npm test`
+- `smoke-test-rust-multisig-sdk`
+- `smoke-test-ts-multisig-sdk`
+
+## Output Shape
+
+Report:
+
+- signature path touched
+- schemes exercised
+- boundary modules updated
+- downstream consumers checked
+- tests and smoke coverage
+- unresolved assumptions

--- a/.agents/skills/guardian-auth-signature-flows/agents/openai.yaml
+++ b/.agents/skills/guardian-auth-signature-flows/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Guardian Auth Signatures"
+  short_description: "Handle Guardian auth and Falcon/ECDSA signature flows"
+  default_prompt: "Use $guardian-auth-signature-flows to work on request signing, ack signatures, keystores, and Falcon or ECDSA behavior."

--- a/.agents/skills/guardian-auth-signature-flows/references/auth-surfaces.md
+++ b/.agents/skills/guardian-auth-signature-flows/references/auth-surfaces.md
@@ -1,0 +1,74 @@
+# Auth And Signature Surfaces
+
+Use this file to find the boundary modules for Guardian auth and signing behavior.
+
+## Server
+
+Ack signing:
+- `crates/server/src/ack/mod.rs`
+- `crates/server/src/ack/miden_falcon_rpo/*`
+- `crates/server/src/ack/miden_ecdsa/*`
+- `crates/server/src/bin/ack-keygen.rs`
+
+Auth verification:
+- `crates/server/src/metadata/auth/*`
+- `crates/server/src/api/http.rs`
+- `crates/server/src/api/grpc.rs`
+
+Use these when:
+- ack scheme handling changed
+- server public key or commitment behavior changed
+- auth metadata validation changed
+
+## Rust Client
+
+- `crates/client/src/auth/*`
+- `crates/client/src/keystore/*`
+- `crates/client/src/client.rs`
+- `crates/client/src/error.rs`
+- `crates/client/src/testing/*`
+
+Use these when:
+- request signing changed
+- signer abstraction changed
+- public key export changed
+- auth header generation changed
+
+## TypeScript Client
+
+- `packages/guardian-client/src/auth-request.ts`
+- `packages/guardian-client/src/http.ts`
+- `packages/guardian-client/src/conversion.ts`
+- `packages/guardian-client/src/server-types.ts`
+- `packages/guardian-client/src/*.test.ts`
+
+Use these when:
+- canonicalization of signed request payloads changed
+- header or error shape changed
+- ack field decoding changed
+
+## Multisig And Examples
+
+Rust:
+- `crates/miden-multisig-client/src/execution.rs`
+- `crates/miden-multisig-client/src/transaction/guardian.rs`
+
+TypeScript:
+- `packages/miden-multisig-client/src/utils/signature.ts`
+- `packages/miden-multisig-client/src/utils/encoding.ts`
+- `packages/miden-multisig-client/src/signers/*`
+- `packages/miden-multisig-client/src/multisig/proposal/execution.ts`
+
+Examples:
+- `examples/rust/src/main.rs`
+- `examples/smoke-web/src/smokeHarness.ts`
+- `examples/_shared/multisig-browser/src/*`
+
+Inspect these when auth or signature changes are observable in proposal execution or browser signers.
+
+## Validation Rules
+
+- Exercise both Falcon and ECDSA when the touched path supports both.
+- Verify public key requirements separately for ECDSA proposal signatures.
+- Verify ack fields remain populated where execution depends on them.
+- Prefer targeted unit tests first, then manual smoke for end-to-end signature collection or execution flows.

--- a/.agents/skills/guardian-change-impact/SKILL.md
+++ b/.agents/skills/guardian-change-impact/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: guardian-change-impact
+description: Identify the impact radius of a proposed or in-progress change in the Guardian repository and turn it into a concrete edit and validation plan. Use when Codex needs to map a request, bug, or diff across server, Rust client, TypeScript client, multisig SDKs, examples, docs, and tests before implementation or review.
+---
+
+# Guardian Change Impact
+
+## Overview
+
+Use this skill before making non-trivial changes or when reviewing a diff that may cross layers. Start from the lowest affected layer, decide what must propagate upward, and produce a short impact report that names the files, tests, and manual smoke surfaces that matter.
+
+## Read First
+
+Read these sources before deciding scope:
+
+- `AGENTS.md`
+- `docs/MULTISIG_SDK.md`
+- `spec/api.md`
+- `spec/components.md`
+- `spec/processes.md`
+- [`references/impact-matrix.md`](references/impact-matrix.md)
+
+Prefer current source files over prose docs when they disagree.
+
+## Workflow
+
+1. Classify the change.
+   Use the matrix in [`references/impact-matrix.md`](references/impact-matrix.md) to decide whether the request is primarily:
+   - server contract
+   - server lifecycle or canonicalization
+   - auth or signature flow
+   - base client parity
+   - multisig proposal workflow
+   - browser signer or example integration
+   - deploy, release, or benchmark infrastructure
+2. Find the lowest affected layer.
+   Start from:
+   - `crates/server`
+   - `crates/client` and `packages/guardian-client`
+   - `crates/miden-multisig-client` and `packages/miden-multisig-client`
+   - `examples/`
+3. Enumerate required propagation upward.
+   If a lower layer changes, name every upstream layer that must be inspected or updated in the same task.
+4. Choose the smallest sufficient validation set.
+   Map the impact classification to the minimum cargo, npm, and manual smoke coverage. Use `guardian-validation-matrix` if the change is already understood and only the verification set needs to be chosen.
+5. Hand off to a narrower skill when appropriate.
+   - Use `guardian-contract-change` for endpoint, payload, or enum changes.
+   - Use `guardian-multisig-proposal-lifecycle` for proposal or offline flow changes.
+   - Use `guardian-auth-signature-flows` for auth, keystore, Falcon, ECDSA, or ack changes.
+   - Use `smoke-test-rust-multisig-sdk` or `smoke-test-ts-multisig-sdk` for manual canaries.
+   - Use `deploy-guardian-aws`, `release-guardian-sdk-packages`, or `run-guardian-prod-benchmarks` for those specialized flows.
+
+## Output Shape
+
+Produce a compact report with:
+
+- lowest affected layer
+- directly impacted files or modules
+- required propagation layers
+- mandatory tests and smoke checks
+- docs that must be checked or updated
+- open questions or risky assumptions
+
+Do not stop at vague statements like "probably affects clients". Name the concrete surfaces.
+
+## Guardrails
+
+- Preserve bottom-up reasoning. Do not start from examples or docs and infer the server contract from them.
+- Treat auth, signature handling, canonicalization, proposal status transitions, and offline import or export as high-risk.
+- Treat server contract edits as multi-package edits by default.
+- Do not assume Rust and TypeScript behavior match. Verify both surfaces explicitly when the workflow exists in both stacks.
+- Prefer a minimal edit plan over a large refactor plan.

--- a/.agents/skills/guardian-change-impact/agents/openai.yaml
+++ b/.agents/skills/guardian-change-impact/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Guardian Change Impact"
+  short_description: "Map a Guardian change to impacted layers and checks"
+  default_prompt: "Use $guardian-change-impact to map this repo change to the affected layers, files, and validation steps."

--- a/.agents/skills/guardian-change-impact/references/impact-matrix.md
+++ b/.agents/skills/guardian-change-impact/references/impact-matrix.md
@@ -1,0 +1,139 @@
+# Guardian Change Impact Matrix
+
+Use this file to classify the request before editing code.
+
+## Server Contract
+
+Trigger:
+- `guardian.proto`
+- HTTP JSON fields
+- endpoint semantics
+- status enums
+- auth metadata requirements
+
+Likely surfaces:
+- `crates/server/proto/guardian.proto`
+- `crates/server/src/api/http.rs`
+- `crates/server/src/api/grpc.rs`
+- `crates/server/src/services/*`
+- `crates/client/src/client.rs`
+- `packages/guardian-client/src/server-types.ts`
+- `packages/guardian-client/src/conversion.ts`
+- both multisig SDKs if proposal or state shapes change
+
+Validation:
+- `cargo test -p guardian-server`
+- `cargo test -p guardian-client`
+- `cd packages/guardian-client && npm test`
+- one upstream smoke when user-visible behavior changes
+
+## Canonicalization Or State Lifecycle
+
+Trigger:
+- pending, candidate, canonical, discarded behavior
+- nonce or commitment convergence
+- `get_delta_since`
+- canonicalization worker or storage rules
+
+Likely surfaces:
+- `crates/server/src/jobs/canonicalization/*`
+- `crates/server/src/services/get_delta_since.rs`
+- `crates/server/src/services/push_delta.rs`
+- `crates/server/src/services/push_delta_proposal.rs`
+- `crates/server/src/storage/*`
+- `crates/server/src/metadata/*`
+- multisig sync and example canaries if client-observable
+
+Validation:
+- `cargo test -p guardian-server`
+- integration or e2e server tests when transport semantics changed
+- at least one Rust or TS multisig smoke if convergence behavior is visible upstream
+
+## Auth Or Signature Flow
+
+Trigger:
+- request signing
+- `x-pubkey`, `x-signature`, `x-timestamp`
+- Falcon or ECDSA behavior
+- ack key, ack signature, ack scheme, ack pubkey
+- keystore or signature encoding
+
+Likely surfaces:
+- `crates/server/src/ack/*`
+- `crates/server/src/metadata/auth/*`
+- `crates/client/src/auth/*`
+- `crates/client/src/keystore/*`
+- `packages/guardian-client/src/auth-request.ts`
+- multisig execution or signature utility modules
+
+Validation:
+- both Rust and TS client tests where relevant
+- both Falcon and ECDSA targeted coverage
+- manual smoke if proposal execution or browser signers are affected
+
+## Base Client Parity
+
+Trigger:
+- raw client request or response shapes
+- conversion rules
+- error shapes
+- HTTP or gRPC client semantics
+
+Likely surfaces:
+- `crates/client/src/*`
+- `packages/guardian-client/src/*`
+
+Validation:
+- `cargo test -p guardian-client`
+- `cd packages/guardian-client && npm test`
+
+## Multisig Proposal Lifecycle
+
+Trigger:
+- create, list, sign, execute
+- threshold counting
+- export, import, offline sign
+- proposal metadata mapping
+- `SwitchGuardian`
+
+Likely surfaces:
+- `crates/miden-multisig-client/src/client/*`
+- `crates/miden-multisig-client/src/proposal.rs`
+- `crates/miden-multisig-client/src/execution.rs`
+- `packages/miden-multisig-client/src/multisig/*`
+- `packages/miden-multisig-client/src/proposal/*`
+- `packages/miden-multisig-client/src/transaction/*`
+
+Validation:
+- Rust and TS multisig package tests
+- example smoke in `examples/demo` or `examples/smoke-web`
+
+## Browser Signer Or Example Integration
+
+Trigger:
+- Para or Miden Wallet integration
+- browser-only workflows
+- shared example adapters
+
+Likely surfaces:
+- `examples/_shared/multisig-browser/src/*`
+- `examples/smoke-web/src/*`
+- `examples/web/src/*`
+- TS multisig signers and client wrappers
+
+Validation:
+- `cd examples/smoke-web && npm run typecheck && npm run build`
+- `cd examples/web && npm run build`
+- browser smoke with isolated profiles when signer behavior changed
+
+## Deploy, Release, Or Benchmarks
+
+Trigger:
+- ECS, Terraform, AWS auth, prod rollout
+- SDK version bump or publish
+- benchmark execution or reporting
+
+Use the existing specialized skills instead of expanding this one:
+- `deploy-guardian-aws`
+- `release-guardian-sdk-packages`
+- `run-guardian-prod-benchmarks`

--- a/.agents/skills/guardian-contract-change/SKILL.md
+++ b/.agents/skills/guardian-contract-change/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: guardian-contract-change
+description: Propagate Guardian contract changes safely across server, Rust client, TypeScript client, multisig SDKs, examples, docs, and tests. Use when Codex changes `guardian.proto`, HTTP JSON payloads, response shapes, status enums, auth requirements, or any user-visible server contract.
+---
+
+# Guardian Contract Change
+
+## Overview
+
+Use this skill when the server contract is the source of truth for the task. Update the server first, then move outward through every consumer that depends on the changed shape or semantics.
+
+## Read First
+
+Read these sources before making edits:
+
+- `AGENTS.md`
+- `crates/server/proto/guardian.proto`
+- `crates/server/src/api/http.rs`
+- `crates/server/src/api/grpc.rs`
+- `packages/guardian-client/src/server-types.ts`
+- `packages/guardian-client/src/conversion.ts`
+- `crates/client/src/client.rs`
+- [`references/contract-surfaces.md`](references/contract-surfaces.md)
+
+If the change touches proposal payloads or account state shapes, also inspect both multisig SDKs and the example harnesses before editing.
+
+## Workflow
+
+1. Confirm the contract change.
+   Decide whether the change is:
+   - gRPC-only
+   - HTTP-only
+   - shared semantic behavior exposed through both transports
+2. Update the server contract source first.
+   - gRPC: edit `crates/server/proto/guardian.proto`
+   - HTTP JSON: edit `crates/server/src/api/http.rs` and the backing service modules
+   - shared behavior: edit service and domain modules before the transport adapters
+3. Update Rust client compatibility.
+   Inspect and update:
+   - generated proto usage in `crates/client`
+   - request builders
+   - response mapping
+   - auth or signature handling if required by the new contract
+4. Update TypeScript client compatibility.
+   Inspect and update:
+   - `packages/guardian-client/src/server-types.ts`
+   - `packages/guardian-client/src/conversion.ts`
+   - `packages/guardian-client/src/http.ts`
+   - tests for malformed or missing fields
+5. Propagate into multisig SDKs if the changed fields cross that boundary.
+   Proposal metadata, state objects, ack fields, and status transitions are the common triggers.
+6. Update examples and docs when the change is visible to users or integrators.
+   Start with `examples/demo`, `examples/smoke-web`, and `examples/web`.
+7. Run the smallest meaningful validation set, then expand if high-risk.
+
+## Guardrails
+
+- Do not change client adapters first and infer the new contract from them later.
+- Do not add permissive parsing or silent fallback behavior unless the task explicitly requires it.
+- Keep Rust and TypeScript client semantics aligned.
+- Treat auth changes, proposal status changes, and JSON field optionality as high-risk.
+- If the server contract changed, both `crates/client` and `packages/guardian-client` must be considered in the same task.
+
+## Output Shape
+
+Report:
+
+- contract source changed
+- dependent files updated
+- transport surfaces affected
+- client parity work completed
+- upstream SDK or example fallout
+- tests and smoke checks run
+- any intentionally skipped propagation with reason

--- a/.agents/skills/guardian-contract-change/agents/openai.yaml
+++ b/.agents/skills/guardian-contract-change/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Guardian Contract Change"
+  short_description: "Propagate Guardian API and schema changes safely"
+  default_prompt: "Use $guardian-contract-change to update a Guardian contract change across server, clients, SDKs, examples, and tests."

--- a/.agents/skills/guardian-contract-change/references/contract-surfaces.md
+++ b/.agents/skills/guardian-contract-change/references/contract-surfaces.md
@@ -1,0 +1,86 @@
+# Guardian Contract Surfaces
+
+Use this file to decide which consumers must move with the server contract.
+
+## Primary Server Sources
+
+- `crates/server/proto/guardian.proto`
+- `crates/server/src/api/http.rs`
+- `crates/server/src/api/grpc.rs`
+- `crates/server/src/services/*`
+- `crates/server/src/delta_object.rs`
+- `crates/server/src/state_object.rs`
+
+## Rust Client Surfaces
+
+- `crates/client/src/client.rs`
+- `crates/client/src/lib.rs`
+- `crates/client/src/error.rs`
+- `crates/client/src/testing/*`
+
+Use these when:
+- request fields changed
+- response field presence changed
+- auth metadata or signing behavior changed
+- proto messages changed
+
+## TypeScript Client Surfaces
+
+- `packages/guardian-client/src/server-types.ts`
+- `packages/guardian-client/src/conversion.ts`
+- `packages/guardian-client/src/http.ts`
+- `packages/guardian-client/src/types.ts`
+- tests in `packages/guardian-client/src/*.test.ts`
+
+Use these when:
+- HTTP JSON shape changed
+- union or status mapping changed
+- optionality changed
+- error decoding changed
+
+## Multisig Surfaces
+
+Rust:
+- `crates/miden-multisig-client/src/client/proposals.rs`
+- `crates/miden-multisig-client/src/client/account.rs`
+- `crates/miden-multisig-client/src/client/offline.rs`
+- `crates/miden-multisig-client/src/proposal.rs`
+- `crates/miden-multisig-client/src/execution.rs`
+
+TypeScript:
+- `packages/miden-multisig-client/src/client.ts`
+- `packages/miden-multisig-client/src/raw-client.ts`
+- `packages/miden-multisig-client/src/multisig/proposal/*`
+- `packages/miden-multisig-client/src/proposal/*`
+- `packages/miden-multisig-client/src/transaction/*`
+
+Inspect these when:
+- proposal metadata changed
+- proposal status semantics changed
+- ack data changed
+- state fields used by multisig sync changed
+
+## Example And Doc Surfaces
+
+- `examples/demo/src/actions/*`
+- `examples/smoke-web/src/smokeHarness.ts`
+- `examples/_shared/multisig-browser/src/*`
+- `examples/web/src/lib/*`
+- `docs/MULTISIG_SDK.md`
+- `spec/api.md`
+
+Update these when the public workflow or expected responses changed.
+
+## Typical Validation Set
+
+Minimum:
+- `cargo test -p guardian-server`
+- `cargo test -p guardian-client`
+- `cd packages/guardian-client && npm test`
+
+Expand when the contract crosses layers:
+- `cargo test -p miden-multisig-client`
+- `cd packages/miden-multisig-client && npm test`
+- `cargo test -p guardian-demo`
+- `cd examples/smoke-web && npm run typecheck && npm run build`
+- manual smoke with `smoke-test-rust-multisig-sdk` or `smoke-test-ts-multisig-sdk`

--- a/.agents/skills/guardian-multisig-proposal-lifecycle/SKILL.md
+++ b/.agents/skills/guardian-multisig-proposal-lifecycle/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: guardian-multisig-proposal-lifecycle
+description: Implement, debug, and validate proposal lifecycle changes across the Rust and TypeScript multisig SDKs and their example harnesses. Use when Codex touches proposal creation, listing, signing, readiness, execution, import or export, offline signing, sync behavior, threshold counting, or `SwitchGuardian` flows.
+---
+
+# Guardian Multisig Proposal Lifecycle
+
+## Overview
+
+Use this skill for high-risk multisig workflow changes. Keep the Rust and TypeScript SDKs behaviorally aligned and verify the user-visible flow in at least one upstream example surface.
+
+## Read First
+
+Read the current workflow surface before editing:
+
+- `AGENTS.md`
+- `crates/miden-multisig-client/src/client/proposals.rs`
+- `crates/miden-multisig-client/src/client/offline.rs`
+- `crates/miden-multisig-client/src/proposal.rs`
+- `crates/miden-multisig-client/src/execution.rs`
+- `packages/miden-multisig-client/src/multisig/proposal/execution.ts`
+- `packages/miden-multisig-client/src/multisig/proposal/parser.ts`
+- `packages/miden-multisig-client/src/proposal/metadata.ts`
+- `examples/demo/src/actions/proposal_management.rs`
+- `examples/smoke-web/src/smokeHarness.ts`
+- [`references/workflow-matrix.md`](references/workflow-matrix.md)
+
+## Workflow
+
+1. Identify the stage being changed.
+   Classify the work as:
+   - proposal creation
+   - proposal parsing or metadata
+   - signature collection
+   - readiness or threshold logic
+   - execution and ack integration
+   - export, import, or offline signing
+   - post-execution sync or state verification
+2. Inspect both Rust and TypeScript implementations for the same stage.
+   If the workflow exists in both stacks, do not change one in isolation without at least confirming whether the other must also move.
+3. Preserve lifecycle invariants.
+   Use [`references/workflow-matrix.md`](references/workflow-matrix.md) as the checklist for what must remain true.
+4. Update the nearest example surface.
+   - `examples/demo` for Rust flow verification
+   - `examples/smoke-web` and `examples/web` for browser flow verification
+5. Validate the minimal affected path first, then expand to adjacent risky paths.
+
+## Guardrails
+
+- Do not silently change threshold semantics.
+- Do not hide fallback from online to offline flows. Fallback must stay explicit.
+- Keep proposal identifiers and metadata stable across export and import.
+- Treat `SwitchGuardian` as a distinct path. Do not generalize offline execution claims beyond what the current code supports.
+- Preserve Rust and TypeScript naming and behavior parity unless the divergence is intentional and documented.
+- Fail fast on malformed signature, commitment, or metadata data rather than coercing it.
+
+## Validation
+
+Default targeted checks:
+
+```bash
+cargo test -p miden-multisig-client
+cd packages/miden-multisig-client && npm test
+```
+
+Then expand as needed:
+
+- `cargo test -p guardian-client` or `cd packages/guardian-client && npm test` if the change crosses the GUARDIAN client boundary
+- `cargo test -p guardian-demo`
+- `cd examples/smoke-web && npm run typecheck && npm run build`
+- `cd examples/web && npm run build`
+- `smoke-test-rust-multisig-sdk`
+- `smoke-test-ts-multisig-sdk`
+
+## Output Shape
+
+Report:
+
+- proposal stages touched
+- Rust files updated
+- TypeScript files updated
+- example surfaces updated or checked
+- lifecycle invariants preserved
+- targeted tests and smoke coverage
+- gaps or skipped paths

--- a/.agents/skills/guardian-multisig-proposal-lifecycle/agents/openai.yaml
+++ b/.agents/skills/guardian-multisig-proposal-lifecycle/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Guardian Multisig Lifecycle"
+  short_description: "Implement and validate multisig proposal lifecycle changes"
+  default_prompt: "Use $guardian-multisig-proposal-lifecycle to work on proposal creation, signing, execution, import/export, and sync behavior."

--- a/.agents/skills/guardian-multisig-proposal-lifecycle/references/workflow-matrix.md
+++ b/.agents/skills/guardian-multisig-proposal-lifecycle/references/workflow-matrix.md
@@ -1,0 +1,93 @@
+# Proposal Workflow Matrix
+
+Use this file to decide what else must be checked when one proposal stage changes.
+
+## Create
+
+Primary surfaces:
+- `crates/miden-multisig-client/src/transaction/*`
+- `crates/miden-multisig-client/src/client/proposals.rs`
+- `packages/miden-multisig-client/src/transaction/*`
+- `packages/miden-multisig-client/src/multisig/proposal/parser.ts`
+
+Verify:
+- metadata fields are complete and explicit
+- required signatures are derived correctly
+- proposal commitment is stable
+
+## List And Parse
+
+Primary surfaces:
+- `crates/miden-multisig-client/src/proposal.rs`
+- `packages/miden-multisig-client/src/proposal/metadata.ts`
+- `packages/miden-multisig-client/src/types/proposal.ts`
+
+Verify:
+- malformed payloads fail loudly
+- status mapping is exhaustive
+- proposal type mapping is stable across Rust and TS
+
+## Sign
+
+Primary surfaces:
+- `crates/miden-multisig-client/src/client/proposals.rs`
+- `packages/miden-multisig-client/src/multisig/signing.ts`
+- signature utility modules in both stacks
+
+Verify:
+- non-cosigner rejection
+- already-signed rejection
+- Falcon and ECDSA handling when relevant
+- public key requirements for ECDSA are preserved
+
+## Ready To Execute
+
+Primary surfaces:
+- readiness checks in both SDKs
+- threshold and procedure-threshold logic
+
+Verify:
+- collected vs required signatures are reported correctly
+- signer-update transactions validate against current account signers, not proposed future signers
+
+## Execute
+
+Primary surfaces:
+- `crates/miden-multisig-client/src/execution.rs`
+- `crates/miden-multisig-client/src/client/proposals.rs`
+- `packages/miden-multisig-client/src/multisig/proposal/execution.ts`
+
+Verify:
+- canonical transaction summary binding
+- guardian ack inclusion when required
+- `SwitchGuardian` special handling
+- post-execution sync behavior
+
+## Export, Import, Offline Sign
+
+Primary surfaces:
+- `crates/miden-multisig-client/src/export.rs`
+- `crates/miden-multisig-client/src/client/offline.rs`
+- offline proposal helpers in `packages/miden-multisig-client`
+
+Verify:
+- proposal id remains stable after export and import
+- imported signatures are preserved exactly
+- offline execution claims stay explicit and narrow
+
+## Upstream Canaries
+
+Rust:
+- `examples/demo/src/actions/proposal_management.rs`
+- `examples/demo/src/actions/verify_state_commitment.rs`
+
+TypeScript:
+- `examples/smoke-web/src/smokeHarness.ts`
+- `examples/_shared/multisig-browser/src/multisigApi.ts`
+- `examples/web/src/lib/multisigApi.ts`
+
+Required manual smoke increases when:
+- proposal metadata changed
+- offline import or export changed
+- signer scheme behavior changed
+- post-execution convergence changed

--- a/.agents/skills/guardian-validation-matrix/SKILL.md
+++ b/.agents/skills/guardian-validation-matrix/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: guardian-validation-matrix
+description: Select the smallest meaningful verification set for changes in the Guardian repository. Use when Codex needs to decide which cargo tests, npm tests, builds, example smokes, or specialized validation skills are required for server, client, multisig, browser, deploy, release, or benchmark changes.
+---
+
+# Guardian Validation Matrix
+
+## Overview
+
+Use this skill after the change scope is understood. Choose the minimum validation that still covers the changed behavior, then expand only when the touched path is high-risk or crosses more layers.
+
+## Read First
+
+Read:
+
+- `AGENTS.md`
+- [`references/command-matrix.md`](references/command-matrix.md)
+- the changed files or summarized impact report
+
+## Workflow
+
+1. Classify the affected layer and risk.
+   Decide whether the change is:
+   - server-only internal
+   - server contract
+   - Rust client
+   - TS client
+   - multisig Rust
+   - multisig TS
+   - browser example or signer integration
+   - deploy, release, or benchmark
+2. Start with the package-local checks from [`references/command-matrix.md`](references/command-matrix.md).
+3. Expand when any of these are true:
+   - the change affects a public contract
+   - the change affects auth or signature flows
+   - the change affects proposal lifecycle or canonicalization
+   - the change affects browser signers or user-visible examples
+4. Add manual smoke when a lower-layer change is observable in `examples/demo` or `examples/smoke-web`.
+5. Prefer existing specialized skills over duplicating their workflow.
+
+## Guardrails
+
+- Do not jump directly to `cargo test --workspace` unless the impact is broad or targeted checks already failed.
+- Do not treat unit tests as a replacement for example smoke when the behavior is user-visible.
+- When a server or client contract changes, validate at least one upstream consumer.
+- Document skipped coverage with a reason instead of implying it was unnecessary.
+
+## Specialized Skills
+
+Use these instead of expanding this skill:
+
+- `smoke-test-rust-multisig-sdk`
+- `smoke-test-ts-multisig-sdk`
+- `deploy-guardian-aws`
+- `release-guardian-sdk-packages`
+- `run-guardian-prod-benchmarks`
+
+## Output Shape
+
+Produce:
+
+- exact ordered commands to run
+- manual smoke required
+- why each command is included
+- what was intentionally skipped
+- next expansion step if the first layer of checks fails

--- a/.agents/skills/guardian-validation-matrix/agents/openai.yaml
+++ b/.agents/skills/guardian-validation-matrix/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Guardian Validation Matrix"
+  short_description: "Choose the smallest meaningful Guardian validation set"
+  default_prompt: "Use $guardian-validation-matrix to choose and run the minimal Guardian tests, builds, and smoke checks for this change."

--- a/.agents/skills/guardian-validation-matrix/references/command-matrix.md
+++ b/.agents/skills/guardian-validation-matrix/references/command-matrix.md
@@ -1,0 +1,114 @@
+# Guardian Validation Command Matrix
+
+Use this file to choose the minimum meaningful verification set.
+
+## Server Only
+
+Code in:
+- `crates/server/src/services/*`
+- `crates/server/src/jobs/*`
+- `crates/server/src/storage/*`
+- `crates/server/src/metadata/*`
+
+Run:
+```bash
+cargo test -p guardian-server
+```
+
+Add when transport, auth, or integration semantics changed:
+```bash
+cargo test -p guardian-server --features integration
+```
+
+## Rust Client
+
+Code in:
+- `crates/client/src/*`
+
+Run:
+```bash
+cargo test -p guardian-client
+```
+
+## TypeScript Guardian Client
+
+Code in:
+- `packages/guardian-client/src/*`
+
+Run:
+```bash
+cd packages/guardian-client && npm test
+cd packages/guardian-client && npm run build
+```
+
+## Rust Multisig SDK
+
+Code in:
+- `crates/miden-multisig-client/src/*`
+
+Run:
+```bash
+cargo test -p miden-multisig-client
+```
+
+Add when the lower client or server boundary changed too:
+```bash
+cargo test -p guardian-client
+```
+
+## TypeScript Multisig SDK
+
+Code in:
+- `packages/miden-multisig-client/src/*`
+
+Run:
+```bash
+cd packages/miden-multisig-client && npm test
+cd packages/miden-multisig-client && npm run build
+```
+
+## Rust Example Surface
+
+Code in:
+- `examples/demo/*`
+- Rust multisig changes with user-visible behavior
+
+Run:
+```bash
+cargo test -p guardian-demo
+```
+
+Manual canary:
+- `cargo run -p guardian-demo`
+
+## Browser Example Surface
+
+Code in:
+- `examples/_shared/multisig-browser/src/*`
+- `examples/smoke-web/src/*`
+- `examples/web/src/*`
+
+Run:
+```bash
+cd examples/smoke-web && npm run typecheck && npm run build
+cd examples/web && npm run build
+```
+
+Manual canary:
+- use `smoke-test-ts-multisig-sdk`
+
+## Cross-Layer Changes
+
+If the change touches server contract, auth, proposal lifecycle, or browser signer behavior, combine the relevant package-local commands and add at least one upstream example smoke.
+
+## Broad Changes
+
+Only escalate to workspace-wide checks when:
+- multiple packages were edited across Rust and TypeScript
+- targeted checks failed in a way that suggests wider fallout
+- the task explicitly asks for a broad verification sweep
+
+Escalation:
+```bash
+cargo test --workspace
+```


### PR DESCRIPTION
Created five repo-local skills under `.agents/skills:`

- `guardian-change-impact`: bottom-up impact triage and propagation planning
- `guardian-contract-change`: server-first contract change workflow across Rust, TS, multisig, and examples
- `guardian-multisig-proposal-lifecycle`: proposal create/sign/execute/import-export/offline flow guidance
- `guardian-auth-signature-flows`: auth metadata, ack signing, Falcon/ECDSA, and boundary conversion rules
- `guardian-validation-matrix`: minimal meaningful test/build/smoke selection