### PR TITLE
feat(server): file-based ACK secret provider for stable identity without AWS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,22 @@ GUARDIAN_STORAGE_PATH=.guardian/storage
 GUARDIAN_METADATA_PATH=.guardian/metadata
 GUARDIAN_KEYSTORE_PATH=.guardian/keystore
 
+# ACK signing identity
+# Where Guardian's ACK signing secrets come from. Determines whether the
+# Guardian keeps a stable identity across restarts.
+#   none  - (default outside prod) ephemeral keys, regenerated every restart.
+#           Each restart changes the on-chain ack-key commitment and freezes
+#           accounts that pinned the old one. Dev only.
+#   file  - load fixed keys from local files (stable identity, no AWS).
+#   aws   - (default when GUARDIAN_ENV=prod) AWS Secrets Manager.
+# GUARDIAN_ACK_SECRET_PROVIDER=file
+# For the `file` provider, point these at files holding the hex-encoded secret
+# keys. Generate the pair once with: cargo run -p guardian-server --bin ack-keygen
+# (prints {"falcon_secret_key":"<hex>","ecdsa_secret_key":"<hex>"}); write each
+# hex value to its own file, mounted read-only and kept out of version control.
+# GUARDIAN_ACK_FALCON_SECRET_PATH=.guardian/ack-falcon-secret-key
+# GUARDIAN_ACK_ECDSA_SECRET_PATH=.guardian/ack-ecdsa-secret-key
+
 # Optional Postgres Storage
 # Inside docker compose: host is "postgres" (the service name in docker-compose.postgres.yml)
 # DATABASE_URL=postgres://guardian:guardian_dev_password@postgres:5432/guardian

--- a/.env.example
+++ b/.env.example
@@ -18,8 +18,11 @@ GUARDIAN_KEYSTORE_PATH=.guardian/keystore
 # For the `file` provider, point these at files holding the hex-encoded secret
 # keys. Generate the pair once with: cargo run -p guardian-server --bin ack-keygen
 # (prints {"falcon_secret_key":"<hex>","ecdsa_secret_key":"<hex>"}); write each
-# hex value to its own file, mounted read-only and kept out of version control.
+# hex value to its own file and `chmod 600` it — on Unix the server refuses to
+# start if the file is readable by group/other. Keep them out of version control.
 # GUARDIAN_ACK_FALCON_SECRET_PATH=.guardian/ack-falcon-secret-key
+# The ECDSA path can be omitted when GUARDIAN_ACK_ECDSA_BACKEND=aws-kms (the key
+# comes from KMS and this file is never read).
 # GUARDIAN_ACK_ECDSA_SECRET_PATH=.guardian/ack-ecdsa-secret-key
 
 # Optional Postgres Storage

--- a/crates/server/src/ack/file_provider.rs
+++ b/crates/server/src/ack/file_provider.rs
@@ -30,14 +30,20 @@ const ENV_ACK_ECDSA_SECRET_PATH: &str = "GUARDIAN_ACK_ECDSA_SECRET_PATH";
 /// [`from_env`]: FileSecretProvider::from_env
 pub struct FileSecretProvider {
     falcon_secret_path: PathBuf,
-    ecdsa_secret_path: PathBuf,
+    /// `None` when `GUARDIAN_ACK_ECDSA_SECRET_PATH` is unset. The ECDSA secret
+    /// file is only read for the in-memory ECDSA backend; an `aws-kms` backend
+    /// signs with the KMS key and never calls [`ecdsa_secret_key`], so the path
+    /// is optional and only required to exist when actually consulted.
+    ///
+    /// [`ecdsa_secret_key`]: AckSecretProvider::ecdsa_secret_key
+    ecdsa_secret_path: Option<PathBuf>,
 }
 
 impl FileSecretProvider {
     pub fn from_env() -> Result<Self> {
         Ok(Self {
             falcon_secret_path: required_path(ENV_ACK_FALCON_SECRET_PATH)?,
-            ecdsa_secret_path: required_path(ENV_ACK_ECDSA_SECRET_PATH)?,
+            ecdsa_secret_path: optional_path(ENV_ACK_ECDSA_SECRET_PATH)?,
         })
     }
 
@@ -45,6 +51,7 @@ impl FileSecretProvider {
     where
         F: FnOnce(&[u8]) -> std::result::Result<T, String>,
     {
+        ensure_owner_only(path)?;
         // Read-and-wrap in one expression so the key bytes never bind to a bare
         // `String` (CONTRIBUTING.md, "Secrets in server memory").
         let contents = SecretString::new(std::fs::read_to_string(path).map_err(|error| {
@@ -70,7 +77,12 @@ impl AckSecretProvider for FileSecretProvider {
     }
 
     async fn ecdsa_secret_key(&self) -> Result<EcdsaSecretKey> {
-        self.parsed_secret_key(&self.ecdsa_secret_path, |secret_bytes| {
+        let path = self.ecdsa_secret_path.as_deref().ok_or_else(|| {
+            GuardianError::ConfigurationError(format!(
+                "{ENV_ACK_ECDSA_SECRET_PATH} is required for the in-memory ECDSA backend; set it or use GUARDIAN_ACK_ECDSA_BACKEND=aws-kms"
+            ))
+        })?;
+        self.parsed_secret_key(path, |secret_bytes| {
             EcdsaSecretKey::read_from_bytes(secret_bytes).map_err(|error| error.to_string())
         })
     }
@@ -97,6 +109,60 @@ fn required_path(env_var: &str) -> Result<PathBuf> {
     }
 }
 
+/// Like [`required_path`] but absent is allowed (`Ok(None)`); a set-but-blank
+/// value is still a misconfiguration.
+fn optional_path(env_var: &str) -> Result<Option<PathBuf>> {
+    match std::env::var(env_var) {
+        Ok(value) => {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                Err(GuardianError::ConfigurationError(format!(
+                    "{env_var} must not be blank when set"
+                )))
+            } else {
+                Ok(Some(PathBuf::from(trimmed)))
+            }
+        }
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => Err(GuardianError::ConfigurationError(format!(
+            "{env_var} must contain valid UTF-8"
+        ))),
+    }
+}
+
+/// Reject a secret file that any principal other than the owner can touch, the
+/// way OpenSSH guards private keys. These hold long-lived ACK signing keys, so a
+/// group/other-accessible file fails startup rather than loading silently.
+/// Unix-only; a no-op elsewhere (Windows ACLs are not modeled here).
+#[cfg(unix)]
+fn ensure_owner_only(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mode = std::fs::metadata(path)
+        .map_err(|error| {
+            GuardianError::ConfigurationError(format!(
+                "Failed to inspect ack secret file {}: {error}",
+                path.display()
+            ))
+        })?
+        .permissions()
+        .mode();
+
+    if mode & 0o077 != 0 {
+        return Err(GuardianError::ConfigurationError(format!(
+            "Ack secret file {} must not be accessible by group or others (set its permissions to 0600)",
+            path.display()
+        )));
+    }
+
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn ensure_owner_only(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
 #[cfg(all(test, not(any(feature = "integration", feature = "e2e"))))]
 mod tests {
     use super::*;
@@ -111,8 +177,19 @@ mod tests {
         dir
     }
 
+    /// Write a secret file with owner-only (`0600`) permissions so it passes
+    /// [`ensure_owner_only`].
+    fn write_secret(path: &Path, contents: impl AsRef<[u8]>) {
+        std::fs::write(path, contents).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        }
+    }
+
     fn write_hex(path: &Path, bytes: &[u8]) {
-        std::fs::write(path, hex::encode(bytes)).unwrap();
+        write_secret(path, hex::encode(bytes));
     }
 
     #[tokio::test]
@@ -126,7 +203,7 @@ mod tests {
         write_hex(&ecdsa_path, &ecdsa.to_bytes());
         let provider = FileSecretProvider {
             falcon_secret_path: falcon_path,
-            ecdsa_secret_path: ecdsa_path,
+            ecdsa_secret_path: Some(ecdsa_path),
         };
 
         assert_eq!(
@@ -148,7 +225,7 @@ mod tests {
         write_hex(&falcon_path, &falcon.to_bytes());
         let provider = FileSecretProvider {
             falcon_secret_path: falcon_path,
-            ecdsa_secret_path: dir.join("ecdsa"),
+            ecdsa_secret_path: None,
         };
 
         let first = provider.falcon_secret_key().await.unwrap();
@@ -165,14 +242,13 @@ mod tests {
         let dir = temp_dir("trim");
         let ecdsa = EcdsaSecretKey::new();
         let ecdsa_path = dir.join("ecdsa");
-        std::fs::write(
+        write_secret(
             &ecdsa_path,
             format!("  {}\n", hex::encode(ecdsa.to_bytes())),
-        )
-        .unwrap();
+        );
         let provider = FileSecretProvider {
             falcon_secret_path: dir.join("falcon"),
-            ecdsa_secret_path: ecdsa_path,
+            ecdsa_secret_path: Some(ecdsa_path),
         };
 
         assert_eq!(
@@ -186,7 +262,7 @@ mod tests {
     async fn missing_file_is_configuration_error() {
         let provider = FileSecretProvider {
             falcon_secret_path: PathBuf::from("/nonexistent/guardian/ack-falcon"),
-            ecdsa_secret_path: PathBuf::from("/nonexistent/guardian/ack-ecdsa"),
+            ecdsa_secret_path: Some(PathBuf::from("/nonexistent/guardian/ack-ecdsa")),
         };
         assert!(matches!(
             provider.falcon_secret_key().await,
@@ -198,15 +274,63 @@ mod tests {
     async fn invalid_hex_is_configuration_error() {
         let dir = temp_dir("badhex");
         let falcon_path = dir.join("falcon");
-        std::fs::write(&falcon_path, "nothex!!").unwrap();
+        write_secret(&falcon_path, "nothex!!");
         let provider = FileSecretProvider {
             falcon_secret_path: falcon_path,
-            ecdsa_secret_path: dir.join("ecdsa"),
+            ecdsa_secret_path: None,
         };
 
         let err = provider.falcon_secret_key().await.unwrap_err();
         assert!(
             matches!(err, GuardianError::ConfigurationError(message) if message.contains("hex"))
+        );
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    // The ECDSA file is only consulted by the in-memory backend; an aws-kms
+    // backend never calls `ecdsa_secret_key`, so an unset path must not block
+    // loading the Falcon key, yet must surface a clear error if consulted.
+    #[tokio::test]
+    async fn unset_ecdsa_path_loads_falcon_but_errors_only_when_ecdsa_consulted() {
+        let dir = temp_dir("ecdsa_opt");
+        let falcon = FalconSecretKey::new();
+        let falcon_path = dir.join("falcon");
+        write_hex(&falcon_path, &falcon.to_bytes());
+        let provider = FileSecretProvider {
+            falcon_secret_path: falcon_path,
+            ecdsa_secret_path: None,
+        };
+
+        assert_eq!(
+            provider.falcon_secret_key().await.unwrap().to_bytes(),
+            falcon.to_bytes()
+        );
+        let err = provider.ecdsa_secret_key().await.unwrap_err();
+        assert!(matches!(
+            err,
+            GuardianError::ConfigurationError(message)
+                if message.contains(ENV_ACK_ECDSA_SECRET_PATH)
+        ));
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn rejects_group_or_world_accessible_file() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = temp_dir("perms");
+        let falcon = FalconSecretKey::new();
+        let falcon_path = dir.join("falcon");
+        std::fs::write(&falcon_path, hex::encode(falcon.to_bytes())).unwrap();
+        std::fs::set_permissions(&falcon_path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        let provider = FileSecretProvider {
+            falcon_secret_path: falcon_path,
+            ecdsa_secret_path: None,
+        };
+
+        let err = provider.falcon_secret_key().await.unwrap_err();
+        assert!(
+            matches!(err, GuardianError::ConfigurationError(message) if message.contains("0600"))
         );
         std::fs::remove_dir_all(dir).ok();
     }

--- a/crates/server/src/ack/file_provider.rs
+++ b/crates/server/src/ack/file_provider.rs
@@ -45,15 +45,17 @@ impl FileSecretProvider {
     where
         F: FnOnce(&[u8]) -> std::result::Result<T, String>,
     {
-        let contents = std::fs::read_to_string(path).map_err(|error| {
+        // Read-and-wrap in one expression so the key bytes never bind to a bare
+        // `String` (CONTRIBUTING.md, "Secrets in server memory").
+        let contents = SecretString::new(std::fs::read_to_string(path).map_err(|error| {
             GuardianError::ConfigurationError(format!(
                 "Failed to read ack secret file {}: {error}",
                 path.display()
             ))
-        })?;
+        })?);
         decode_secret_key(
             &format!("Ack secret file {}", path.display()),
-            &SecretString::new(contents),
+            &contents,
             parser,
         )
     }

--- a/crates/server/src/ack/file_provider.rs
+++ b/crates/server/src/ack/file_provider.rs
@@ -1,0 +1,211 @@
+//! Local-file ACK secret provider: a stable Guardian identity without AWS.
+//!
+//! Reads hex-encoded Falcon and ECDSA ACK secret keys from files whose paths
+//! come from `GUARDIAN_ACK_FALCON_SECRET_PATH` and
+//! `GUARDIAN_ACK_ECDSA_SECRET_PATH`. This lets a self-hosted Guardian keep a
+//! fixed identity across restarts without AWS Secrets Manager. The file format
+//! is the hex string emitted by the `ack-keygen` binary — identical to what the
+//! Secrets Manager path stores — so the same key material is portable between
+//! the two.
+//!
+//! The alternative (no provider) mints a fresh keypair on every boot, which
+//! changes the on-chain ack-key commitment and freezes any account that pinned
+//! the old one (recovery then requires a per-account `SwitchGuardian`).
+
+use crate::error::{GuardianError, Result};
+use crate::secret::SecretString;
+use async_trait::async_trait;
+use miden_protocol::crypto::dsa::ecdsa_k256_keccak::SigningKey as EcdsaSecretKey;
+use miden_protocol::crypto::dsa::falcon512_poseidon2::SecretKey as FalconSecretKey;
+use miden_protocol::utils::serde::Deserializable;
+use std::path::{Path, PathBuf};
+
+use super::secrets_manager::{AckSecretProvider, decode_secret_key};
+
+const ENV_ACK_FALCON_SECRET_PATH: &str = "GUARDIAN_ACK_FALCON_SECRET_PATH";
+const ENV_ACK_ECDSA_SECRET_PATH: &str = "GUARDIAN_ACK_ECDSA_SECRET_PATH";
+
+/// Reads the ACK secrets from local files. Construct with [`from_env`].
+///
+/// [`from_env`]: FileSecretProvider::from_env
+pub struct FileSecretProvider {
+    falcon_secret_path: PathBuf,
+    ecdsa_secret_path: PathBuf,
+}
+
+impl FileSecretProvider {
+    pub fn from_env() -> Result<Self> {
+        Ok(Self {
+            falcon_secret_path: required_path(ENV_ACK_FALCON_SECRET_PATH)?,
+            ecdsa_secret_path: required_path(ENV_ACK_ECDSA_SECRET_PATH)?,
+        })
+    }
+
+    fn parsed_secret_key<T, F>(&self, path: &Path, parser: F) -> Result<T>
+    where
+        F: FnOnce(&[u8]) -> std::result::Result<T, String>,
+    {
+        let contents = std::fs::read_to_string(path).map_err(|error| {
+            GuardianError::ConfigurationError(format!(
+                "Failed to read ack secret file {}: {error}",
+                path.display()
+            ))
+        })?;
+        decode_secret_key(
+            &format!("Ack secret file {}", path.display()),
+            &SecretString::new(contents),
+            parser,
+        )
+    }
+}
+
+#[async_trait]
+impl AckSecretProvider for FileSecretProvider {
+    async fn falcon_secret_key(&self) -> Result<FalconSecretKey> {
+        self.parsed_secret_key(&self.falcon_secret_path, |secret_bytes| {
+            FalconSecretKey::read_from_bytes(secret_bytes).map_err(|error| error.to_string())
+        })
+    }
+
+    async fn ecdsa_secret_key(&self) -> Result<EcdsaSecretKey> {
+        self.parsed_secret_key(&self.ecdsa_secret_path, |secret_bytes| {
+            EcdsaSecretKey::read_from_bytes(secret_bytes).map_err(|error| error.to_string())
+        })
+    }
+}
+
+fn required_path(env_var: &str) -> Result<PathBuf> {
+    match std::env::var(env_var) {
+        Ok(value) => {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                Err(GuardianError::ConfigurationError(format!(
+                    "{env_var} must not be blank when GUARDIAN_ACK_SECRET_PROVIDER=file"
+                )))
+            } else {
+                Ok(PathBuf::from(trimmed))
+            }
+        }
+        Err(std::env::VarError::NotPresent) => Err(GuardianError::ConfigurationError(format!(
+            "{env_var} is required when GUARDIAN_ACK_SECRET_PROVIDER=file"
+        ))),
+        Err(std::env::VarError::NotUnicode(_)) => Err(GuardianError::ConfigurationError(format!(
+            "{env_var} must contain valid UTF-8"
+        ))),
+    }
+}
+
+#[cfg(all(test, not(any(feature = "integration", feature = "e2e"))))]
+mod tests {
+    use super::*;
+    use miden_protocol::utils::serde::Serializable;
+
+    fn temp_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "guardian_file_provider_{tag}_{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn write_hex(path: &Path, bytes: &[u8]) {
+        std::fs::write(path, hex::encode(bytes)).unwrap();
+    }
+
+    #[tokio::test]
+    async fn reads_falcon_and_ecdsa_secrets_from_files() {
+        let dir = temp_dir("read");
+        let falcon = FalconSecretKey::new();
+        let ecdsa = EcdsaSecretKey::new();
+        let falcon_path = dir.join("falcon");
+        let ecdsa_path = dir.join("ecdsa");
+        write_hex(&falcon_path, &falcon.to_bytes());
+        write_hex(&ecdsa_path, &ecdsa.to_bytes());
+        let provider = FileSecretProvider {
+            falcon_secret_path: falcon_path,
+            ecdsa_secret_path: ecdsa_path,
+        };
+
+        assert_eq!(
+            provider.falcon_secret_key().await.unwrap().to_bytes(),
+            falcon.to_bytes()
+        );
+        assert_eq!(
+            provider.ecdsa_secret_key().await.unwrap().to_bytes(),
+            ecdsa.to_bytes()
+        );
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    #[tokio::test]
+    async fn same_file_yields_same_identity_across_reads() {
+        let dir = temp_dir("stable");
+        let falcon = FalconSecretKey::new();
+        let falcon_path = dir.join("falcon");
+        write_hex(&falcon_path, &falcon.to_bytes());
+        let provider = FileSecretProvider {
+            falcon_secret_path: falcon_path,
+            ecdsa_secret_path: dir.join("ecdsa"),
+        };
+
+        let first = provider.falcon_secret_key().await.unwrap();
+        let second = provider.falcon_secret_key().await.unwrap();
+        assert_eq!(
+            first.public_key().to_commitment(),
+            second.public_key().to_commitment()
+        );
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    #[tokio::test]
+    async fn tolerates_surrounding_whitespace_in_file() {
+        let dir = temp_dir("trim");
+        let ecdsa = EcdsaSecretKey::new();
+        let ecdsa_path = dir.join("ecdsa");
+        std::fs::write(
+            &ecdsa_path,
+            format!("  {}\n", hex::encode(ecdsa.to_bytes())),
+        )
+        .unwrap();
+        let provider = FileSecretProvider {
+            falcon_secret_path: dir.join("falcon"),
+            ecdsa_secret_path: ecdsa_path,
+        };
+
+        assert_eq!(
+            provider.ecdsa_secret_key().await.unwrap().to_bytes(),
+            ecdsa.to_bytes()
+        );
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    #[tokio::test]
+    async fn missing_file_is_configuration_error() {
+        let provider = FileSecretProvider {
+            falcon_secret_path: PathBuf::from("/nonexistent/guardian/ack-falcon"),
+            ecdsa_secret_path: PathBuf::from("/nonexistent/guardian/ack-ecdsa"),
+        };
+        assert!(matches!(
+            provider.falcon_secret_key().await,
+            Err(GuardianError::ConfigurationError(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn invalid_hex_is_configuration_error() {
+        let dir = temp_dir("badhex");
+        let falcon_path = dir.join("falcon");
+        std::fs::write(&falcon_path, "nothex!!").unwrap();
+        let provider = FileSecretProvider {
+            falcon_secret_path: falcon_path,
+            ecdsa_secret_path: dir.join("ecdsa"),
+        };
+
+        let err = provider.falcon_secret_key().await.unwrap_err();
+        assert!(
+            matches!(err, GuardianError::ConfigurationError(message) if message.contains("hex"))
+        );
+        std::fs::remove_dir_all(dir).ok();
+    }
+}

--- a/crates/server/src/ack/mod.rs
+++ b/crates/server/src/ack/mod.rs
@@ -165,7 +165,8 @@ impl AckSecretProviderKind {
     /// reads concurrently). `raw` is the `GUARDIAN_ACK_SECRET_PROVIDER` value
     /// (`None` when unset); `is_prod` is whether `GUARDIAN_ENV=prod`. Unset or
     /// blank falls back to the backward-compatible default — AWS in prod,
-    /// ephemeral elsewhere — while an explicit value always wins.
+    /// ephemeral elsewhere — while an explicit value wins, except `none` is
+    /// refused in prod so a stable-identity deployment can't boot ephemeral.
     fn resolve(raw: Option<&str>, is_prod: bool) -> Result<Self> {
         let default = if is_prod { Self::Aws } else { Self::None };
         match raw.map(|value| value.trim().to_ascii_lowercase()) {
@@ -174,6 +175,12 @@ impl AckSecretProviderKind {
                 "" => Ok(default),
                 PROVIDER_AWS => Ok(Self::Aws),
                 PROVIDER_FILE => Ok(Self::File),
+                // Explicit `none` in prod would boot ephemeral keys and silently
+                // invalidate every account that pinned the on-chain commitment;
+                // refuse it rather than start with a throwaway identity.
+                PROVIDER_NONE if is_prod => Err(GuardianError::ConfigurationError(format!(
+                    "{ENV_ACK_SECRET_PROVIDER}=`{PROVIDER_NONE}` is not allowed when {ENV_GUARDIAN_ENV}=`{PROD_ENV}`"
+                ))),
                 PROVIDER_NONE => Ok(Self::None),
                 other => Err(GuardianError::ConfigurationError(format!(
                     "{ENV_ACK_SECRET_PROVIDER} `{other}` is not supported (expected `{PROVIDER_AWS}`, `{PROVIDER_FILE}`, or `{PROVIDER_NONE}`)"
@@ -400,9 +407,17 @@ mod tests {
     }
 
     #[test]
-    fn provider_kind_explicit_none_overrides_prod_default() {
+    fn provider_kind_rejects_explicit_none_in_prod() {
+        let error = AckSecretProviderKind::resolve(Some("none"), true).unwrap_err();
+        assert!(
+            matches!(error, GuardianError::ConfigurationError(message) if message.contains("not allowed"))
+        );
+    }
+
+    #[test]
+    fn provider_kind_explicit_none_allowed_outside_prod() {
         assert_eq!(
-            AckSecretProviderKind::resolve(Some("none"), true).unwrap(),
+            AckSecretProviderKind::resolve(Some("none"), false).unwrap(),
             AckSecretProviderKind::None
         );
     }

--- a/crates/server/src/ack/mod.rs
+++ b/crates/server/src/ack/mod.rs
@@ -6,6 +6,7 @@
 //! concrete. The two are built independently at startup: a hosted ECDSA backend
 //! must not require an ECDSA secret in Secrets Manager that does not exist.
 
+mod file_provider;
 pub mod miden_ecdsa;
 pub mod miden_falcon_rpo;
 mod secrets_manager;
@@ -17,6 +18,7 @@ use miden_protocol::crypto::dsa::ecdsa_k256_keccak::SigningKey as EcdsaSecretKey
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use self::file_provider::FileSecretProvider;
 use self::secrets_manager::{AckSecretProvider, AwsSecretsManagerProvider};
 
 pub(crate) use miden_ecdsa::{
@@ -27,6 +29,10 @@ pub use miden_falcon_rpo::MidenFalconRpoSigner;
 
 const ENV_GUARDIAN_ENV: &str = "GUARDIAN_ENV";
 const PROD_ENV: &str = "prod";
+const ENV_ACK_SECRET_PROVIDER: &str = "GUARDIAN_ACK_SECRET_PROVIDER";
+const PROVIDER_AWS: &str = "aws";
+const PROVIDER_FILE: &str = "file";
+const PROVIDER_NONE: &str = "none";
 
 /// The ECDSA signer is abstracted over [`EcdsaSignerBackend`] so its key can live
 /// in a hosted backend (e.g. AWS KMS); Falcon stays concrete because hosted
@@ -40,17 +46,8 @@ pub struct AckRegistry {
 impl AckRegistry {
     pub async fn new(keystore_path: PathBuf) -> Result<Self> {
         let ecdsa_backend = EcdsaBackendKind::from_env()?;
-        if is_prod_environment()? {
-            let provider = AwsSecretsManagerProvider::from_env().await?;
-            Self::from_provider(keystore_path, ecdsa_backend, Some(&provider)).await
-        } else {
-            Self::from_provider(
-                keystore_path,
-                ecdsa_backend,
-                None::<&AwsSecretsManagerProvider>,
-            )
-            .await
-        }
+        let provider = AckSecretProviderKind::from_env()?.build().await?;
+        Self::from_provider(keystore_path, ecdsa_backend, provider.as_deref()).await
     }
 
     pub fn pubkey(&self, scheme: &SignatureScheme) -> String {
@@ -82,7 +79,7 @@ impl AckRegistry {
         }
     }
 
-    async fn from_provider<P: AckSecretProvider>(
+    async fn from_provider<P: AckSecretProvider + ?Sized>(
         keystore_path: PathBuf,
         ecdsa_backend: EcdsaBackendKind,
         provider: Option<&P>,
@@ -93,7 +90,7 @@ impl AckRegistry {
     }
 }
 
-async fn build_falcon_signer<P: AckSecretProvider>(
+async fn build_falcon_signer<P: AckSecretProvider + ?Sized>(
     keystore_path: &Path,
     provider: Option<&P>,
 ) -> Result<MidenFalconRpoSigner> {
@@ -107,7 +104,7 @@ async fn build_falcon_signer<P: AckSecretProvider>(
     )?)
 }
 
-async fn acquire_ecdsa_secret<P: AckSecretProvider>(
+async fn acquire_ecdsa_secret<P: AckSecretProvider + ?Sized>(
     ecdsa_backend: EcdsaBackendKind,
     provider: Option<&P>,
 ) -> Result<Option<EcdsaSecretKey>> {
@@ -119,7 +116,7 @@ async fn acquire_ecdsa_secret<P: AckSecretProvider>(
     }
 }
 
-async fn build_ecdsa_signer<P: AckSecretProvider>(
+async fn build_ecdsa_signer<P: AckSecretProvider + ?Sized>(
     keystore_path: PathBuf,
     ecdsa_backend: EcdsaBackendKind,
     provider: Option<&P>,
@@ -133,6 +130,67 @@ async fn build_ecdsa_signer<P: AckSecretProvider>(
     };
     tracing::info!(backend = backend.backend_id(), "ECDSA ACK signer ready");
     Ok(MidenEcdsaSigner::new(backend))
+}
+
+/// Selects where the ACK signing secrets come from at startup, and thus whether
+/// Guardian keeps a stable identity. [`Aws`](Self::Aws) and [`File`](Self::File)
+/// both supply fixed key material; [`None`](Self::None) generates an ephemeral
+/// keypair on every boot, so the on-chain ack-key commitment changes each
+/// restart and freezes any account that pinned the previous one. Selected by
+/// `GUARDIAN_ACK_SECRET_PROVIDER`; when unset it defaults to AWS in prod and
+/// ephemeral elsewhere, preserving the historical behavior.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AckSecretProviderKind {
+    Aws,
+    File,
+    None,
+}
+
+impl AckSecretProviderKind {
+    fn from_env() -> Result<Self> {
+        let raw = match std::env::var(ENV_ACK_SECRET_PROVIDER) {
+            Ok(value) => Some(value),
+            Err(std::env::VarError::NotPresent) => None,
+            Err(std::env::VarError::NotUnicode(_)) => {
+                return Err(GuardianError::ConfigurationError(format!(
+                    "{ENV_ACK_SECRET_PROVIDER} must contain valid UTF-8"
+                )));
+            }
+        };
+        Self::resolve(raw.as_deref(), is_prod_environment()?)
+    }
+
+    /// Pure resolution of the provider kind, split out from [`from_env`] so it is
+    /// testable without mutating process-global env vars (which `AckRegistry::new`
+    /// reads concurrently). `raw` is the `GUARDIAN_ACK_SECRET_PROVIDER` value
+    /// (`None` when unset); `is_prod` is whether `GUARDIAN_ENV=prod`. Unset or
+    /// blank falls back to the backward-compatible default — AWS in prod,
+    /// ephemeral elsewhere — while an explicit value always wins.
+    fn resolve(raw: Option<&str>, is_prod: bool) -> Result<Self> {
+        let default = if is_prod { Self::Aws } else { Self::None };
+        match raw.map(|value| value.trim().to_ascii_lowercase()) {
+            None => Ok(default),
+            Some(value) => match value.as_str() {
+                "" => Ok(default),
+                PROVIDER_AWS => Ok(Self::Aws),
+                PROVIDER_FILE => Ok(Self::File),
+                PROVIDER_NONE => Ok(Self::None),
+                other => Err(GuardianError::ConfigurationError(format!(
+                    "{ENV_ACK_SECRET_PROVIDER} `{other}` is not supported (expected `{PROVIDER_AWS}`, `{PROVIDER_FILE}`, or `{PROVIDER_NONE}`)"
+                ))),
+            },
+        }
+    }
+
+    /// Constructs the selected provider. `None` means no provider — the signers
+    /// fall back to ephemeral keys generated in the keystore.
+    async fn build(self) -> Result<Option<Box<dyn AckSecretProvider>>> {
+        match self {
+            Self::Aws => Ok(Some(Box::new(AwsSecretsManagerProvider::from_env().await?))),
+            Self::File => Ok(Some(Box::new(FileSecretProvider::from_env()?))),
+            Self::None => Ok(None),
+        }
+    }
 }
 
 fn is_prod_environment() -> Result<bool> {
@@ -300,5 +358,68 @@ mod tests {
 
         assert_eq!(provider.falcon_calls.load(Ordering::SeqCst), 1);
         std::fs::remove_dir_all(dir).ok();
+    }
+
+    // `AckSecretProviderKind::resolve` is the pure core of provider selection;
+    // it is tested directly so these cases never mutate the process-global env
+    // vars that `AckRegistry::new` reads concurrently in other tests.
+    #[test]
+    fn provider_kind_unset_defaults_to_none_outside_prod() {
+        assert_eq!(
+            AckSecretProviderKind::resolve(None, false).unwrap(),
+            AckSecretProviderKind::None
+        );
+    }
+
+    #[test]
+    fn provider_kind_unset_defaults_to_aws_in_prod() {
+        assert_eq!(
+            AckSecretProviderKind::resolve(None, true).unwrap(),
+            AckSecretProviderKind::Aws
+        );
+    }
+
+    #[test]
+    fn provider_kind_blank_falls_back_to_default() {
+        assert_eq!(
+            AckSecretProviderKind::resolve(Some("   "), true).unwrap(),
+            AckSecretProviderKind::Aws
+        );
+        assert_eq!(
+            AckSecretProviderKind::resolve(Some(""), false).unwrap(),
+            AckSecretProviderKind::None
+        );
+    }
+
+    #[test]
+    fn provider_kind_explicit_file_overrides_prod_default() {
+        assert_eq!(
+            AckSecretProviderKind::resolve(Some("FILE"), true).unwrap(),
+            AckSecretProviderKind::File
+        );
+    }
+
+    #[test]
+    fn provider_kind_explicit_none_overrides_prod_default() {
+        assert_eq!(
+            AckSecretProviderKind::resolve(Some("none"), true).unwrap(),
+            AckSecretProviderKind::None
+        );
+    }
+
+    #[test]
+    fn provider_kind_explicit_aws_selected_outside_prod() {
+        assert_eq!(
+            AckSecretProviderKind::resolve(Some("aws"), false).unwrap(),
+            AckSecretProviderKind::Aws
+        );
+    }
+
+    #[test]
+    fn provider_kind_rejects_unknown_value() {
+        let error = AckSecretProviderKind::resolve(Some("vault"), false).unwrap_err();
+        assert!(
+            matches!(error, GuardianError::ConfigurationError(message) if message.contains("vault"))
+        );
     }
 }

--- a/crates/server/src/ack/secrets_manager.rs
+++ b/crates/server/src/ack/secrets_manager.rs
@@ -68,20 +68,35 @@ impl AwsSecretsManagerProvider {
         F: FnOnce(&[u8]) -> std::result::Result<T, String>,
     {
         let secret_hex = self.secret_string(secret_id).await?;
-        let secret_bytes = SecretBytes::new(
-            hex::decode(secret_hex.expose_secret().trim()).map_err(|error| {
-                GuardianError::ConfigurationError(format!(
-                    "Secret {secret_id} must contain valid hex-encoded key bytes: {error}"
-                ))
-            })?,
-        );
-
-        parser(secret_bytes.expose_secret()).map_err(|error| {
-            GuardianError::ConfigurationError(format!(
-                "Secret {secret_id} does not contain a valid key: {error}"
-            ))
-        })
+        decode_secret_key(&format!("Secret {secret_id}"), &secret_hex, parser)
     }
+}
+
+/// Hex-decode a secret string into key bytes and parse them, mapping both
+/// failure modes to [`GuardianError::ConfigurationError`]. Shared by every
+/// [`AckSecretProvider`] so the on-disk key-material format is identical no
+/// matter where the hex came from (Secrets Manager, a local file, ...).
+/// `label` names the source in error messages (e.g. `"Secret <id>"`,
+/// `"Ack secret file <path>"`).
+pub(super) fn decode_secret_key<T, F>(
+    label: &str,
+    secret_hex: &SecretString,
+    parser: F,
+) -> Result<T>
+where
+    F: FnOnce(&[u8]) -> std::result::Result<T, String>,
+{
+    let secret_bytes = SecretBytes::new(hex::decode(secret_hex.expose_secret().trim()).map_err(
+        |error| {
+            GuardianError::ConfigurationError(format!(
+                "{label} must contain valid hex-encoded key bytes: {error}"
+            ))
+        },
+    )?);
+
+    parser(secret_bytes.expose_secret()).map_err(|error| {
+        GuardianError::ConfigurationError(format!("{label} does not contain a valid key: {error}"))
+    })
 }
 
 #[async_trait]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -80,7 +80,7 @@ DATABASE_URL=postgres://guardian:guardian@localhost:5432/guardian
 
 | Variable | Default | Notes |
 |---|---|---|
-| `GUARDIAN_ENV` | _unset_ | Set to `prod` to load ACK keys from AWS Secrets Manager. Anything else (or unset) uses filesystem keystore and auto-generates if absent. |
+| `GUARDIAN_ENV` | _unset_ | Selects the **default** ACK secret source: `prod` → AWS Secrets Manager; anything else (or unset) → ephemeral filesystem keys, regenerated each restart. Override explicitly with `GUARDIAN_ACK_SECRET_PROVIDER` (below) — e.g. `file` for a stable identity without AWS. |
 | `AWS_REGION` | _unset_ | **Required** when `GUARDIAN_ENV=prod`. Region for Secrets Manager calls. |
 | `GUARDIAN_NETWORK_TYPE` | `MidenDevnet` | Miden network identifier (`MidenDevnet`, `MidenTestnet`, etc.). Required only when you need a non-default network. Pins which Miden RPC and on-chain consensus the server speaks to. |
 
@@ -92,6 +92,22 @@ and falls back to fixed defaults when they're unset
 |---|---|---|
 | `GUARDIAN_ACK_FALCON_SECRET_ID` | `guardian-prod/server/ack-falcon-secret-key` | Secrets Manager name/ARN for the Falcon ACK secret key. |
 | `GUARDIAN_ACK_ECDSA_SECRET_ID` | `guardian-prod/server/ack-ecdsa-secret-key` | Secrets Manager name/ARN for the ECDSA ACK secret key. Used only when the ECDSA backend is `in-memory`. |
+
+### ACK secret provider (stable identity without AWS)
+
+Outside prod the default (`GUARDIAN_ACK_SECRET_PROVIDER=none`) generates a fresh
+ACK keypair on every restart, which changes the Guardian's on-chain ack-key
+commitment and freezes accounts that pinned the old one. Set the provider to
+`file` to load fixed keys from local files instead — a stable identity without
+AWS Secrets Manager. Each file holds the hex string emitted by `ack-keygen`
+(identical to what Secrets Manager stores). See the
+[Secrets runbook](./runbooks/secrets.md#self-hosted-stable-identity-without-aws).
+
+| Variable | Default | Notes |
+|---|---|---|
+| `GUARDIAN_ACK_SECRET_PROVIDER` | `aws` when `GUARDIAN_ENV=prod`, else `none` | Source of the ACK signing keys: `aws` (Secrets Manager), `file` (local files), or `none` (ephemeral, dev only). An unrecognized value fails startup; `none` is rejected when `GUARDIAN_ENV=prod`. |
+| `GUARDIAN_ACK_FALCON_SECRET_PATH` | _unset_ | **Required** when `GUARDIAN_ACK_SECRET_PROVIDER=file`. Path to a file holding the hex-encoded Falcon ACK secret key. On Unix the file must be owner-only (mode `0600`) or startup fails. |
+| `GUARDIAN_ACK_ECDSA_SECRET_PATH` | _unset_ | **Required** when `GUARDIAN_ACK_SECRET_PROVIDER=file`, **unless** `GUARDIAN_ACK_ECDSA_BACKEND=aws-kms` (then the ECDSA key comes from KMS and this file is never read). Path to the hex-encoded ECDSA ACK secret key; same `0600` requirement. |
 
 ### Storage encryption at rest
 

--- a/docs/runbooks/secrets.md
+++ b/docs/runbooks/secrets.md
@@ -102,11 +102,16 @@ cargo run --quiet -p guardian-server --bin ack-keygen \
 chmod 600 ack-falcon-secret-key ack-ecdsa-secret-key
 ```
 
-Treat these files like any private key: mount them read-only (Docker/k8s
-secrets, a `0600` file on disk), keep them out of version control and image
-layers, and back them up — losing them is a Guardian identity change, with the
-same `SwitchGuardian` migration path described above. The ECDSA file is unused
-when `GUARDIAN_ACK_ECDSA_BACKEND=aws-kms`; Falcon is always read from its file.
+Treat these files like any private key: keep them out of version control and
+image layers, and back them up — losing them is a Guardian identity change, with
+the same `SwitchGuardian` migration path described above. On Unix the server
+**enforces** owner-only permissions and refuses to start if the file is readable
+by group or others, so a bare file on disk must be `0600` and a Kubernetes secret
+mount needs `defaultMode: 0400` (the `0644` default is rejected).
+
+With `GUARDIAN_ACK_ECDSA_BACKEND=aws-kms` the ECDSA key comes from KMS and its
+file is never read, so you can omit `GUARDIAN_ACK_ECDSA_SECRET_PATH` entirely on
+that path; only the Falcon file is required.
 
 ### Hosted ECDSA backend (AWS KMS)
 

--- a/docs/runbooks/secrets.md
+++ b/docs/runbooks/secrets.md
@@ -66,6 +66,48 @@ accounts will fail with a Guardian commitment mismatch. A `SwitchGuardian`
 proposal is the account-level migration path for changing that stored
 commitment.
 
+### Where the ACK secrets come from
+
+`GUARDIAN_ACK_SECRET_PROVIDER` selects the source of the ACK signing keys:
+
+| Value | Source | Default for | Identity |
+|---|---|---|---|
+| `aws` | AWS Secrets Manager (IDs from `GUARDIAN_ACK_{FALCON,ECDSA}_SECRET_ID`) | `GUARDIAN_ENV=prod` | Stable |
+| `file` | Local files (paths from `GUARDIAN_ACK_{FALCON,ECDSA}_SECRET_PATH`) | — | Stable |
+| `none` | Ephemeral keys generated in the keystore on every boot | everything else | **Changes every restart** |
+
+When unset, it falls back to the historical behavior: `aws` in prod,
+`none` otherwise. The `none` path is dev-only — a fresh identity on each
+restart freezes every account that pinned the previous commitment, with
+per-account `SwitchGuardian` as the only recovery.
+
+### Self-hosted: stable identity without AWS
+
+A self-hosted, non-AWS Guardian keeps a fixed identity with the `file`
+provider. Set `GUARDIAN_ACK_SECRET_PROVIDER=file` and point
+`GUARDIAN_ACK_FALCON_SECRET_PATH` / `GUARDIAN_ACK_ECDSA_SECRET_PATH` at files
+holding the hex-encoded secret keys
+([`file_provider.rs`](../../crates/server/src/ack/file_provider.rs)). The file
+format is the hex string emitted by `ack-keygen` — identical to what Secrets
+Manager stores — so the same key material is portable between the two providers.
+
+Generate the pair once and write each value to its own file:
+
+```bash
+cargo run --quiet -p guardian-server --bin ack-keygen \
+  | tee /dev/stderr \
+  | { read -r json; \
+      jq -rj '.falcon_secret_key' <<<"$json" > ack-falcon-secret-key; \
+      jq -rj '.ecdsa_secret_key'  <<<"$json" > ack-ecdsa-secret-key; }
+chmod 600 ack-falcon-secret-key ack-ecdsa-secret-key
+```
+
+Treat these files like any private key: mount them read-only (Docker/k8s
+secrets, a `0600` file on disk), keep them out of version control and image
+layers, and back them up — losing them is a Guardian identity change, with the
+same `SwitchGuardian` migration path described above. The ECDSA file is unused
+when `GUARDIAN_ACK_ECDSA_BACKEND=aws-kms`; Falcon is always read from its file.
+
 ### Hosted ECDSA backend (AWS KMS)
 
 The ECDSA ACK signer can be backed by AWS KMS instead of a Secrets Manager


### PR DESCRIPTION
## Summary

Closes #289.

A self-hosted Guardian outside prod gets a **new identity on every restart**. The only `AckSecretProvider` is `AwsSecretsManagerProvider`, so the non-AWS path falls through to `keystore.generate_key()` / `generate_ecdsa_key()`, which mint a fresh keypair each boot. Because each multisig account pins the Guardian's ack-key commitment on-chain and the client refuses to co-sign on a mismatch, a changing identity freezes accounts — recovery requires a per-account `SwitchGuardian`.

This adds a local **file** secret provider so a non-AWS deployment can keep a fixed identity.

## What changed

- **New `FileSecretProvider`** (`crates/server/src/ack/file_provider.rs`) — loads hex-encoded Falcon + ECDSA secret keys from files named by `GUARDIAN_ACK_FALCON_SECRET_PATH` / `GUARDIAN_ACK_ECDSA_SECRET_PATH`. The file format is the hex string emitted by `ack-keygen` (identical to what Secrets Manager stores), so key material is portable between the AWS and file providers.
- **Provider selection** via `GUARDIAN_ACK_SECRET_PROVIDER` (`aws` / `file` / `none`), modeled as `AckSecretProviderKind`. `AckRegistry::new` now builds the chosen provider through `&dyn AckSecretProvider` (the signer helpers gained `+ ?Sized`, which also removed the old `None::<&AwsSecretsManagerProvider>` placeholder).
- **Shared parsing** — the hex-decode-and-parse step is factored into `decode_secret_key`, used by both providers (no behavior change for AWS).
- **Docs** — `.env.example` and a new "Self-hosted: stable identity without AWS" section in `docs/runbooks/secrets.md`, with the `ack-keygen` recipe and key-handling guidance.

## Backward compatibility

Fully preserved. With `GUARDIAN_ACK_SECRET_PROVIDER` unset, selection defaults to AWS in prod and ephemeral elsewhere — identical to today. An explicit value always wins.

## Usage

```bash
# Generate the key pair once
cargo run -p guardian-server --bin ack-keygen
# -> {"falcon_secret_key":"<hex>","ecdsa_secret_key":"<hex>"}

# Write each hex value to its own file, then:
export GUARDIAN_ACK_SECRET_PROVIDER=file
export GUARDIAN_ACK_FALCON_SECRET_PATH=/path/to/ack-falcon-secret-key
export GUARDIAN_ACK_ECDSA_SECRET_PATH=/path/to/ack-ecdsa-secret-key


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable ACK signing secret sources, including file-based, AWS, and ephemeral modes.
  * Introduced support for loading signing secrets from local files for self-hosted setups.
* **Bug Fixes**
  * Improved validation and error handling for missing, blank, or invalid secret configuration.
  * Unified secret parsing behavior so key handling is more consistent across supported sources.
* **Documentation**
  * Updated setup guidance and operational notes for secret configuration and safe file handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->