### PR TITLE
fix(docker): make compose flow work as documented

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,11 @@ DOMAIN_NAME=openzeppelin.com
 AWS_REGION=us-east-1
 CPU_ARCHITECTURE=X86_64
 GUARDIAN_NETWORK_TYPE=MidenTestnet
-GUARDIAN_OPERATOR_PUBLIC_KEYS_JSON='["0x<falcon-public-key-1>","0x<falcon-public-key-2>"]'
+# Operator allowlist for dashboard auth — pick ONE:
+# Local / docker: point to a JSON file (in docker, mount the file into the container).
+# GUARDIAN_OPERATOR_PUBLIC_KEYS_FILE=/path/to/operator-keys.json
+# AWS deploy (via scripts/aws-deploy.sh): inline JSON, consumed by the script not the server.
+# GUARDIAN_OPERATOR_PUBLIC_KEYS_JSON='["0x<key-1>","0x<key-2>"]'
 
 # HTTPS and DNS
 # ACM_CERTIFICATE_ARN=arn:aws:acm:us-east-1:123456789012:certificate/...

--- a/.env.example
+++ b/.env.example
@@ -7,9 +7,12 @@ GUARDIAN_METADATA_PATH=/var/guardian/metadata
 GUARDIAN_KEYSTORE_PATH=/var/guardian/keystore
 
 # Optional Postgres Storage
+# Inside docker compose: host is "postgres" (the service name in docker-compose.postgres.yml)
+# DATABASE_URL=postgres://guardian:guardian_dev_password@postgres:5432/guardian
+# Outside docker (server running on host against a local postgres): host is "localhost"
 # DATABASE_URL=postgres://guardian:guardian_dev_password@localhost:5432/guardian
 
-# Optional local Postgres password for docker-compose.postgres.yml
+# Required for docker-compose.postgres.yml
 # POSTGRES_PASSWORD=guardian_dev_password
 
 # AWS deployment

--- a/.env.example
+++ b/.env.example
@@ -25,10 +25,10 @@ DOMAIN_NAME=openzeppelin.com
 AWS_REGION=us-east-1
 CPU_ARCHITECTURE=X86_64
 GUARDIAN_NETWORK_TYPE=MidenTestnet
-# Operator allowlist for dashboard auth — pick ONE:
+# Operator allowlist for dashboard auth; pick ONE:
 # Local / docker: point to a JSON file (in docker, mount the file into the container).
 # GUARDIAN_OPERATOR_PUBLIC_KEYS_FILE=/path/to/operator-keys.json
-# AWS deploy (via scripts/aws-deploy.sh): inline JSON, consumed by the script not the server.
+# AWS deploy (via scripts/aws-deploy.sh): inline JSON, consumed by the deploy script, not by the server.
 # GUARDIAN_OPERATOR_PUBLIC_KEYS_JSON='["0x<key-1>","0x<key-2>"]'
 
 # HTTPS and DNS

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 target/
 store.sqlite3
 /keystore/
+/var/
 miden-client.toml
 templates/
 .env

--- a/README.md
+++ b/README.md
@@ -105,10 +105,10 @@ The HTTP server will be available at `http://localhost:3000`
 
 The gRPC server will be available at `localhost:50051`
 
-This default Compose flow uses the filesystem backend. If you need a local Postgres container for benchmark or explicit Postgres-backed runs, set `POSTGRES_PASSWORD` in `.env` and run with the [Postgres override](./docker-compose.postgres.yml):
+This default Compose flow uses the filesystem backend. If you need a local Postgres container for benchmark or explicit Postgres-backed runs, set `POSTGRES_PASSWORD` in `.env` and run [docker-compose.postgres.yml](./docker-compose.postgres.yml):
 
 ```bash
-docker compose -f docker-compose.yml -f docker-compose.postgres.yml up --build -d
+docker compose -f docker-compose.postgres.yml up --build -d
 ```
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -111,8 +111,6 @@ This default Compose flow uses the filesystem backend. If you need a local Postg
 docker compose -f docker-compose.yml -f docker-compose.postgres.yml up --build -d
 ```
 
-`--build` is required the first time because the server image must be rebuilt with the `postgres` Cargo feature enabled.
-
 ### Testing
 
 #### Rust Tests

--- a/README.md
+++ b/README.md
@@ -105,10 +105,10 @@ The HTTP server will be available at `http://localhost:3000`
 
 The gRPC server will be available at `localhost:50051`
 
-This default Compose flow uses the filesystem backend. If you need a local Postgres container for benchmark or explicit Postgres-backed runs, set `POSTGRES_PASSWORD` in `.env` and run [docker-compose.postgres.yml](./docker-compose.postgres.yml):
+This default Compose flow uses the filesystem backend. If you need a local Postgres container for benchmark or explicit Postgres-backed runs, set `POSTGRES_PASSWORD` in `.env` and run with the [Postgres override](./docker-compose.postgres.yml):
 
 ```bash
-docker compose -f docker-compose.postgres.yml up --build -d
+docker compose -f docker-compose.yml -f docker-compose.postgres.yml up --build -d
 ```
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -105,7 +105,13 @@ The HTTP server will be available at `http://localhost:3000`
 
 The gRPC server will be available at `localhost:50051`
 
-This default Compose flow uses the filesystem backend. If you need a local Postgres container for benchmark or explicit Postgres-backed runs, use [docker-compose.postgres.yml](/Users/marcos/repos/guardian/docker-compose.postgres.yml) instead.
+This default Compose flow uses the filesystem backend. If you need a local Postgres container for benchmark or explicit Postgres-backed runs, set `POSTGRES_PASSWORD` in `.env` and run with the [Postgres override](./docker-compose.postgres.yml):
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.postgres.yml up --build -d
+```
+
+`--build` is required the first time because the server image must be rebuilt with the `postgres` Cargo feature enabled.
 
 ### Testing
 

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -9,7 +9,7 @@ services:
       postgres:
         condition: service_healthy
     environment:
-      - DATABASE_URL=postgres://guardian:${POSTGRES_PASSWORD}@postgres:5432/guardian
+      - DATABASE_URL=postgres://guardian:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}@postgres:5432/guardian
 
   postgres:
     image: postgres:16-alpine

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -1,4 +1,5 @@
-version: "3.8"
+include:
+  - docker-compose.yml
 
 services:
   server:

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -1,5 +1,4 @@
-include:
-  - docker-compose.yml
+version: "3.8"
 
 services:
   server:

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -1,6 +1,16 @@
 version: "3.8"
 
 services:
+  server:
+    build:
+      args:
+        GUARDIAN_SERVER_FEATURES: postgres
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      - DATABASE_URL=postgres://guardian:${POSTGRES_PASSWORD}@postgres:5432/guardian
+
   postgres:
     image: postgres:16-alpine
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,8 @@ services:
       - guardian-metadata:/var/guardian/metadata
       - guardian-keystore:/var/guardian/keystore
     env_file:
-      - .env
+      - path: .env
+        required: false
     environment:
       - RUST_LOG=info
       - GUARDIAN_STORAGE_PATH=/var/guardian/storage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       - guardian-storage:/var/guardian/storage
       - guardian-metadata:/var/guardian/metadata
       - guardian-keystore:/var/guardian/keystore
+    env_file:
+      - .env
     environment:
       - RUST_LOG=info
       - GUARDIAN_STORAGE_PATH=/var/guardian/storage


### PR DESCRIPTION
Hey! At LambdaClass we are experimenting with deploying our own guardian instance and we found a few things that we thought were worth changing, mostly aimed towards improving the docker compose flow.

## Fixes

- `.env` was being ignored by the container, it now reaches the server (or skipped cleanly if absent)
- Postgres compose advertised but didn't wire connection between server and postgres, now it works end-to-end (documented it in the README)
- Clarify in `.env.example` that the `GUARDIAN_OPERATOR_PUBLIC_KEYS_JSON` variable is not read by the server but by a script that is for AWS deploy.
- Missing `POSTGRES_PASSWORD` silently broke postgres later, now it fails immediately with a clear hint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated environment configuration examples with clearer guidance for Docker Compose and local server deployments.
  * Revised Docker Compose setup instructions for improved Postgres integration.

* **Chores**
  * Updated `.gitignore` to exclude temporary directory.
  * Enhanced Docker configuration for improved environment variable management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenZeppelin/guardian/pull/247?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->