### PR TITLE
feat(ci): add npm publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,104 @@
+# Publish workflow for Guardian TypeScript packages
+# ================================================
+
+name: Publish NPM Packages
+
+on:
+  release:
+    types: [published]
+  push:
+    branches: ["release-workflows"]
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Dry run (skip actual publish)"
+        type: boolean
+        required: false
+        default: false
+
+concurrency:
+  group: publish-npm
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+  attestations: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      max-parallel: 1
+      matrix:
+        package:
+          - guardian-client
+          - guardian-evm-client
+          - guardian-operator-client
+          - miden-multisig-client
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout Repo
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Setup Node.js with npm trusted publishing
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        working-directory: packages/${{ matrix.package }}
+        run: npm ci
+
+      - name: Build
+        working-directory: packages/${{ matrix.package }}
+        run: npm run build
+
+      - name: Run tests
+        working-directory: packages/${{ matrix.package }}
+        run: npm test
+
+      - name: Check if version is already published
+        id: check-version
+        working-directory: packages/${{ matrix.package }}
+        run: |
+          set -euo pipefail
+          PACKAGE_NAME=$(jq -r '.name' package.json)
+          PACKAGE_VERSION=$(jq -r '.version' package.json)
+          echo "name=${PACKAGE_NAME}" >> "${GITHUB_OUTPUT}"
+          echo "version=${PACKAGE_VERSION}" >> "${GITHUB_OUTPUT}"
+
+          if npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version 2>/dev/null; then
+            echo "already_published=true" >> "${GITHUB_OUTPUT}"
+            echo "⚠️ ${PACKAGE_NAME}@${PACKAGE_VERSION} is already published — skipping."
+          else
+            echo "already_published=false" >> "${GITHUB_OUTPUT}"
+            echo "📦 ${PACKAGE_NAME}@${PACKAGE_VERSION} will be published."
+          fi
+
+      # - name: Publish to npm
+      #   if: steps.check-version.outputs.already_published == 'false' && !(github.event.inputs.dry-run == 'true')
+      #   working-directory: packages/${{ matrix.package }}
+      #   run: npm publish --provenance --access public
+      #   env:
+      #     NPM_CONFIG_PROVENANCE: true
+
+      - name: Publish to npm (dry run)
+        # if: steps.check-version.outputs.already_published == 'false' && github.event.inputs.dry-run == 'true'
+        working-directory: packages/${{ matrix.package }}
+        run: npm publish --provenance --access public --dry-run
+        env:
+          NPM_CONFIG_PROVENANCE: true
+
+      - name: Generate attestation
+        if: steps.check-version.outputs.already_published == 'false' && !(github.event.inputs.dry-run == 'true')
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
+        with:
+          subject-path: packages/${{ matrix.package }}
+          subject-name: ${{ steps.check-version.outputs.name }}@${{ steps.check-version.outputs.version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,8 +6,6 @@ name: Publish NPM Packages
 on:
   release:
     types: [published]
-  push:
-    branches: ["release-workflows"]
   workflow_dispatch:
     inputs:
       dry-run:
@@ -82,15 +80,15 @@ jobs:
             echo "📦 ${PACKAGE_NAME}@${PACKAGE_VERSION} will be published."
           fi
 
-      # - name: Publish to npm
-      #   if: steps.check-version.outputs.already_published == 'false' && !(github.event.inputs.dry-run == 'true')
-      #   working-directory: packages/${{ matrix.package }}
-      #   run: npm publish --provenance --access public
-      #   env:
-      #     NPM_CONFIG_PROVENANCE: true
+      - name: Publish to npm
+        if: steps.check-version.outputs.already_published == 'false' && !(github.event.inputs.dry-run == 'true')
+        working-directory: packages/${{ matrix.package }}
+        run: npm publish --provenance --access public
+        env:
+          NPM_CONFIG_PROVENANCE: true
 
       - name: Publish to npm (dry run)
-        # if: steps.check-version.outputs.already_published == 'false' && github.event.inputs.dry-run == 'true'
+        if: steps.check-version.outputs.already_published == 'false' && github.event.inputs.dry-run == 'true'
         working-directory: packages/${{ matrix.package }}
         run: npm publish --provenance --access public --dry-run
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: release
     strategy:
       fail-fast: true
       max-parallel: 1
@@ -49,6 +50,7 @@ jobs:
         with:
           node-version: "24"
           registry-url: https://registry.npmjs.org
+          package-manager-cache: false
 
       - name: Install dependencies
         working-directory: packages/${{ matrix.package }}


### PR DESCRIPTION
Adds npm publish workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated package publishing when a release is created or triggered manually.
  * Supports a dry-run mode to validate the publish process without releasing anything.
  * Prevents duplicate publishes by skipping package versions that are already on npm.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->