### PR TITLE
chore: Update skill and operator package version

### DIFF
--- a/.agents/skills/release-guardian-sdk-packages/SKILL.md
+++ b/.agents/skills/release-guardian-sdk-packages/SKILL.md
@@ -19,6 +19,8 @@ Read the current source of truth at the start of every release task:
 - `packages/guardian-evm-client/package-lock.json`
 - `packages/miden-multisig-client/package.json`
 - `packages/miden-multisig-client/package-lock.json`
+- `packages/guardian-operator-client/package.json`
+- `packages/guardian-operator-client/package-lock.json`
 - `references/release-surface.md`
 
 Trust these sources in this order:
@@ -75,6 +77,7 @@ TypeScript packages:
 - `@openzeppelin/guardian-client`
 - `@openzeppelin/guardian-evm-client`
 - `@openzeppelin/miden-multisig-client`
+- `@openzeppelin/guardian-operator-client`
 
 ## Version Bump Rules
 
@@ -88,6 +91,7 @@ For a coordinated release, update all of these:
 - `packages/guardian-evm-client/package.json` `version`
 - `packages/miden-multisig-client/package.json` `version`
 - `packages/miden-multisig-client/package.json` `@openzeppelin/guardian-client` dependency range
+- `packages/guardian-operator-client/package.json` `version`
 
 After editing TypeScript versions, refresh lockfiles from the package directories:
 
@@ -95,6 +99,7 @@ After editing TypeScript versions, refresh lockfiles from the package directorie
 cd packages/guardian-client && npm install --package-lock-only
 cd packages/guardian-evm-client && npm install --package-lock-only
 cd packages/miden-multisig-client && npm install --package-lock-only
+cd packages/guardian-operator-client && npm install --package-lock-only
 ```
 
 Inspect the resulting lockfile diff. Keep the refresh focused on version and dependency metadata.
@@ -117,6 +122,8 @@ cd packages/guardian-evm-client && npm test
 cd packages/guardian-evm-client && npm run build
 cd packages/miden-multisig-client && npm test
 cd packages/miden-multisig-client && npm run build
+cd packages/guardian-operator-client && npm test
+cd packages/guardian-operator-client && npm run build
 ```
 
 Then run publish dry-runs:
@@ -132,6 +139,7 @@ cargo publish -p miden-multisig-client --dry-run
 cd packages/guardian-client && npm publish --access public --dry-run
 cd packages/guardian-evm-client && npm publish --access public --dry-run
 cd packages/miden-multisig-client && npm publish --access public --dry-run
+cd packages/guardian-operator-client && npm publish --access public --dry-run
 ```
 
 If a dry-run or test fails, stop there and report the failing step, package, and minimal next action.
@@ -172,6 +180,7 @@ TypeScript packages must be published in dependency order:
 1. `@openzeppelin/guardian-client`
 2. `@openzeppelin/guardian-evm-client`
 3. `@openzeppelin/miden-multisig-client`
+4. `@openzeppelin/guardian-operator-client` (no internal deps — order-independent, listed last for convenience)
 
 ## Manual Boundary
 

--- a/packages/guardian-operator-client/README.md
+++ b/packages/guardian-operator-client/README.md
@@ -70,6 +70,23 @@ console.log(detail.authorizedSignerIds);
 console.log(detail.currentCommitment, detail.stateUpdatedAt);
 ```
 
+### Decoded Account Snapshot
+
+Returns the decoded state (vault contents, pending-candidate flag) at
+the commitment Guardian last canonicalized for the account. Sourced
+from Guardian's stored state — no live Miden RPC calls.
+
+```typescript
+const snapshot = await client.getAccountSnapshot('0x...');
+console.log(snapshot.commitment, snapshot.updatedAt);
+if (snapshot.hasPendingCandidate) {
+  console.warn('vault may be stale — candidate delta in flight');
+}
+for (const asset of snapshot.vault.fungible) {
+  console.log(asset.faucetId, asset.amount);
+}
+```
+
 ### Inventory And Health Snapshot
 
 ```typescript
@@ -100,6 +117,41 @@ proposal queue.
 const page = await client.listAccountProposals('0x...', { limit: 50 });
 for (const entry of page.items) {
   console.log(
+    entry.commitment,
+    entry.signaturesCollected,
+    '/',
+    entry.signaturesRequired,
+  );
+}
+```
+
+### Cross-Account Delta Feed
+
+Paginated newest-first by `status_timestamp DESC`. The optional
+`status` filter accepts a single status or an array; the wrapper
+serializes the array to a comma-separated query parameter.
+
+```typescript
+const page = await client.listGlobalDeltas({
+  limit: 50,
+  status: ['candidate', 'canonical'],
+});
+for (const entry of page.items) {
+  console.log(entry.accountId, entry.nonce, entry.status);
+}
+```
+
+### Cross-Account In-Flight Proposal Feed
+
+Paginated newest-first by `originating_timestamp DESC`. There is no
+`status` filter — every entry is in-flight by definition. EVM accounts
+do not appear in v1.
+
+```typescript
+const page = await client.listGlobalProposals({ limit: 50 });
+for (const entry of page.items) {
+  console.log(
+    entry.accountId,
     entry.commitment,
     entry.signaturesCollected,
     '/',

--- a/packages/guardian-operator-client/package-lock.json
+++ b/packages/guardian-operator-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openzeppelin/guardian-operator-client",
-  "version": "0.14.3",
+  "version": "0.14.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openzeppelin/guardian-operator-client",
-      "version": "0.14.3",
+      "version": "0.14.6",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.7.2",

--- a/packages/guardian-operator-client/package.json
+++ b/packages/guardian-operator-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/guardian-operator-client",
-  "version": "0.14.3",
+  "version": "0.14.6",
   "description": "TypeScript HTTP client for Guardian operator dashboard endpoints",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
This PR updates  operator package/readme versions and skill for publishing packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Guardian Operator Client documentation with new sections covering account snapshots with state examples, cross-account delta feeds with pagination and filtering, and in-flight proposal feeds with field documentation.

* **Chores**
  * Guardian Operator Client version updated to 0.14.6.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenZeppelin/guardian/pull/232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->