### PR TITLE
 fix(contracts): skip cleanup_pubkey_mapping when signer count does n…

### DIFF
--- a/crates/contracts/masm/auth/multisig.masm
+++ b/crates/contracts/masm/auth/multisig.masm
@@ -349,14 +349,20 @@ pub proc update_signers_and_threshold(multisig_config_hash: word)
     drop
     # => [pad(12)]
 
-    # compare initial vs current multisig config
-
-    # load init_num_of_approvers & new_num_of_approvers
     loc_load.0 loc_load.1
     # => [init_num_of_approvers, new_num_of_approvers, pad(12)]
 
-    exec.cleanup_pubkey_mapping
-    # => [pad(12)]
+    dup.1 dup.1
+    u32assert2 u32lt
+    # => [should_cleanup, init_num_of_approvers, new_num_of_approvers, pad(12)]
+
+    if.true
+        exec.cleanup_pubkey_mapping
+        # => [pad(12)]
+    else
+        drop drop
+        # => [pad(12)]
+    end
 end
 
 #! Update or clear the threshold override for a specific procedure.

--- a/crates/contracts/masm/auth/multisig_ecdsa.masm
+++ b/crates/contracts/masm/auth/multisig_ecdsa.masm
@@ -349,14 +349,20 @@ pub proc update_signers_and_threshold(multisig_config_hash: word)
     drop
     # => [pad(12)]
 
-    # compare initial vs current multisig config
-
-    # load init_num_of_approvers & new_num_of_approvers
     loc_load.0 loc_load.1
     # => [init_num_of_approvers, new_num_of_approvers, pad(12)]
 
-    exec.cleanup_pubkey_mapping
-    # => [pad(12)]
+    dup.1 dup.1
+    u32assert2 u32lt
+    # => [should_cleanup, init_num_of_approvers, new_num_of_approvers, pad(12)]
+
+    if.true
+        exec.cleanup_pubkey_mapping
+        # => [pad(12)]
+    else
+        drop drop
+        # => [pad(12)]
+    end
 end
 
 #! Update or clear the threshold override for a specific procedure.

--- a/crates/contracts/src/multisig_guardian.rs
+++ b/crates/contracts/src/multisig_guardian.rs
@@ -481,10 +481,10 @@ mod tests {
             .build()
             .expect("account");
 
-        assert_eq!(account.id().to_hex(), "0x4c053cea120ba890494eba281a8e5c");
+        assert_eq!(account.id().to_hex(), "0xbb9656eb0cf54e9011b206ed311b0a");
         assert_eq!(
             account.to_commitment().into_hex(),
-            "0x49f0b7a53c9104ae8b370ac5db29a0ad04348b1aa4b104f5ec260775cf6bd5b9"
+            "0xe67939e39fd360e5b9a69e9632e2d2f898cf5c19275f3d1906d163b3c4e1cd5f"
         );
     }
 }

--- a/crates/contracts/tests/auth/multisig.rs
+++ b/crates/contracts/tests/auth/multisig.rs
@@ -567,7 +567,7 @@ async fn test_multisig_add_signer_with_guardian_from_single_signer() -> anyhow::
         NoteType::Public,
     )?;
 
-    let mock_chain = mock_chain_builder.clone().build().unwrap();
+    let mut mock_chain = mock_chain_builder.clone().build().unwrap();
 
     let salt = Word::from([Felt::new(9); 4]);
     let mut advice_map = AdviceMap::default();
@@ -649,6 +649,9 @@ async fn test_multisig_add_signer_with_guardian_from_single_signer() -> anyhow::
         update_approvers_tx.account_delta().nonce_delta(),
         Felt::new(1)
     );
+
+    mock_chain.add_pending_executed_transaction(&update_approvers_tx)?;
+    mock_chain.prove_next_block()?;
 
     let mut updated_multisig_account = multisig_account.clone();
     updated_multisig_account.apply_delta(update_approvers_tx.account_delta())?;

--- a/crates/miden-multisig-client/src/procedures.rs
+++ b/crates/miden-multisig-client/src/procedures.rs
@@ -29,7 +29,7 @@ impl ProcedureName {
                 "0x1f43e9d56ceff5d547ffdcb89896fb38cae0be1b74d9235ed2b4aa525df85f8d",
             ),
             ProcedureName::AuthTx => procedure_root_word(
-                "0x415530d7169f849d7219e810065f9119bba9af2c55070de0bf4f082a1c0aea5c",
+                "0x58156720b5dba3490a008a733e9f414363b4fb367bfdf36c324f3c2867372484",
             ),
             ProcedureName::UpdateGuardian => procedure_root_word(
                 "0xc8ea876f1837e5cd1d6031becdbd40ce262ecd55930d65400f6890a37149d80c",

--- a/packages/miden-multisig-client/masm/auth/multisig.masm
+++ b/packages/miden-multisig-client/masm/auth/multisig.masm
@@ -349,14 +349,20 @@ pub proc update_signers_and_threshold(multisig_config_hash: word)
     drop
     # => [pad(12)]
 
-    # compare initial vs current multisig config
-
-    # load init_num_of_approvers & new_num_of_approvers
     loc_load.0 loc_load.1
     # => [init_num_of_approvers, new_num_of_approvers, pad(12)]
 
-    exec.cleanup_pubkey_mapping
-    # => [pad(12)]
+    dup.1 dup.1
+    u32assert2 u32lt
+    # => [should_cleanup, init_num_of_approvers, new_num_of_approvers, pad(12)]
+
+    if.true
+        exec.cleanup_pubkey_mapping
+        # => [pad(12)]
+    else
+        drop drop
+        # => [pad(12)]
+    end
 end
 
 #! Update or clear the threshold override for a specific procedure.

--- a/packages/miden-multisig-client/masm/auth/multisig_ecdsa.masm
+++ b/packages/miden-multisig-client/masm/auth/multisig_ecdsa.masm
@@ -349,14 +349,20 @@ pub proc update_signers_and_threshold(multisig_config_hash: word)
     drop
     # => [pad(12)]
 
-    # compare initial vs current multisig config
-
-    # load init_num_of_approvers & new_num_of_approvers
     loc_load.0 loc_load.1
     # => [init_num_of_approvers, new_num_of_approvers, pad(12)]
 
-    exec.cleanup_pubkey_mapping
-    # => [pad(12)]
+    dup.1 dup.1
+    u32assert2 u32lt
+    # => [should_cleanup, init_num_of_approvers, new_num_of_approvers, pad(12)]
+
+    if.true
+        exec.cleanup_pubkey_mapping
+        # => [pad(12)]
+    else
+        drop drop
+        # => [pad(12)]
+    end
 end
 
 #! Update or clear the threshold override for a specific procedure.

--- a/packages/miden-multisig-client/src/account/masm/auth.ts
+++ b/packages/miden-multisig-client/src/account/masm/auth.ts
@@ -352,14 +352,20 @@ pub proc update_signers_and_threshold(multisig_config_hash: word)
     drop
     # => [pad(12)]
 
-    # compare initial vs current multisig config
-
-    # load init_num_of_approvers & new_num_of_approvers
     loc_load.0 loc_load.1
     # => [init_num_of_approvers, new_num_of_approvers, pad(12)]
 
-    exec.cleanup_pubkey_mapping
-    # => [pad(12)]
+    dup.1 dup.1
+    u32assert2 u32lt
+    # => [should_cleanup, init_num_of_approvers, new_num_of_approvers, pad(12)]
+
+    if.true
+        exec.cleanup_pubkey_mapping
+        # => [pad(12)]
+    else
+        drop drop
+        # => [pad(12)]
+    end
 end
 
 #! Update or clear the threshold override for a specific procedure.
@@ -902,14 +908,20 @@ pub proc update_signers_and_threshold(multisig_config_hash: word)
     drop
     # => [pad(12)]
 
-    # compare initial vs current multisig config
-
-    # load init_num_of_approvers & new_num_of_approvers
     loc_load.0 loc_load.1
     # => [init_num_of_approvers, new_num_of_approvers, pad(12)]
 
-    exec.cleanup_pubkey_mapping
-    # => [pad(12)]
+    dup.1 dup.1
+    u32assert2 u32lt
+    # => [should_cleanup, init_num_of_approvers, new_num_of_approvers, pad(12)]
+
+    if.true
+        exec.cleanup_pubkey_mapping
+        # => [pad(12)]
+    else
+        drop drop
+        # => [pad(12)]
+    end
 end
 
 #! Update or clear the threshold override for a specific procedure.

--- a/packages/miden-multisig-client/src/procedures.ts
+++ b/packages/miden-multisig-client/src/procedures.ts
@@ -13,7 +13,7 @@
 export const PROCEDURE_ROOTS = {
   update_signers: '0x3d382ad461f9914c487c6fe908991d088eb54ecbd4aa8560ef79c66c3746bf19',
   update_procedure_threshold: '0x1f43e9d56ceff5d547ffdcb89896fb38cae0be1b74d9235ed2b4aa525df85f8d',
-  auth_tx: '0x415530d7169f849d7219e810065f9119bba9af2c55070de0bf4f082a1c0aea5c',
+  auth_tx: '0x58156720b5dba3490a008a733e9f414363b4fb367bfdf36c324f3c2867372484',
   update_guardian: '0xc8ea876f1837e5cd1d6031becdbd40ce262ecd55930d65400f6890a37149d80c',
   verify_guardian: '0x9bc6e7b25c8dbaa29d6ad41e354a545dd0a4bac7f3a521bb5195ba101f0213cc',
   send_asset: '0x6d30df4312a2c44ec842db1bee227cc045396ca91e2c47d756dcb607f2bf5f89',


### PR DESCRIPTION
  Calling `exec.cleanup_pubkey_mapping` after `update_signers_and_threshold`
  unconditionally produces a STARK-invalid proof when the storage map has
  exactly one entry (e.g. add-signer from a 1-signer account). The proc's
  internal loop guard already short-circuits in this case, so the body never
  ran — but entering the proc at all perturbs the prover trace enough to fail
  node-side STARK verification with `constraint mismatch: quotient * vanishing
  != folded constraints`.

  Gate the call on `init_num_of_approvers > new_num_of_approvers` so cleanup
  only runs when the signer set actually shrinks. Add-signer and threshold-only
  updates skip the call entirely; remove-signer behavior is unchanged.
  Applied to both Falcon and ECDSA multisig MASM. The existing add-signer test
  is extended to call `prove_next_block()` so MockChain exercises proof
  generation and would catch this class of regression.


TODO: Open PR against https://github.com/OpenZeppelin/miden-confidential-contracts and verify with @onurinanc 
  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized multisig contract efficiency by making public key mapping cleanup conditional, now executing only when approver counts differ, with improvements applied to both standard and ECDSA contract variants

* **Tests**
  * Strengthened signer management tests by improving transaction handling and chain state progression to ensure proper validation after threshold updates

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenZeppelin/guardian/pull/259?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->