### PR TITLE
Fix getSigners ABI to use uint64 range parameters

### DIFF
--- a/crates/server/src/evm/contracts.rs
+++ b/crates/server/src/evm/contracts.rs
@@ -19,7 +19,7 @@ sol! {
 
     #[sol(rpc)]
     interface IERC7579MultisigValidator {
-        function getSigners(address account, uint256 start, uint256 end) external view returns (bytes[]);
+        function getSigners(address account, uint64 start, uint64 end) external view returns (bytes[]);
         function getSignerCount(address account) external view returns (uint256);
         function threshold(address account) external view returns (uint64);
     }
@@ -94,8 +94,10 @@ impl EvmContractReader {
                 "signer count {signer_count} exceeds safety limit"
             )));
         }
+        // bounded above, so fits in u64
+        let signer_count_u64 = signer_count.to::<u64>();
         let raw_signers = validator
-            .getSigners(account, U256::ZERO, signer_count)
+            .getSigners(account, 0u64, signer_count_u64)
             .call()
             .await
             .map_err(|e| GuardianError::RpcUnavailable(e.to_string()))?;


### PR DESCRIPTION
## Summary
The `IERC7579MultisigValidator.getSigners` ABI declared `start` and `end` as `uint256`, but the expected multisig validator contract uses `uint64`. Because Solidity's 4-byte selector is computed from the canonical type signature, the mismatched types meant calls would not have dispatched to the intended function.

- `getSigners(address, uint256, uint256)` → `getSigners(address, uint64, uint64)`
- Convert the bounded `signer_count` to `u64` at the call site (the existing `≤ 1024` guard makes the conversion safe).

Verified end-to-end using the expected multisig validator contract.