### PR TITLE
chore: Add docker-publish GH workflow release trigger and update docs

### DIFF
--- a/.agents/skills/release-guardian-sdk-packages/SKILL.md
+++ b/.agents/skills/release-guardian-sdk-packages/SKILL.md
@@ -190,7 +190,7 @@ The user should usually only need to handle:
 - `cargo login <CRATES_IO_TOKEN>` or equivalent registry auth check
 - `npm whoami` or `npm login`
 - any final publish confirmation the user wants to own
-- git tag creation and push
+- cutting the GitHub Release (`gh release create`), which also triggers the server image build
 
 When auth is missing or unverified, give a short ordered command sequence. Prefer:
 
@@ -205,10 +205,41 @@ If the user has already authenticated, continue with the automated prep and only
 
 After publishing:
 
-- ask the user whether to create and push the release tag
+- ask the user whether to cut the GitHub Release for the tag
 - verify the published versions if the task requires it
 
-Use:
+Cut the release with `gh`. Prefer `--draft` so the user can review notes and the
+tag before anything ships:
+
+```bash
+gh release create v<version> --generate-notes --draft
+```
+
+A **draft** release does not fire the `release: published` event, so the Docker
+Publish workflow stays idle while the draft is reviewed. Publish the draft when
+ready, which is what actually triggers the build:
+
+```bash
+gh release edit v<version> --draft=false
+```
+
+To skip the review step and publish immediately, omit `--draft`:
+
+```bash
+gh release create v<version> --generate-notes
+```
+
+Publishing a GitHub Release auto-triggers the **Docker Publish** workflow, which
+builds and pushes the Guardian server image for that tag. The build waits for
+required-reviewer approval on the `release` environment before it pushes:
+
+- approve the run when the release should also ship a server image
+- decline it for SDK-only releases (the SDK and server share the same `vX.Y.Z`
+  tag line, so every release reaches this gate)
+
+A plain `git tag` + `git push` does **not** create a release and will not trigger
+the server image build. Use it only when the server image is intentionally not
+wanted and no GitHub Release is being cut:
 
 ```bash
 git tag v<version>

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,6 +2,8 @@
 name: Docker Publish
 
 on:
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       version:
@@ -48,26 +50,48 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Resolve build parameters
+        id: params
+        env:
+          EVENT: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_BRANCH: ${{ inputs.branch }}
+          INPUT_FEATURES: ${{ inputs.features }}
+          INPUT_OVERWRITE: ${{ inputs.overwrite }}
+          LAUNCH_REF: ${{ github.ref_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [[ "$EVENT" == "release" ]]; then
+            version="$RELEASE_TAG"
+            ref="$RELEASE_TAG"
+            features="postgres"
+            overwrite="false"
+          else
+            version="$INPUT_VERSION"
+            ref="${INPUT_BRANCH:-$LAUNCH_REF}"
+            features="${INPUT_FEATURES:-postgres}"
+            overwrite="$INPUT_OVERWRITE"
+          fi
+          {
+            echo "version=$version"
+            echo "ref=$ref"
+            echo "features=$features"
+            echo "overwrite=$overwrite"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Validate version input
         env:
-          VERSION: ${{ inputs.version }}
+          VERSION: ${{ steps.params.outputs.version }}
         run: |
           if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
             echo "::error::Invalid version '$VERSION'. Expected a tag like v1.2.3 or a pre-release like v1.2.3-rc.1."
             exit 1
           fi
 
-      - name: Resolve build ref
-        id: ref
-        env:
-          INPUT_BRANCH: ${{ inputs.branch }}
-          LAUNCH_REF: ${{ github.ref_name }}
-        run: echo "ref=${INPUT_BRANCH:-$LAUNCH_REF}" >> "$GITHUB_OUTPUT"
-
       - name: Checkout build ref
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
-          ref: ${{ steps.ref.outputs.ref }}
+          ref: ${{ steps.params.outputs.ref }}
           persist-credentials: false
 
       - name: Resolve checked-out commit
@@ -79,7 +103,7 @@ jobs:
       - name: Determine full-release flag
         id: release
         env:
-          VERSION: ${{ inputs.version }}
+          VERSION: ${{ steps.params.outputs.version }}
         run: |
           if [[ "$VERSION" == *-* ]]; then
             echo "full=false" >> "$GITHUB_OUTPUT"
@@ -95,9 +119,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Reject already-published version
-        if: ${{ !inputs.overwrite }}
+        if: ${{ steps.params.outputs.overwrite != 'true' }}
         env:
-          VERSION: ${{ inputs.version }}
+          VERSION: ${{ steps.params.outputs.version }}
         run: |
           if docker manifest inspect "${IMAGE}:${VERSION}" > /dev/null 2>&1; then
             echo "::error::${IMAGE}:${VERSION} already exists. Re-run with overwrite=true to replace it."
@@ -117,16 +141,16 @@ jobs:
           images: ${{ env.IMAGE }}
           flavor: latest=false
           tags: |
-            type=raw,value=${{ inputs.version }}
+            type=raw,value=${{ steps.params.outputs.version }}
             type=raw,value=sha-${{ steps.commit.outputs.short }}
             type=raw,value=latest,enable=${{ steps.release.outputs.full == 'true' }}
           labels: |
             org.opencontainers.image.title=guardian
             org.opencontainers.image.vendor=openzeppelin
-            org.opencontainers.image.version=${{ inputs.version }}
+            org.opencontainers.image.version=${{ steps.params.outputs.version }}
             org.opencontainers.image.revision=${{ steps.commit.outputs.sha }}
-            org.openzeppelin.guardian.features=${{ inputs.features }}
-            org.openzeppelin.guardian.source-ref=${{ steps.ref.outputs.ref }}
+            org.openzeppelin.guardian.features=${{ steps.params.outputs.features }}
+            org.openzeppelin.guardian.source-ref=${{ steps.params.outputs.ref }}
 
       - name: Build and push
         id: build
@@ -137,7 +161,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
-            GUARDIAN_SERVER_FEATURES=${{ inputs.features }}
+            GUARDIAN_SERVER_FEATURES=${{ steps.params.outputs.features }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
@@ -156,7 +180,7 @@ jobs:
         env:
           TAGS: ${{ steps.meta.outputs.tags }}
           DIGEST: ${{ steps.build.outputs.digest }}
-          SOURCE_REF: ${{ steps.ref.outputs.ref }}
+          SOURCE_REF: ${{ steps.params.outputs.ref }}
           SHORT_SHA: ${{ steps.commit.outputs.short }}
         run: |
           {

--- a/docs/SERVER_AWS_DEPLOY.md
+++ b/docs/SERVER_AWS_DEPLOY.md
@@ -44,7 +44,24 @@ build the server from source for contributors; `docker-compose.registry.yml` pul
 the published image.
 
 Maintainers publish a version by running the **Docker Publish** GitHub Actions
-workflow (manual dispatch: pick the branch to build from and the version to tag).
+workflow one of two ways:
+
+- **On a GitHub Release.** Publishing a release auto-triggers the workflow: the
+  version and build ref come from the release tag, the build uses the `postgres`
+  feature, and an existing tag is never overwritten. The build first **waits for
+  required-reviewer approval** on the `release` environment before it pushes —
+  approve releases that should ship a server image, and decline ones that should
+  not (e.g. SDK-only releases that share the same `vX.Y.Z` tag line). A release
+  tag that does not match `vMAJOR.MINOR.PATCH[-prerelease]` fails the workflow.
+  Cutting the release as a **draft** (`gh release create … --draft`) does not
+  trigger the workflow — review it first, then publish the draft to start the build.
+- **Manual dispatch.** Pick the branch/tag/commit to build from, the version to
+  tag, the build features, and whether to overwrite an existing tag — for
+  off-release or one-off builds.
+
+In both cases a version containing `-` (e.g. `v1.2.3-rc.1`) is treated as a
+pre-release and does not move the `latest` tag.
+
 The AWS deploy below still builds and pushes to ECR via `scripts/aws-deploy.sh`;
 consuming the published GHCR image from the deploy flow is a separate, later change.
 


### PR DESCRIPTION
Improve GH Docker Release workflow by adding release trigger in addition to manual dispatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release process documentation with clearer guidance on publishing releases and managing draft vs. published releases.
  * Enhanced deployment documentation to explain GitHub Actions workflow behavior, including release tag validation and pre-release handling.

* **Chores**
  * Improved release automation to streamline the publish workflow for releases and manual dispatch scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->