### PR TITLE
fix: report the real version and git commit on the running server

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -99,6 +99,7 @@ jobs:
         run: |
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           echo "short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "short12=$(git rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Determine full-release flag
         id: release
@@ -162,7 +163,7 @@ jobs:
           push: true
           build-args: |
             GUARDIAN_SERVER_FEATURES=${{ steps.params.outputs.features }}
-            GUARDIAN_GIT_SHA=${{ steps.commit.outputs.sha }}
+            GUARDIAN_GIT_SHA=${{ steps.commit.outputs.short12 }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -162,6 +162,7 @@ jobs:
           push: true
           build-args: |
             GUARDIAN_SERVER_FEATURES=${{ steps.params.outputs.features }}
+            GUARDIAN_GIT_SHA=${{ steps.commit.outputs.sha }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "guardian-server"
-version = "0.1.0"
+version = "0.14.9"
 dependencies = [
  "alloy",
  "async-trait",

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,6 @@ FROM base-builder as server-builder
 
 # build.rs reads this to stamp the git commit; the build context has no .git to fall back on.
 ARG GUARDIAN_GIT_SHA
-# Also expose as ENV so a SHA change reliably invalidates the build cache.
-ENV GUARDIAN_GIT_SHA=${GUARDIAN_GIT_SHA}
 
 RUN if [ -n "$GUARDIAN_SERVER_FEATURES" ]; then \
       cargo build --release --package guardian-server --bin server --features "$GUARDIAN_SERVER_FEATURES"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,9 @@ COPY examples ./examples
 # Build for release (only server)
 FROM base-builder as server-builder
 
+# build.rs reads this to stamp the git commit; the build context has no .git to fall back on.
+ARG GUARDIAN_GIT_SHA
+
 RUN if [ -n "$GUARDIAN_SERVER_FEATURES" ]; then \
       cargo build --release --package guardian-server --bin server --features "$GUARDIAN_SERVER_FEATURES"; \
     else \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,8 @@ FROM base-builder as server-builder
 
 # build.rs reads this to stamp the git commit; the build context has no .git to fall back on.
 ARG GUARDIAN_GIT_SHA
+# Also expose as ENV so a SHA change reliably invalidates the build cache.
+ENV GUARDIAN_GIT_SHA=${GUARDIAN_GIT_SHA}
 
 RUN if [ -n "$GUARDIAN_SERVER_FEATURES" ]; then \
       cargo build --release --package guardian-server --bin server --features "$GUARDIAN_SERVER_FEATURES"; \

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "guardian-server"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 
 [lib]

--- a/crates/server/build.rs
+++ b/crates/server/build.rs
@@ -7,6 +7,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let git_sha = std::env::var("GUARDIAN_GIT_SHA")
         .ok()
+        .filter(|s| !s.is_empty())
         .or_else(|| {
             Command::new("git")
                 .args(["rev-parse", "--short=12", "HEAD"])

--- a/docs/openapi-client.json
+++ b/docs/openapi-client.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0",
       "identifier": "AGPL-3.0"
     },
-    "version": "0.1.0"
+    "version": "0.14.9"
   },
   "paths": {
     "/configure": {

--- a/docs/openapi-dashboard.json
+++ b/docs/openapi-dashboard.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0",
       "identifier": "AGPL-3.0"
     },
-    "version": "0.1.0"
+    "version": "0.14.9"
   },
   "paths": {
     "/auth/challenge": {

--- a/docs/openapi-evm.json
+++ b/docs/openapi-evm.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0",
       "identifier": "AGPL-3.0"
     },
-    "version": "0.1.0"
+    "version": "0.14.9"
   },
   "paths": {
     "/evm/accounts": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0",
       "identifier": "AGPL-3.0"
     },
-    "version": "0.1.0"
+    "version": "0.14.9"
   },
   "paths": {
     "/auth/challenge": {


### PR DESCRIPTION
A running Guardian reported the wrong version (always `0.1.0`) and, in the published image, an `unknown` git commit, so you couldn't tell which build was actually running.

This reports the real release version everywhere the server exposes it, and stamps the actual git commit into the published image.

Verified locally and from the built Docker image: the server now reports the real release version and git commit (previously `0.1.0` / `unknown`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened build pipeline with integrated Git commit tracking for improved deployment visibility.
  * Streamlined version management by adopting workspace-managed versioning across the codebase.

* **Documentation**
  * Updated API specification documentation to version 0.14.9 across all interface documentation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->