### PR TITLE
remove reverse on signature felts

### DIFF
--- a/packages/miden-multisig-client/src/utils/signature.ts
+++ b/packages/miden-multisig-client/src/utils/signature.ts
@@ -36,9 +36,8 @@ function bytesToPackedU32Felts(bytes: Uint8Array): Felt[] {
 function encodeEcdsaSignatureFelts(pubkeyBytes: Uint8Array, sigBytes: Uint8Array): Felt[] {
   const pkFelts = bytesToPackedU32Felts(pubkeyBytes);
   const sigFelts = bytesToPackedU32Felts(sigBytes);
-  const encoded = [...pkFelts, ...sigFelts];
-  encoded.reverse();
-  return encoded;
+  return [...pkFelts, ...sigFelts];
+  
 }
 
 export function buildSignatureAdviceEntry(


### PR DESCRIPTION
I keep getting "invalid public key commitment" every time I call multisig.executeProposal after switching from Miden testnet 0.13 to 0.14. Create / sign proposals work fine but only execute fails. After digging in, it's seems like because Miden 0.14 flipped the operand stack to little-endian, and encodeEcdsaSignatureFelts has a .reverse() which causing the error format of [...pkFelts, ...sigFelts]