### PR TITLE
chore: Bump operator client to 0.14.7

### DIFF
--- a/packages/guardian-operator-client/package-lock.json
+++ b/packages/guardian-operator-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openzeppelin/guardian-operator-client",
-  "version": "0.14.6",
+  "version": "0.14.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openzeppelin/guardian-operator-client",
-      "version": "0.14.6",
+      "version": "0.14.7",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.7.2",

--- a/packages/guardian-operator-client/package.json
+++ b/packages/guardian-operator-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/guardian-operator-client",
-  "version": "0.14.6",
+  "version": "0.14.7",
   "description": "TypeScript HTTP client for Guardian operator dashboard endpoints",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released patch version update for the Guardian Operator Client package.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenZeppelin/guardian/pull/261?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->