### PR TITLE
fix(multisig-client): fall back to toFelts() in wordElementToBigInt

### DIFF
--- a/packages/miden-multisig-client/src/utils/word.ts
+++ b/packages/miden-multisig-client/src/utils/word.ts
@@ -5,8 +5,15 @@ export function wordToHex(word: Word): string {
 }
 
 export function wordElementToBigInt(word: Word, index: number): bigint {
-  const elements = word.toU64s();
-  return index >= 0 && index < elements.length ? elements[index] : 0n;
+  if (index < 0 || index > 3) {
+    return 0n;
+  }
+  // The wallet-embedded 0.15 SDK exposes `toFelts()` but not `toU64s()` on
+  // storage-read Words (a published-0.15 .d.ts/glue gap), so fall back to
+  // toFelts — same element order, so indices are unchanged.
+  const elements: BigUint64Array | bigint[] =
+    typeof word.toU64s === 'function' ? word.toU64s() : word.toFelts().map(f => f.asInt());
+  return index < elements.length ? elements[index] : 0n;
 }
 
 export function wordToBytes(word: { toFelts: () => Array<{ asInt: () => bigint }> }): Uint8Array {


### PR DESCRIPTION
## What

`wordElementToBigInt` reads a `Word`'s elements via `word.toU64s()`. This adds a defensive fallback to `word.toFelts().map(f => f.asInt())` when `toU64s` isn't available at runtime (same element order, so the `index` semantics are unchanged). No behavior change when `toU64s` is present.

## Why

Embedding this package (built against `@miden-sdk/miden-sdk@0.15.0`) in the Miden wallet's multi-threaded SDK build, `AccountInspector.fromAccount` throws at runtime during `MultisigClient.load`:

```
TypeError: word.toU64s is not a function
    at wordElementToBigInt
    at AccountInspector.fromAccount
```

The storage-read `Word` from `account.storage().getItem(...)` exposes `toFelts()` but **not** `toU64s()` in that runtime, even though `Word.toU64s()` is declared in the `0.15.0` `.d.ts`. Because `load` runs the inspector for every multisig account, this blocked **all** multisig transactions (consume, send, switch-guardian).

`wordToBytes` in the same file already uses `toFelts()`, so the fallback only relies on API this package already depends on.

## Verification

- `src/utils/word.test.ts` + `src/inspector.test.ts` pass (the existing mocks provide `toU64s`, so they exercise the unchanged path).
- A full guardian-account flow — create → fund → consume notes → send — now passes end-to-end against a `0.15` guardian server (`GUARDIAN_NETWORK_TYPE=MidenDevnet`) on Miden devnet, driven through the wallet's e2e harness. Before this fix it failed at `MultisigClient.load`.

Targeted at `miden-v0-15-upgrade` since that's where the 0.15 SDK migration lives.