### PR TITLE
chore(release): bump multisig SDK packages to 0.14.8

### DIFF
--- a/.agents/skills/smoke-test-rust-multisig-sdk/SKILL.md
+++ b/.agents/skills/smoke-test-rust-multisig-sdk/SKILL.md
@@ -39,8 +39,8 @@ Record the returned commitment — you'll paste it into the demo's "GUARDIAN com
 2. Declare the published crates as registry dependencies pinned to the release under test:
    ```toml
    [dependencies]
-   miden-multisig-client = "0.14.6"
-   guardian-client       = "0.14.6"
+   miden-multisig-client = "0.14.8"
+   guardian-client       = "0.14.8"
    miden-client          = "0.14.5"
    tokio                 = { version = "1", features = ["full"] }
    ```

--- a/.agents/skills/smoke-test-ts-multisig-sdk/SKILL.md
+++ b/.agents/skills/smoke-test-ts-multisig-sdk/SKILL.md
@@ -36,8 +36,8 @@ If the commitment does not round-trip into `status().multisig.guardianPubkey` af
    ```json
    {
      "dependencies": {
-       "@openzeppelin/miden-multisig-client": "0.14.6",
-       "@openzeppelin/guardian-client": "0.14.6",
+       "@openzeppelin/miden-multisig-client": "0.14.8",
+       "@openzeppelin/guardian-client": "0.14.8",
        "@miden-sdk/miden-sdk": "0.14.5"
      }
    }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2944,7 +2944,7 @@ dependencies = [
 
 [[package]]
 name = "guardian-client"
-version = "0.14.6"
+version = "0.14.8"
 dependencies = [
  "chrono",
  "guardian-shared",
@@ -3092,7 +3092,7 @@ dependencies = [
 
 [[package]]
 name = "guardian-shared"
-version = "0.14.6"
+version = "0.14.8"
 dependencies = [
  "base64",
  "hex",
@@ -4202,7 +4202,7 @@ dependencies = [
 
 [[package]]
 name = "miden-confidential-contracts"
-version = "0.14.6"
+version = "0.14.8"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4491,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "miden-multisig-client"
-version = "0.14.6"
+version = "0.14.8"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.14.6"
+version = "0.14.8"
 edition = "2024"
 rust-version = "1.93"
 authors = ["OpenZeppelin"]

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -11,7 +11,7 @@ description = "Client library for Guardian"
 include = ["src/**/*", "proto/**/*", "build.rs", "Cargo.toml", "LICENSE", "README.md"]
 
 [dependencies]
-guardian-shared = { version = "=0.14.6", path = "../shared" }
+guardian-shared = { version = "=0.14.8", path = "../shared" }
 miden-protocol = { version = "=0.14.5" }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/contracts/Cargo.toml
+++ b/crates/contracts/Cargo.toml
@@ -18,7 +18,7 @@ miden-testing = { version = "=0.14.5" }
 
 anyhow = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "net", "macros", "fs"] }
-guardian-shared = { version = "=0.14.6", path = "../shared" }
+guardian-shared = { version = "=0.14.8", path = "../shared" }
 
 [dev-dependencies]
 miden-client = { version = "=0.14.5", features = ["testing", "tonic"] }

--- a/crates/miden-multisig-client/Cargo.toml
+++ b/crates/miden-multisig-client/Cargo.toml
@@ -11,9 +11,9 @@ description = "High-level SDK for interacting with multisig accounts on Miden vi
 
 [dependencies]
 # Internal crates
-guardian-client = { version = "=0.14.6", path = "../client" }
-guardian-shared = { version = "=0.14.6", path = "../shared" }
-miden-confidential-contracts = { version = "=0.14.6", path = "../contracts" }
+guardian-client = { version = "=0.14.8", path = "../client" }
+guardian-shared = { version = "=0.14.8", path = "../shared" }
+miden-confidential-contracts = { version = "=0.14.8", path = "../contracts" }
 
 # Miden
 miden-client = { version = "=0.14.5", features = ["tonic", "testing"] }

--- a/examples/smoke-web/package-lock.json
+++ b/examples/smoke-web/package-lock.json
@@ -37,7 +37,7 @@
     },
     "../../packages/guardian-client": {
       "name": "@openzeppelin/guardian-client",
-      "version": "0.14.6",
+      "version": "0.14.8",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.7.2",
@@ -49,13 +49,13 @@
     },
     "../../packages/miden-multisig-client": {
       "name": "@openzeppelin/miden-multisig-client",
-      "version": "0.14.6",
+      "version": "0.14.8",
       "license": "MIT",
       "dependencies": {
         "@miden-sdk/miden-sdk": "0.14.5",
         "@noble/curves": "^1.9.7",
         "@noble/hashes": "^2.0.1",
-        "@openzeppelin/guardian-client": "^0.14.6"
+        "@openzeppelin/guardian-client": "^0.14.8"
       },
       "devDependencies": {
         "typescript": "^5.7.2",

--- a/packages/guardian-client/package-lock.json
+++ b/packages/guardian-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openzeppelin/guardian-client",
-  "version": "0.14.6",
+  "version": "0.14.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openzeppelin/guardian-client",
-      "version": "0.14.6",
+      "version": "0.14.8",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.7.2",

--- a/packages/guardian-client/package.json
+++ b/packages/guardian-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/guardian-client",
-  "version": "0.14.6",
+  "version": "0.14.8",
   "description": "TypeScript HTTP client for Guardian server",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/miden-multisig-client/package-lock.json
+++ b/packages/miden-multisig-client/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@openzeppelin/miden-multisig-client",
-  "version": "0.14.6",
+  "version": "0.14.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openzeppelin/miden-multisig-client",
-      "version": "0.14.6",
+      "version": "0.14.8",
       "license": "MIT",
       "dependencies": {
         "@miden-sdk/miden-sdk": "0.14.5",
         "@noble/curves": "^1.9.7",
         "@noble/hashes": "^2.0.1",
-        "@openzeppelin/guardian-client": "^0.14.6"
+        "@openzeppelin/guardian-client": "^0.14.8"
       },
       "devDependencies": {
         "typescript": "^5.7.2",
@@ -505,9 +505,9 @@
       }
     },
     "node_modules/@openzeppelin/guardian-client": {
-      "version": "0.14.6",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/guardian-client/-/guardian-client-0.14.6.tgz",
-      "integrity": "sha512-+obykBGEzTfdjODfdhyrdrlFL8A5SQ6rfeuUBGz0RJE2BAGN2jn6IcrJzKddUECW/3hrLukLCAuhqdzdW/KaPg==",
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/guardian-client/-/guardian-client-0.14.8.tgz",
+      "integrity": "sha512-L3gUUqD5T4s+dDAcQkGCXfBRz6xWc3DMObsjPb9XbXNLoDpP2Bj3JzuwS80/UfDxdamXoF79M0EpYbpS1h6QgQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/packages/miden-multisig-client/package.json
+++ b/packages/miden-multisig-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/miden-multisig-client",
-  "version": "0.14.6",
+  "version": "0.14.8",
   "description": "TypeScript SDK for Miden multisig accounts with GUARDIAN integration",
   "type": "module",
   "main": "./dist/index.js",
@@ -30,7 +30,7 @@
     "@noble/curves": "^1.9.7",
     "@miden-sdk/miden-sdk": "0.14.5",
     "@noble/hashes": "^2.0.1",
-    "@openzeppelin/guardian-client": "^0.14.6"
+    "@openzeppelin/guardian-client": "^0.14.8"
   },
   "devDependencies": {
     "typescript": "^5.7.2",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package versions from 0.14.6 to 0.14.8 across Rust and TypeScript SDKs.
  * Updated testing documentation to reflect the latest SDK versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenZeppelin/guardian/pull/263?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->