### PR TITLE
feat(server): release accounts on canonicalized guardian switch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3245,6 +3245,8 @@ dependencies = [
  "miden-protocol",
  "miden-rpc-client",
  "miden-standards",
+ "miden-testing",
+ "miden-tx",
  "pin-project-lite",
  "prost",
  "rand 0.9.2",

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -72,6 +72,8 @@ diesel_migrations = { version = "2.2", optional = true }
 # Optional dependencies for e2e tests
 miden-client = { workspace = true, features = ["testing"], optional = true }
 miden-confidential-contracts = { path = "../contracts", optional = true }
+miden-testing = { workspace = true, optional = true }
+miden-tx = { workspace = true, optional = true }
 
 [build-dependencies]
 tonic-prost-build = { workspace = true }
@@ -102,4 +104,4 @@ postgres = [
     "tokio-postgres-rustls",
 ]
 integration = []
-e2e = ["miden-client", "miden-confidential-contracts"]
+e2e = ["miden-client", "miden-confidential-contracts", "miden-testing", "miden-tx"]

--- a/crates/server/migrations/2026-07-06-000001_account_released_field/down.sql
+++ b/crates/server/migrations/2026-07-06-000001_account_released_field/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_account_metadata_released;
+ALTER TABLE account_metadata DROP COLUMN IF EXISTS released_at;

--- a/crates/server/migrations/2026-07-06-000001_account_released_field/up.sql
+++ b/crates/server/migrations/2026-07-06-000001_account_released_field/up.sql
@@ -1,0 +1,14 @@
+-- Issue #305: release-on-guardian-switch. `released_at` marks the UTC
+-- instant this server detected (via a canonicalized SwitchGuardian
+-- delta) that it is no longer the account's guardian. NULL while this
+-- server is the guardian. Terminal until the account re-onboards via
+-- /configure; owned by set_released / clear_released at the trait
+-- level — generic metadata writes never change it. Orthogonal to
+-- paused_at so an operator unpause cannot resurrect a released account.
+ALTER TABLE account_metadata ADD COLUMN released_at TIMESTAMPTZ NULL;
+
+-- Partial index supports "list all released accounts" cheaply; size
+-- scales with the count of released accounts, not total accounts.
+CREATE INDEX IF NOT EXISTS idx_account_metadata_released
+    ON account_metadata(released_at)
+    WHERE released_at IS NOT NULL;

--- a/crates/server/src/api/dashboard.rs
+++ b/crates/server/src/api/dashboard.rs
@@ -592,6 +592,7 @@ mod tests {
             last_auth_timestamp: None,
             paused_at: None,
             paused_reason: None,
+            released_at: None,
         };
         state
             .metadata
@@ -1130,6 +1131,7 @@ mod tests {
             last_auth_timestamp: None,
             paused_at: None,
             paused_reason: None,
+            released_at: None,
         }
     }
 

--- a/crates/server/src/api/dashboard_feeds.rs
+++ b/crates/server/src/api/dashboard_feeds.rs
@@ -453,6 +453,7 @@ mod tests {
             last_auth_timestamp: None,
             paused_at: None,
             paused_reason: None,
+            released_at: None,
         }
     }
 

--- a/crates/server/src/api/grpc.rs
+++ b/crates/server/src/api/grpc.rs
@@ -579,6 +579,7 @@ mod tests {
             last_auth_timestamp: None,
             paused_at: None,
             paused_reason: None,
+            released_at: None,
         }
     }
 

--- a/crates/server/src/api/http.rs
+++ b/crates/server/src/api/http.rs
@@ -688,6 +688,7 @@ mod tests {
             last_auth_timestamp: None,
             paused_at: None,
             paused_reason: None,
+            released_at: None,
         }
     }
 

--- a/crates/server/src/audit/kinds.rs
+++ b/crates/server/src/audit/kinds.rs
@@ -26,9 +26,22 @@ pub const ACCOUNTS_PAUSE: &str = "accounts.pause";
 /// `target_account_id` is set.
 pub const ACCOUNTS_UNPAUSE: &str = "accounts.unpause";
 
+/// The server detected a canonicalized guardian switch away from its
+/// own ack key and released the account (issue #305). System-initiated
+/// (`operator_identity` is `system`). `payload` carries
+/// `{ new_guardian_commitment, delta_nonce, new_commitment }`;
+/// `target_account_id` is set.
+pub const ACCOUNTS_RELEASE: &str = "accounts.release";
+
 /// All registered kinds in v1, for tests and introspection. Append
 /// new consts above and add them to this slice in the same commit.
-pub const ALL_KINDS: &[&str] = &[AUTH_DENIED, PROBE_ACCESS, ACCOUNTS_PAUSE, ACCOUNTS_UNPAUSE];
+pub const ALL_KINDS: &[&str] = &[
+    AUTH_DENIED,
+    PROBE_ACCESS,
+    ACCOUNTS_PAUSE,
+    ACCOUNTS_UNPAUSE,
+    ACCOUNTS_RELEASE,
+];
 
 #[cfg(test)]
 mod tests {
@@ -38,7 +51,13 @@ mod tests {
     fn all_kinds_matches_consts() {
         assert_eq!(
             ALL_KINDS,
-            &[AUTH_DENIED, PROBE_ACCESS, ACCOUNTS_PAUSE, ACCOUNTS_UNPAUSE]
+            &[
+                AUTH_DENIED,
+                PROBE_ACCESS,
+                ACCOUNTS_PAUSE,
+                ACCOUNTS_UNPAUSE,
+                ACCOUNTS_RELEASE,
+            ]
         );
     }
 

--- a/crates/server/src/error.rs
+++ b/crates/server/src/error.rs
@@ -102,6 +102,15 @@ pub enum GuardianError {
         paused_at: DateTime<Utc>,
         paused_reason: Option<String>,
     },
+    /// The account switched to a different guardian and this server
+    /// released it; mutating action rejected with stable code
+    /// `GUARDIAN_ACCOUNT_RELEASED`. HTTP 409 Conflict, gRPC
+    /// `FAILED_PRECONDITION`. Terminal until the wallet re-onboards via
+    /// `/configure`. `released_at` is carried on the response body /
+    /// gRPC `Status::details`.
+    AccountReleased {
+        released_at: DateTime<Utc>,
+    },
 }
 
 /// Signing-specific error type for Miden Falcon RPO operations
@@ -157,6 +166,7 @@ impl GuardianError {
             GuardianError::InsufficientOperatorPermission { .. } => StatusCode::FORBIDDEN,
             GuardianError::DataUnavailable(_) => StatusCode::SERVICE_UNAVAILABLE,
             GuardianError::AccountPaused { .. } => StatusCode::CONFLICT,
+            GuardianError::AccountReleased { .. } => StatusCode::CONFLICT,
         }
     }
 
@@ -202,6 +212,7 @@ impl GuardianError {
             GuardianError::InsufficientOperatorPermission { .. } => tonic::Code::PermissionDenied,
             GuardianError::DataUnavailable(_) => tonic::Code::Unavailable,
             GuardianError::AccountPaused { .. } => tonic::Code::FailedPrecondition,
+            GuardianError::AccountReleased { .. } => tonic::Code::FailedPrecondition,
         }
     }
 
@@ -246,6 +257,7 @@ impl GuardianError {
             }
             GuardianError::DataUnavailable(_) => "data_unavailable",
             GuardianError::AccountPaused { .. } => "GUARDIAN_ACCOUNT_PAUSED",
+            GuardianError::AccountReleased { .. } => "GUARDIAN_ACCOUNT_RELEASED",
         }
     }
 }
@@ -349,6 +361,11 @@ impl fmt::Display for GuardianError {
                 Some(reason) => write!(f, "Account is paused: {reason}"),
                 None => write!(f, "Account is paused"),
             },
+            GuardianError::AccountReleased { .. } => write!(
+                f,
+                "Account was released: it switched to a different guardian. \
+                 Re-onboard via /configure to reactivate"
+            ),
         }
     }
 }
@@ -403,6 +420,10 @@ struct ErrorResponse {
     /// if the reason field is null).
     #[serde(skip_serializing_if = "Option::is_none")]
     paused_reason: Option<String>,
+    /// RFC 3339 UTC timestamp of the guardian-switch release. Populated
+    /// only for `GUARDIAN_ACCOUNT_RELEASED`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    released_at: Option<String>,
 }
 
 impl IntoResponse for GuardianError {
@@ -414,10 +435,16 @@ impl IntoResponse for GuardianError {
             } => Some(*retry_after_secs),
             _ => None,
         };
-        let (missing_permissions, retryable, paused_at, paused_reason) = match &self {
+        let (missing_permissions, retryable, paused_at, paused_reason, released_at) = match &self {
             GuardianError::InsufficientOperatorPermission {
                 missing_permissions,
-            } => (Some(missing_permissions.clone()), Some(false), None, None),
+            } => (
+                Some(missing_permissions.clone()),
+                Some(false),
+                None,
+                None,
+                None,
+            ),
             GuardianError::AccountPaused {
                 paused_at,
                 paused_reason,
@@ -426,8 +453,16 @@ impl IntoResponse for GuardianError {
                 Some(false),
                 Some(paused_at.to_rfc3339()),
                 paused_reason.clone(),
+                None,
             ),
-            _ => (None, None, None, None),
+            GuardianError::AccountReleased { released_at } => (
+                None,
+                Some(false),
+                None,
+                None,
+                Some(released_at.to_rfc3339()),
+            ),
+            _ => (None, None, None, None, None),
         };
         let body = Json(ErrorResponse {
             success: false,
@@ -438,6 +473,7 @@ impl IntoResponse for GuardianError {
             retryable,
             paused_at,
             paused_reason,
+            released_at,
         });
         if let Some(retry_after_secs) = retry_after_secs {
             (
@@ -463,6 +499,15 @@ impl From<GuardianError> for tonic::Status {
                     "code": err.code(),
                     "paused_at": paused_at.to_rfc3339(),
                     "paused_reason": paused_reason,
+                })
+                .to_string()
+                .into_bytes();
+                tonic::Status::with_details(err.grpc_status(), err.to_string(), details.into())
+            }
+            GuardianError::AccountReleased { released_at } => {
+                let details = serde_json::json!({
+                    "code": err.code(),
+                    "released_at": released_at.to_rfc3339(),
                 })
                 .to_string()
                 .into_bytes();

--- a/crates/server/src/error.rs
+++ b/crates/server/src/error.rs
@@ -407,8 +407,8 @@ struct ErrorResponse {
     /// Populated only for `GUARDIAN_INSUFFICIENT_OPERATOR_PERMISSION`.
     #[serde(skip_serializing_if = "Option::is_none")]
     missing_permissions: Option<Vec<String>>,
-    /// FR-016: `false` for permission denials and `GUARDIAN_ACCOUNT_PAUSED`,
-    /// absent elsewhere.
+    /// FR-016: `false` for permission denials, `GUARDIAN_ACCOUNT_PAUSED`,
+    /// and `GUARDIAN_ACCOUNT_RELEASED`, absent elsewhere.
     #[serde(skip_serializing_if = "Option::is_none")]
     retryable: Option<bool>,
     /// RFC 3339 UTC timestamp of the original pause. Populated only

--- a/crates/server/src/evm/service.rs
+++ b/crates/server/src/evm/service.rs
@@ -133,6 +133,7 @@ pub async fn register_account(
             last_auth_timestamp: existing.as_ref().and_then(|m| m.last_auth_timestamp),
             paused_at: existing.as_ref().and_then(|m| m.paused_at),
             paused_reason: existing.as_ref().and_then(|m| m.paused_reason.clone()),
+            released_at: existing.as_ref().and_then(|m| m.released_at),
         })
         .await
         .map_err(|e| {
@@ -523,6 +524,7 @@ mod tests {
                     .unwrap(),
             ),
             paused_reason: Some("compliance".to_string()),
+            released_at: None,
         }
     }
 

--- a/crates/server/src/jobs/canonicalization/processor.rs
+++ b/crates/server/src/jobs/canonicalization/processor.rs
@@ -442,6 +442,19 @@ impl DeltasProcessorBase {
             }
         }
 
+        // Issue #305: if this canonicalized delta moved the account's
+        // guardian key away from this server (a SwitchGuardian pushed to
+        // the pre-switch guardian), release the account. Best-effort —
+        // the delta is already canonical either way.
+        crate::services::release_on_switch::release_if_guardian_switched(
+            &self.state,
+            &account_metadata,
+            &new_state_json,
+            delta.nonce,
+            &updated_state.commitment,
+        )
+        .await;
+
         record_candidate_outcome(crate::metrics::labels::CandidateOutcome::Canonicalized);
         Ok(())
     }
@@ -527,6 +540,7 @@ mod tests {
             last_auth_timestamp: None,
             paused_at: None,
             paused_reason: None,
+            released_at: None,
         }
     }
 

--- a/crates/server/src/metadata/filesystem.rs
+++ b/crates/server/src/metadata/filesystem.rs
@@ -103,15 +103,17 @@ impl MetadataStore for FilesystemMetadataStore {
     async fn set(&self, metadata: AccountMetadata) -> Result<(), String> {
         let account_id = metadata.account_id.clone();
 
-        // Mirror the Postgres `set` semantics: pause state is owned by
-        // `set_pause` / `clear_pause` and must not be cleared by a
-        // generic metadata write (e.g. reconfigure, EVM re-register).
+        // Mirror the Postgres `set` semantics: pause and released state
+        // are owned by `set_pause` / `clear_pause` and `set_released` /
+        // `clear_released` and must not be changed by a generic metadata
+        // write (e.g. reconfigure, EVM re-register).
         let mut metadata = metadata;
         {
             let mut cache = self.cache.write().await;
             if let Some(existing) = cache.get(&account_id) {
                 metadata.paused_at = existing.paused_at;
                 metadata.paused_reason = existing.paused_reason.clone();
+                metadata.released_at = existing.released_at;
             }
             cache.insert(account_id, metadata);
         }
@@ -262,6 +264,36 @@ impl MetadataStore for FilesystemMetadataStore {
         Ok(transition)
     }
 
+    async fn set_released(&self, account_id: &str, now: DateTime<Utc>) -> Result<bool, String> {
+        let mut cache = self.cache.write().await;
+        let metadata = cache
+            .get_mut(account_id)
+            .ok_or_else(|| format!("Account not found: {account_id}"))?;
+
+        // First-writer-wins: keep the original released_at.
+        if metadata.released_at.is_some() {
+            return Ok(false);
+        }
+        metadata.released_at = Some(now);
+
+        self.persist(&cache).await?;
+        Ok(true)
+    }
+
+    async fn clear_released(&self, account_id: &str) -> Result<(), String> {
+        let mut cache = self.cache.write().await;
+        let metadata = cache
+            .get_mut(account_id)
+            .ok_or_else(|| format!("Account not found: {account_id}"))?;
+
+        if metadata.released_at.is_none() {
+            return Ok(());
+        }
+        metadata.released_at = None;
+
+        self.persist(&cache).await
+    }
+
     async fn find_by_cosigner_commitment(&self, commitment: &str) -> Result<Vec<String>, String> {
         let cache = self.cache.read().await;
         let mut matches = Vec::new();
@@ -311,6 +343,7 @@ mod pause_tests {
                 last_auth_timestamp: None,
                 paused_at: None,
                 paused_reason: None,
+                released_at: None,
             })
             .await
             .unwrap();
@@ -364,5 +397,66 @@ mod pause_tests {
         let post = store.get("acct").await.unwrap().unwrap();
         assert!(post.paused_at.is_none());
         assert!(post.paused_reason.is_none());
+    }
+
+    #[tokio::test]
+    async fn set_released_is_first_writer_wins() {
+        let (store, _dir) = fresh_store().await;
+        let first = Utc.with_ymd_and_hms(2026, 7, 6, 10, 0, 0).unwrap();
+        let later = Utc.with_ymd_and_hms(2026, 7, 6, 11, 0, 0).unwrap();
+
+        assert!(store.set_released("acct", first).await.unwrap());
+        // Second release is a no-op that reports "not newly released".
+        assert!(!store.set_released("acct", later).await.unwrap());
+
+        let post = store.get("acct").await.unwrap().unwrap();
+        assert_eq!(
+            post.released_at,
+            Some(first),
+            "original released_at preserved"
+        );
+    }
+
+    #[tokio::test]
+    async fn set_released_missing_account_errors() {
+        let (store, _dir) = fresh_store().await;
+        let ts = Utc.with_ymd_and_hms(2026, 7, 6, 10, 0, 0).unwrap();
+        assert!(store.set_released("missing", ts).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn clear_released_reactivates_and_is_idempotent() {
+        let (store, _dir) = fresh_store().await;
+        let ts = Utc.with_ymd_and_hms(2026, 7, 6, 10, 0, 0).unwrap();
+        store.set_released("acct", ts).await.unwrap();
+
+        store.clear_released("acct").await.unwrap();
+        let post = store.get("acct").await.unwrap().unwrap();
+        assert!(post.released_at.is_none());
+
+        // Idempotent on an already-active account.
+        store.clear_released("acct").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn generic_set_preserves_released_state() {
+        let (store, _dir) = fresh_store().await;
+        let ts = Utc.with_ymd_and_hms(2026, 7, 6, 10, 0, 0).unwrap();
+        store.set_released("acct", ts).await.unwrap();
+
+        // A generic metadata write (reconfigure-style) that carries
+        // released_at: None must NOT clear the released state — only
+        // clear_released may.
+        let mut refreshed = store.get("acct").await.unwrap().unwrap();
+        refreshed.released_at = None;
+        refreshed.updated_at = "2026-07-06T12:00:00Z".into();
+        store.set(refreshed).await.unwrap();
+
+        let post = store.get("acct").await.unwrap().unwrap();
+        assert_eq!(
+            post.released_at,
+            Some(ts),
+            "generic set must not clear released_at"
+        );
     }
 }

--- a/crates/server/src/metadata/mod.rs
+++ b/crates/server/src/metadata/mod.rs
@@ -31,6 +31,16 @@ pub struct AccountMetadata {
     /// active. Required (non-empty, ≤ 512 UTF-8 chars) on pause.
     #[serde(default)]
     pub paused_reason: Option<String>,
+    /// UTC timestamp at which this server detected it is no longer the
+    /// account's guardian (a canonicalized `SwitchGuardian` delta moved
+    /// the on-chain guardian key away from this server's ack key).
+    /// `None` while this server is the account's guardian. Terminal:
+    /// cleared only by re-onboarding through `/configure`, which
+    /// re-validates the guardian binding. First-writer-wins like
+    /// `paused_at`; orthogonal to pause so an operator unpause can
+    /// never resurrect a released account.
+    #[serde(default)]
+    pub released_at: Option<DateTime<Utc>>,
 }
 
 /// Cursor parameters for the paginated account list read. Sort key is
@@ -169,4 +179,21 @@ pub trait MetadataStore: Send + Sync {
         &self,
         account_id: &str,
     ) -> Result<crate::services::account_status::PauseTransition, String>;
+
+    /// Atomically transition an account to the released state after a
+    /// guardian switch away from this server was detected.
+    /// First-writer-wins: when the account is already released the
+    /// persisted `released_at` is left unchanged. Returns `Ok(true)`
+    /// when this call performed the transition (callers audit on this),
+    /// `Ok(false)` when the account was already released, `Err` if the
+    /// account does not exist. Like pause, released state is owned by
+    /// this method + [`Self::clear_released`]; a generic [`Self::set`]
+    /// must never change it.
+    async fn set_released(&self, account_id: &str, now: DateTime<Utc>) -> Result<bool, String>;
+
+    /// Clear the released state for an account. Called only from the
+    /// `/configure` re-onboarding path, which re-validates that this
+    /// server is the account's guardian before reactivating it.
+    /// Idempotent; `Err` if the account does not exist.
+    async fn clear_released(&self, account_id: &str) -> Result<(), String>;
 }

--- a/crates/server/src/metadata/postgres.rs
+++ b/crates/server/src/metadata/postgres.rs
@@ -55,6 +55,7 @@ struct MetadataRow {
     last_auth_timestamp: Option<i64>,
     paused_at: Option<chrono::DateTime<chrono::Utc>>,
     paused_reason: Option<String>,
+    released_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 // Insertable struct for writing to database
@@ -70,6 +71,7 @@ struct NewMetadata<'a> {
     last_auth_timestamp: Option<i64>,
     paused_at: Option<chrono::DateTime<chrono::Utc>>,
     paused_reason: Option<String>,
+    released_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 impl TryFrom<MetadataRow> for AccountMetadata {
@@ -91,6 +93,7 @@ impl TryFrom<MetadataRow> for AccountMetadata {
             last_auth_timestamp: row.last_auth_timestamp,
             paused_at: row.paused_at,
             paused_reason: row.paused_reason,
+            released_at: row.released_at,
         })
     }
 }
@@ -159,8 +162,13 @@ impl MetadataStore for PostgresMetadataStore {
             last_auth_timestamp: metadata.last_auth_timestamp,
             paused_at: metadata.paused_at,
             paused_reason: metadata.paused_reason.clone(),
+            released_at: metadata.released_at,
         };
 
+        // The on-conflict set deliberately excludes `paused_at`,
+        // `paused_reason`, and `released_at`: those lifecycle flags are
+        // owned by their dedicated set/clear methods and must not be
+        // changed by a generic metadata write.
         diesel::insert_into(account_metadata::table)
             .values(&new_metadata)
             .on_conflict(account_metadata::account_id)
@@ -409,6 +417,61 @@ impl MetadataStore for PostgresMetadataStore {
             paused_at: None,
             paused_reason: None,
         })
+    }
+
+    /// First-writer-wins release: the `released_at IS NULL` filter
+    /// encodes the transition atomically; zero rows updated means the
+    /// account was already released (or missing — disambiguated below).
+    async fn set_released(&self, account_id: &str, now: DateTime<Utc>) -> Result<bool, String> {
+        let mut conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| format!("Failed to get connection: {e}"))?;
+
+        let rows_updated = diesel::update(account_metadata::table)
+            .filter(account_metadata::account_id.eq(account_id))
+            .filter(account_metadata::released_at.is_null())
+            .set(account_metadata::released_at.eq(Some(now)))
+            .execute(&mut conn)
+            .await
+            .map_err(|e| format!("Failed to set released: {e}"))?;
+
+        if rows_updated > 0 {
+            return Ok(true);
+        }
+
+        let exists: Option<MetadataRow> = account_metadata::table
+            .filter(account_metadata::account_id.eq(account_id))
+            .select(MetadataRow::as_select())
+            .first(&mut conn)
+            .await
+            .optional()
+            .map_err(|e| format!("Failed to load account_metadata: {e}"))?;
+        match exists {
+            Some(_) => Ok(false),
+            None => Err(format!("Account not found: {account_id}")),
+        }
+    }
+
+    async fn clear_released(&self, account_id: &str) -> Result<(), String> {
+        let mut conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| format!("Failed to get connection: {e}"))?;
+
+        let rows_updated = diesel::update(account_metadata::table)
+            .filter(account_metadata::account_id.eq(account_id))
+            .set(account_metadata::released_at.eq::<Option<DateTime<Utc>>>(None))
+            .execute(&mut conn)
+            .await
+            .map_err(|e| format!("Failed to clear released: {e}"))?;
+
+        if rows_updated == 0 {
+            return Err(format!("Account not found: {account_id}"));
+        }
+        Ok(())
     }
 
     async fn find_by_cosigner_commitment(&self, commitment: &str) -> Result<Vec<String>, String> {

--- a/crates/server/src/network/miden/mod.rs
+++ b/crates/server/src/network/miden/mod.rs
@@ -29,8 +29,8 @@ impl MidenNetworkClient {
     /// unit tests that exercise the pure serialization/delta paths
     /// (`get_state_commitment`, `validate_guardian_commitment`, `apply_delta`)
     /// which never issue an RPC.
-    #[cfg(all(test, not(any(feature = "integration", feature = "e2e"))))]
-    fn lazy_for_test(network: NetworkType) -> Self {
+    #[cfg(any(test, feature = "integration", feature = "e2e"))]
+    pub(crate) fn lazy_for_test(network: NetworkType) -> Self {
         let client = MidenRpcClient::lazy_unconnected(network.rpc_endpoint())
             .expect("lazy client construction is infallible for a valid endpoint");
         Self { client }
@@ -441,6 +441,15 @@ impl NetworkClient for MidenNetworkClient {
                 "Slot '{OZ_GUARDIAN_PUBLIC_KEY}' mismatch: expected {expected_guardian_commitment}, got {actual_guardian_commitment}"
             ))
         }
+    }
+
+    fn extract_guardian_commitment(
+        &self,
+        state_json: &serde_json::Value,
+    ) -> Result<Option<String>, String> {
+        let account = Account::from_json(state_json)?;
+        let inspector = MidenAccountInspector::new(&account);
+        Ok(inspector.extract_guardian_public_key())
     }
 
     async fn should_update_auth(

--- a/crates/server/src/network/miden/mod.rs
+++ b/crates/server/src/network/miden/mod.rs
@@ -26,10 +26,16 @@ impl MidenNetworkClient {
     }
 
     /// Builds a client without contacting the network or loading TLS roots, for
-    /// unit tests that exercise the pure serialization/delta paths
-    /// (`get_state_commitment`, `validate_guardian_commitment`, `apply_delta`)
-    /// which never issue an RPC.
-    #[cfg(any(test, feature = "integration", feature = "e2e"))]
+    /// tests that exercise the pure serialization/delta paths
+    /// (`get_state_commitment`, `validate_guardian_commitment`, `apply_delta`,
+    /// `extract_guardian_commitment`) which never issue an RPC.
+    ///
+    /// The cfg matches this helper's exact consumers so `-D dead_code`
+    /// holds under every feature combination CI lints: the unit tests
+    /// below (test builds without `integration`/`e2e`) and the e2e
+    /// guardian-switch test (test builds with `e2e`). Non-test builds
+    /// never compile it.
+    #[cfg(all(test, any(feature = "e2e", not(feature = "integration"))))]
     pub(crate) fn lazy_for_test(network: NetworkType) -> Self {
         let client = MidenRpcClient::lazy_unconnected(network.rpc_endpoint())
             .expect("lazy client construction is infallible for a valid endpoint");

--- a/crates/server/src/network/mod.rs
+++ b/crates/server/src/network/mod.rs
@@ -67,6 +67,21 @@ pub trait NetworkClient: Send + Sync {
         expected_guardian_commitment: &str,
     ) -> Result<(), String>;
 
+    /// Extract the guardian public key commitment stored in the account
+    /// state, or `Ok(None)` when the state carries no guardian binding
+    /// (non-guardian account types, networks without the concept). Used
+    /// by the release-on-guardian-switch hook to detect that a committed
+    /// delta moved the account to a different guardian. The default is
+    /// `Ok(None)` — "cannot tell" — so backends without guardian storage
+    /// never trigger a release.
+    fn extract_guardian_commitment(
+        &self,
+        state_json: &serde_json::Value,
+    ) -> Result<Option<String>, String> {
+        let _ = state_json;
+        Ok(None)
+    }
+
     /// Determine if account auth should be updated given the state
     async fn should_update_auth(
         &mut self,

--- a/crates/server/src/openapi.rs
+++ b/crates/server/src/openapi.rs
@@ -40,7 +40,8 @@ pub struct ApiErrorResponse {
     /// `GUARDIAN_INSUFFICIENT_OPERATOR_PERMISSION`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub missing_permissions: Option<Vec<String>>,
-    /// `false` for permission denials and `GUARDIAN_ACCOUNT_PAUSED`.
+    /// `false` for permission denials, `GUARDIAN_ACCOUNT_PAUSED`, and
+    /// `GUARDIAN_ACCOUNT_RELEASED`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retryable: Option<bool>,
     /// RFC 3339 pause timestamp. Present only for
@@ -50,6 +51,10 @@ pub struct ApiErrorResponse {
     /// Pause reason. Present only for `GUARDIAN_ACCOUNT_PAUSED`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub paused_reason: Option<String>,
+    /// RFC 3339 timestamp of the guardian-switch release. Present only
+    /// for `GUARDIAN_ACCOUNT_RELEASED`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub released_at: Option<String>,
 }
 
 /// Security scheme name for the signed-request public key header.

--- a/crates/server/src/schema.rs
+++ b/crates/server/src/schema.rs
@@ -86,6 +86,7 @@ diesel::table! {
         last_auth_timestamp -> Nullable<Int8>,
         paused_at -> Nullable<Timestamptz>,
         paused_reason -> Nullable<Text>,
+        released_at -> Nullable<Timestamptz>,
     }
 }
 

--- a/crates/server/src/services/account_status.rs
+++ b/crates/server/src/services/account_status.rs
@@ -1,11 +1,12 @@
-//! Per-account pause chokepoint.
+//! Per-account pause/release chokepoint.
 //!
 //! Single helper [`ensure_account_active`] consulted from every
 //! per-account mutating entry point (multisig + EVM proposal pipelines).
 //! Admin/setup paths (`services::configure_account`,
 //! `evm::service::register_account`) deliberately do NOT call this
 //! helper. This module is the ONLY place outside read endpoints +
-//! the pause/unpause handlers that reads `AccountMetadata::paused_at` —
+//! the pause/unpause handlers and the guardian-switch release hook that
+//! reads `AccountMetadata::paused_at` / `AccountMetadata::released_at` —
 //! keeping the read centralized is what lets the future `PolicyEngine`
 //! replace this helper wholesale without API, audit, or storage churn.
 use chrono::{DateTime, Utc};
@@ -44,14 +45,23 @@ pub struct PauseTransition {
 }
 
 /// Returns `Ok(())` if the supplied metadata describes an active
-/// account, or `GuardianError::AccountPaused { .. }` carrying the
-/// persisted `paused_at` / `paused_reason` when the account is paused.
+/// account, `GuardianError::AccountReleased { .. }` when the account
+/// switched to a different guardian and was released, or
+/// `GuardianError::AccountPaused { .. }` carrying the persisted
+/// `paused_at` / `paused_reason` when the account is paused. Released
+/// wins over paused: it is the terminal state and its remedy
+/// (re-onboard via `/configure`) differs from pause's (operator
+/// unpause).
 ///
 /// Callers MUST invoke this only after authentication has succeeded —
-/// otherwise unauthenticated probes can learn pause state and reason.
-/// Pair with `resolve_account` (multisig) or post-signature verification
-/// (EVM) so the chokepoint reads from already-loaded metadata.
+/// otherwise unauthenticated probes can learn pause/release state and
+/// reason. Pair with `resolve_account` (multisig) or post-signature
+/// verification (EVM) so the chokepoint reads from already-loaded
+/// metadata.
 pub fn ensure_account_active_metadata(metadata: &AccountMetadata) -> Result<()> {
+    if let Some(released_at) = metadata.released_at {
+        return Err(GuardianError::AccountReleased { released_at });
+    }
     if let Some(paused_at) = metadata.paused_at {
         return Err(GuardianError::AccountPaused {
             paused_at,
@@ -103,6 +113,7 @@ mod tests {
             last_auth_timestamp: None,
             paused_at: paused.map(|(ts, _)| ts),
             paused_reason: paused.and_then(|(_, r)| r.map(|s| s.to_string())),
+            released_at: None,
         }
     }
 
@@ -137,6 +148,41 @@ mod tests {
         ensure_account_active(&state, "acc-1")
             .await
             .expect("active account must pass the chokepoint");
+    }
+
+    #[tokio::test]
+    async fn released_account_returns_account_released() {
+        let ts = Utc.with_ymd_and_hms(2026, 7, 6, 10, 0, 0).unwrap();
+        let mut released = meta("acc-1", None);
+        released.released_at = Some(ts);
+        let metadata = MockMetadataStore::new().with_get(Ok(Some(released)));
+        let state = state_with(metadata).await;
+
+        match ensure_account_active(&state, "acc-1").await {
+            Err(GuardianError::AccountReleased { released_at }) => assert_eq!(released_at, ts),
+            other => panic!("expected AccountReleased, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn released_wins_over_paused() {
+        // A released account that is ALSO paused must surface the
+        // release: its remedy (re-onboard via /configure) differs from
+        // pause's (operator unpause), and unpausing must never imply
+        // the account became mutable again.
+        let paused_ts = Utc.with_ymd_and_hms(2026, 5, 19, 14, 30, 0).unwrap();
+        let released_ts = Utc.with_ymd_and_hms(2026, 7, 6, 10, 0, 0).unwrap();
+        let mut both = meta("acc-1", Some((paused_ts, Some("compliance"))));
+        both.released_at = Some(released_ts);
+        let metadata = MockMetadataStore::new().with_get(Ok(Some(both)));
+        let state = state_with(metadata).await;
+
+        match ensure_account_active(&state, "acc-1").await {
+            Err(GuardianError::AccountReleased { released_at }) => {
+                assert_eq!(released_at, released_ts)
+            }
+            other => panic!("expected AccountReleased, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/server/src/services/configure_account.rs
+++ b/crates/server/src/services/configure_account.rs
@@ -546,6 +546,68 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_configure_account_reonboarding_fails_closed_when_clear_released_fails() {
+        use crate::testing::helpers::generate_falcon_signature;
+
+        let account_id_hex = "0x1d1d1d1c1d1d1d011d1d1d1d1d1d1d";
+        let (pubkey_hex, commitment_hex, signature_hex, timestamp) =
+            generate_falcon_signature(account_id_hex);
+
+        use chrono::TimeZone;
+        let released_at = chrono::Utc.with_ymd_and_hms(2026, 7, 6, 10, 0, 0).unwrap();
+        let existing_metadata = AccountMetadata {
+            account_id: account_id_hex.to_string(),
+            auth: Auth::MidenFalconRpo {
+                cosigner_commitments: vec![commitment_hex.clone()],
+            },
+            network_config: crate::metadata::NetworkConfig::miden_default(),
+            created_at: "2024-01-01T00:00:00Z".to_string(),
+            updated_at: "2024-01-01T00:00:00Z".to_string(),
+            has_pending_candidate: false,
+            last_auth_timestamp: Some(1000),
+            paused_at: None,
+            paused_reason: None,
+            released_at: Some(released_at),
+        };
+
+        let network_client = MockNetworkClient::new()
+            .with_validate_credential(Ok(()))
+            .with_get_state_commitment(Ok("0x5678".to_string()));
+        let storage_backend = MockStorageBackend::new().with_submit_state(Ok(()));
+        let metadata_store = MockMetadataStore::new()
+            .with_get(Ok(Some(existing_metadata)))
+            .with_set(Ok(()))
+            .with_clear_released(Err("disk on fire".to_string()));
+
+        let state =
+            create_test_app_state(network_client, storage_backend, metadata_store.clone()).await;
+
+        let account_json = include_str!("../testing/fixtures/account.json");
+        let initial_state: serde_json::Value = serde_json::from_str(account_json).unwrap();
+        let credential = Credentials::signature(pubkey_hex, signature_hex, timestamp);
+        let params = ConfigureAccountParams {
+            account_id: account_id_hex.to_string(),
+            auth: Auth::MidenFalconRpo {
+                cosigner_commitments: vec![commitment_hex],
+            },
+            network_config: crate::metadata::NetworkConfig::miden_default(),
+            initial_state,
+            credential,
+        };
+
+        // Fail-closed: the account stays released (mutations still refused)
+        // and the caller sees the storage failure so the wallet retries
+        // the re-onboarding.
+        let err = configure_account(&state, params)
+            .await
+            .expect_err("clear_released failure must surface");
+        assert!(
+            matches!(err, GuardianError::StorageError(_)),
+            "expected StorageError, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn test_configure_account_network_error() {
         use crate::testing::helpers::generate_falcon_signature;
 

--- a/crates/server/src/services/configure_account.rs
+++ b/crates/server/src/services/configure_account.rs
@@ -136,6 +136,7 @@ pub async fn configure_account(
     // is carried forward from `existing` so a new storage backend
     // cannot accidentally clear it (the field is only mutated by
     // `set_pause`/`clear_pause`).
+    let was_released = existing.as_ref().and_then(|m| m.released_at).is_some();
     let metadata_entry = AccountMetadata {
         account_id: params.account_id.clone(),
         auth: params.auth,
@@ -149,6 +150,9 @@ pub async fn configure_account(
         last_auth_timestamp: existing.as_ref().and_then(|m| m.last_auth_timestamp),
         paused_at: existing.as_ref().and_then(|m| m.paused_at),
         paused_reason: existing.as_ref().and_then(|m| m.paused_reason.clone()),
+        // `set` never touches released state; the explicit
+        // `clear_released` below performs the reactivation.
+        released_at: existing.as_ref().and_then(|m| m.released_at),
     };
 
     state.metadata.set(metadata_entry).await.map_err(|e| {
@@ -159,6 +163,31 @@ pub async fn configure_account(
         );
         GuardianError::StorageError(format!("Failed to store metadata: {e}"))
     })?;
+
+    // Deliberate asymmetry with pause: `released` means "a guardian
+    // switch moved this account away from this server", and this very
+    // path just re-validated (validate_guardian_commitment above) that
+    // the submitted state binds the account to this server again — so
+    // re-onboarding is exactly the reactivation event. Pause, an
+    // operator decision, stays in force across reconfiguration.
+    if was_released {
+        tracing::info!(
+            account_id = %params.account_id,
+            "Reactivating released account via /configure re-onboarding"
+        );
+        state
+            .metadata
+            .clear_released(&params.account_id)
+            .await
+            .map_err(|e| {
+                tracing::error!(
+                    account_id = %params.account_id,
+                    error = %e,
+                    "Failed to clear released state during re-onboarding"
+                );
+                GuardianError::StorageError(format!("Failed to clear released state: {e}"))
+            })?;
+    }
 
     // Count only first-time creations — /configure also serves
     // reconfiguration of existing accounts.
@@ -345,6 +374,7 @@ mod tests {
             last_auth_timestamp: Some(1000),
             paused_at: None,
             paused_reason: None,
+            released_at: None,
         };
 
         let network_client = MockNetworkClient::new()
@@ -408,6 +438,7 @@ mod tests {
             last_auth_timestamp: Some(1000),
             paused_at: Some(paused_at),
             paused_reason: Some("compliance".to_string()),
+            released_at: None,
         };
 
         let network_client = MockNetworkClient::new()
@@ -442,6 +473,76 @@ mod tests {
         assert_eq!(set_calls.len(), 1);
         assert_eq!(set_calls[0].paused_at, Some(paused_at));
         assert_eq!(set_calls[0].paused_reason.as_deref(), Some("compliance"));
+        assert!(
+            metadata_store
+                .clear_released_calls
+                .lock()
+                .unwrap()
+                .is_empty(),
+            "no release to clear when the account was not released"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_configure_account_reonboarding_clears_released_state() {
+        use crate::testing::helpers::generate_falcon_signature;
+
+        let account_id_hex = "0x1d1d1d1c1d1d1d011d1d1d1d1d1d1d";
+        let (pubkey_hex, commitment_hex, signature_hex, timestamp) =
+            generate_falcon_signature(account_id_hex);
+
+        use chrono::TimeZone;
+        let released_at = chrono::Utc.with_ymd_and_hms(2026, 7, 6, 10, 0, 0).unwrap();
+        let existing_metadata = AccountMetadata {
+            account_id: account_id_hex.to_string(),
+            auth: Auth::MidenFalconRpo {
+                cosigner_commitments: vec![commitment_hex.clone()],
+            },
+            network_config: crate::metadata::NetworkConfig::miden_default(),
+            created_at: "2024-01-01T00:00:00Z".to_string(),
+            updated_at: "2024-01-01T00:00:00Z".to_string(),
+            has_pending_candidate: false,
+            last_auth_timestamp: Some(1000),
+            paused_at: None,
+            paused_reason: None,
+            released_at: Some(released_at),
+        };
+
+        let network_client = MockNetworkClient::new()
+            .with_validate_credential(Ok(()))
+            .with_get_state_commitment(Ok("0x5678".to_string()));
+        let storage_backend = MockStorageBackend::new().with_submit_state(Ok(()));
+        let metadata_store = MockMetadataStore::new()
+            .with_get(Ok(Some(existing_metadata)))
+            .with_set(Ok(()));
+
+        let state =
+            create_test_app_state(network_client, storage_backend, metadata_store.clone()).await;
+
+        let account_json = include_str!("../testing/fixtures/account.json");
+        let initial_state: serde_json::Value = serde_json::from_str(account_json).unwrap();
+        let credential = Credentials::signature(pubkey_hex, signature_hex, timestamp);
+        let params = ConfigureAccountParams {
+            account_id: account_id_hex.to_string(),
+            auth: Auth::MidenFalconRpo {
+                cosigner_commitments: vec![commitment_hex],
+            },
+            network_config: crate::metadata::NetworkConfig::miden_default(),
+            initial_state,
+            credential,
+        };
+
+        configure_account(&state, params)
+            .await
+            .expect("Re-onboarding a released account should succeed");
+
+        // Re-onboarding (with the guardian binding re-validated) is the
+        // reactivation event: released state must be explicitly cleared.
+        assert_eq!(
+            metadata_store.clear_released_calls.lock().unwrap().clone(),
+            vec![account_id_hex.to_string()],
+            "re-onboarding must clear the released state"
+        );
     }
 
     #[tokio::test]

--- a/crates/server/src/services/dashboard_account_delta_detail.rs
+++ b/crates/server/src/services/dashboard_account_delta_detail.rs
@@ -222,6 +222,7 @@ mod tests {
             last_auth_timestamp: None,
             paused_at: None,
             paused_reason: None,
+            released_at: None,
         }
     }
 

--- a/crates/server/src/services/dashboard_account_deltas.rs
+++ b/crates/server/src/services/dashboard_account_deltas.rs
@@ -357,6 +357,7 @@ mod tests {
                 last_auth_timestamp: None,
                 paused_at: None,
                 paused_reason: None,
+                released_at: None,
             }))
         } else {
             Ok(None)
@@ -475,6 +476,7 @@ mod tests {
                 last_auth_timestamp: None,
                 paused_at: None,
                 paused_reason: None,
+                released_at: None,
             })));
         let storage = MockStorageBackend::new()
             .with_list_account_deltas_paged(Err("disk read failed".into()));
@@ -562,6 +564,7 @@ mod tests {
                     last_auth_timestamp: None,
                     paused_at: None,
                     paused_reason: None,
+                    released_at: None,
                 })));
             }
             m

--- a/crates/server/src/services/dashboard_account_proposals.rs
+++ b/crates/server/src/services/dashboard_account_proposals.rs
@@ -279,6 +279,7 @@ mod tests {
             last_auth_timestamp: None,
             paused_at: None,
             paused_reason: None,
+            released_at: None,
         }
     }
 

--- a/crates/server/src/services/dashboard_account_snapshot.rs
+++ b/crates/server/src/services/dashboard_account_snapshot.rs
@@ -209,6 +209,7 @@ mod tests {
             last_auth_timestamp: None,
             paused_at: None,
             paused_reason: None,
+            released_at: None,
         }
     }
 

--- a/crates/server/src/services/dashboard_accounts.rs
+++ b/crates/server/src/services/dashboard_accounts.rs
@@ -35,6 +35,8 @@ pub struct DashboardAccountSummary {
     pub paused_at: Option<String>,
     #[serde(default)]
     pub paused_reason: Option<String>,
+    #[serde(default)]
+    pub released_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, utoipa::ToSchema)]
@@ -60,6 +62,11 @@ pub struct DashboardAccountDetail {
     /// Reason captured at first pause; `None` when active.
     #[serde(default)]
     pub paused_reason: Option<String>,
+    /// RFC 3339 UTC timestamp at which this server detected the account
+    /// switched to a different guardian and released it; `None` while
+    /// this server is the account's guardian.
+    #[serde(default)]
+    pub released_at: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -218,6 +225,7 @@ impl DashboardAccountSummary {
             updated_at: metadata.updated_at.clone(),
             paused_at: metadata.paused_at.map(|ts| ts.to_rfc3339()),
             paused_reason: metadata.paused_reason.clone(),
+            released_at: metadata.released_at.map(|ts| ts.to_rfc3339()),
         }
     }
 }
@@ -241,6 +249,7 @@ impl DashboardAccountDetail {
             state_updated_at: Some(account_state.updated_at.clone()),
             paused_at: metadata.paused_at.map(|ts| ts.to_rfc3339()),
             paused_reason: metadata.paused_reason.clone(),
+            released_at: metadata.released_at.map(|ts| ts.to_rfc3339()),
         }
     }
 }
@@ -306,6 +315,7 @@ mod tests {
             last_auth_timestamp: None,
             paused_at: None,
             paused_reason: None,
+            released_at: None,
         }
     }
 
@@ -349,6 +359,7 @@ mod tests {
             last_auth_timestamp: None,
             paused_at: None,
             paused_reason: None,
+            released_at: None,
         };
         assert!(bech32_for_account(&meta).is_none());
     }

--- a/crates/server/src/services/dashboard_global_proposals.rs
+++ b/crates/server/src/services/dashboard_global_proposals.rs
@@ -248,6 +248,7 @@ mod tests {
             last_auth_timestamp: None,
             paused_at: None,
             paused_reason: None,
+            released_at: None,
         }
     }
 

--- a/crates/server/src/services/dashboard_info.rs
+++ b/crates/server/src/services/dashboard_info.rs
@@ -366,6 +366,7 @@ mod tests {
             last_auth_timestamp: None,
             paused_at: None,
             paused_reason: None,
+            released_at: None,
         };
         let metadata = MockMetadataStore::new()
             .with_list(Ok(account_ids))

--- a/crates/server/src/services/delta_commit.rs
+++ b/crates/server/src/services/delta_commit.rs
@@ -164,6 +164,20 @@ impl DeltaCommitStrategy {
                     }
                 }
 
+                // Issue #305: if this delta moved the account's guardian
+                // key away from this server (a SwitchGuardian pushed to
+                // the pre-switch guardian), release the account. In
+                // optimistic mode this runs at commit time — the same
+                // trust level as every other optimistic commit.
+                crate::services::release_on_switch::release_if_guardian_switched(
+                    ctx.state,
+                    &ctx.resolved.metadata,
+                    &new_state.state_json,
+                    delta.nonce,
+                    &new_state.commitment,
+                )
+                .await;
+
                 Ok(())
             }
         }
@@ -218,6 +232,7 @@ mod tests {
             last_auth_timestamp: None,
             paused_at: None,
             paused_reason: None,
+            released_at: None,
         }
     }
 

--- a/crates/server/src/services/get_delta_proposal.rs
+++ b/crates/server/src/services/get_delta_proposal.rs
@@ -93,6 +93,7 @@ mod tests {
             last_auth_timestamp: None,
             paused_at: None,
             paused_reason: None,
+            released_at: None,
         }
     }
 

--- a/crates/server/src/services/get_delta_proposals.rs
+++ b/crates/server/src/services/get_delta_proposals.rs
@@ -96,6 +96,7 @@ mod tests {
             last_auth_timestamp: None,
             paused_at: None,
             paused_reason: None,
+            released_at: None,
         }
     }
 

--- a/crates/server/src/services/mod.rs
+++ b/crates/server/src/services/mod.rs
@@ -28,6 +28,7 @@ mod lookup_account;
 pub mod pause_account;
 mod push_delta;
 mod push_delta_proposal;
+pub mod release_on_switch;
 mod sign_delta_proposal;
 mod status;
 pub mod unpause_account;
@@ -443,6 +444,7 @@ mod tests {
             last_auth_timestamp: None,
             paused_at: None,
             paused_reason: None,
+            released_at: None,
         }
     }
 

--- a/crates/server/src/services/push_delta.rs
+++ b/crates/server/src/services/push_delta.rs
@@ -238,6 +238,7 @@ mod tests {
                     .unwrap(),
             ),
             paused_reason: Some("compliance".to_string()),
+            released_at: None,
         }
     }
 
@@ -363,6 +364,7 @@ mod tests {
             last_auth_timestamp: None,
             paused_at: None,
             paused_reason: None,
+            released_at: None,
         })));
 
         let state = create_test_app_state_with_mocks(
@@ -466,6 +468,7 @@ mod tests {
             last_auth_timestamp: None,
             paused_at: None,
             paused_reason: None,
+            released_at: None,
         })));
 
         let state = create_test_app_state_with_mocks(

--- a/crates/server/src/services/push_delta_proposal.rs
+++ b/crates/server/src/services/push_delta_proposal.rs
@@ -274,6 +274,7 @@ mod tests {
             last_auth_timestamp: None,
             paused_at: None,
             paused_reason: None,
+            released_at: None,
         }
     }
 

--- a/crates/server/src/services/release_on_switch.rs
+++ b/crates/server/src/services/release_on_switch.rs
@@ -1,0 +1,299 @@
+//! Release-on-guardian-switch detection (issue #305).
+//!
+//! Since #287 the multisig clients push a `SwitchGuardian` delta to the
+//! **pre-switch** guardian, best-effort, so it canonicalizes there like
+//! any other delta. This hook is the server-side reaction: after a
+//! delta commits (optimistic mode) or canonicalizes (candidate mode),
+//! compare the guardian public key commitment recorded in the resulting
+//! account state against this server's own ack key. When they differ,
+//! the account has verifiably switched to a different guardian — this
+//! server's co-signatures are no longer accepted on-chain — so the
+//! account transitions to the terminal `released` state: mutations are
+//! refused by the pause/release chokepoint, reads keep working so the
+//! wallet and operator can fetch final state, and only re-onboarding
+//! through `/configure` (which re-validates the guardian binding)
+//! reactivates it.
+//!
+//! Best-effort by design: a failure here is logged and never fails the
+//! delta commit — the delta itself is valid and already persisted. In
+//! candidate mode a mid-canonicalization failure leaves the delta a
+//! candidate, so the worker retries and this hook runs again.
+
+use serde_json::json;
+
+use crate::audit::{AuditEvent, AuditOutcome, kinds};
+use crate::metadata::AccountMetadata;
+use crate::state::AppState;
+
+/// `operator_identity` recorded on system-initiated release audit rows.
+pub const SYSTEM_OPERATOR_IDENTITY: &str = "system";
+
+/// Release the account when `new_state_json` (the just-committed state)
+/// carries a guardian public key commitment different from this
+/// server's ack key. Infallible for callers: all failures are logged.
+pub async fn release_if_guardian_switched(
+    state: &AppState,
+    metadata: &AccountMetadata,
+    new_state_json: &serde_json::Value,
+    delta_nonce: u64,
+    new_commitment: &str,
+) {
+    // EVM accounts have no on-chain guardian binding to compare.
+    if metadata.network_config.is_evm() {
+        return;
+    }
+
+    let own_commitment = state.ack.commitment(&metadata.auth.scheme());
+
+    let extracted = {
+        let client = state.network_client.lock().await;
+        client.extract_guardian_commitment(new_state_json)
+    };
+
+    let new_guardian_commitment = match extracted {
+        // `None` means the state carries no guardian binding at all
+        // (e.g. guardian component absent). Absence is not evidence of
+        // a switch — do nothing.
+        Ok(Some(commitment)) if commitment != own_commitment => commitment,
+        Ok(_) => return,
+        Err(e) => {
+            tracing::error!(
+                account_id = %metadata.account_id,
+                nonce = delta_nonce,
+                error = %e,
+                "Failed to inspect guardian commitment after delta commit; \
+                 release-on-switch check skipped"
+            );
+            return;
+        }
+    };
+
+    match state
+        .metadata
+        .set_released(&metadata.account_id, state.clock.now())
+        .await
+    {
+        Ok(true) => {
+            tracing::warn!(
+                account_id = %metadata.account_id,
+                nonce = delta_nonce,
+                new_guardian_commitment = %new_guardian_commitment,
+                "Account switched to a different guardian; released \
+                 (mutations refused until re-onboarded via /configure)"
+            );
+            state.auditor.record(AuditEvent {
+                operator_identity: SYSTEM_OPERATOR_IDENTITY.to_string(),
+                action_kind: kinds::ACCOUNTS_RELEASE,
+                target_account_id: Some(metadata.account_id.clone()),
+                payload: json!({
+                    "new_guardian_commitment": new_guardian_commitment,
+                    "delta_nonce": delta_nonce,
+                    "new_commitment": new_commitment,
+                }),
+                outcome: AuditOutcome::Success,
+                error_code: None,
+                client_ip: None,
+            });
+        }
+        // Already released — first-writer-wins, nothing to audit.
+        Ok(false) => {}
+        Err(e) => {
+            tracing::error!(
+                account_id = %metadata.account_id,
+                nonce = delta_nonce,
+                error = %e,
+                "Detected guardian switch but failed to persist released state"
+            );
+        }
+    }
+}
+
+#[cfg(all(test, not(any(feature = "integration", feature = "e2e"))))]
+mod tests {
+    use super::*;
+    use crate::ack::AckRegistry;
+    use crate::audit::kinds;
+    use crate::builder::clock::test::MockClock;
+    use crate::metadata::{AccountMetadata, Auth, NetworkConfig};
+    use crate::storage::filesystem::FilesystemService;
+    use crate::testing::helpers::CapturingAuditor;
+    use crate::testing::mocks::{MockMetadataStore, MockNetworkClient};
+    use std::sync::Arc;
+    use tempfile::TempDir;
+    use tokio::sync::Mutex;
+
+    fn miden_meta(account_id: &str) -> AccountMetadata {
+        AccountMetadata {
+            account_id: account_id.to_string(),
+            auth: Auth::MidenFalconRpo {
+                cosigner_commitments: vec!["0xc1".into()],
+            },
+            network_config: NetworkConfig::miden_default(),
+            created_at: "2026-07-01T00:00:00Z".into(),
+            updated_at: "2026-07-01T00:00:00Z".into(),
+            has_pending_candidate: false,
+            last_auth_timestamp: None,
+            paused_at: None,
+            paused_reason: None,
+            released_at: None,
+        }
+    }
+
+    async fn state_with(
+        network: MockNetworkClient,
+        metadata: MockMetadataStore,
+        auditor: CapturingAuditor,
+    ) -> AppState {
+        let dir = TempDir::new().expect("tempdir");
+        let storage = FilesystemService::new(dir.path().to_path_buf())
+            .await
+            .expect("svc");
+        let keystore_dir =
+            std::env::temp_dir().join(format!("guardian_test_keystore_{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&keystore_dir).expect("keystore dir");
+        let ack = AckRegistry::new(keystore_dir).await.expect("ack");
+        AppState {
+            storage: Arc::new(storage),
+            metadata: Arc::new(metadata),
+            network_client: Arc::new(Mutex::new(network)),
+            ack,
+            canonicalization: None,
+            clock: Arc::new(MockClock::default()),
+            dashboard: Arc::new(crate::dashboard::DashboardState::default()),
+            auditor: Arc::new(auditor),
+            #[cfg(feature = "evm")]
+            evm: Arc::new(crate::evm::EvmAppState::for_tests()),
+        }
+    }
+
+    #[tokio::test]
+    async fn releases_and_audits_when_guardian_differs() {
+        let network = MockNetworkClient::new()
+            .with_extract_guardian_commitment(Ok(Some("0xother_guardian".into())));
+        let metadata_store = MockMetadataStore::new();
+        let auditor = CapturingAuditor::new();
+        let state = state_with(network, metadata_store.clone(), auditor.clone()).await;
+
+        release_if_guardian_switched(
+            &state,
+            &miden_meta("acc-1"),
+            &serde_json::json!({}),
+            7,
+            "0xnew_commitment",
+        )
+        .await;
+
+        assert_eq!(
+            metadata_store.set_released_calls.lock().unwrap().clone(),
+            vec!["acc-1".to_string()],
+            "guardian mismatch must persist the released transition"
+        );
+        let events = auditor.snapshot();
+        assert_eq!(events.len(), 1, "release must emit exactly one audit event");
+        assert_eq!(events[0].action_kind, kinds::ACCOUNTS_RELEASE);
+        assert_eq!(events[0].operator_identity, SYSTEM_OPERATOR_IDENTITY);
+        assert_eq!(events[0].target_account_id.as_deref(), Some("acc-1"));
+        assert_eq!(
+            events[0].payload["new_guardian_commitment"],
+            "0xother_guardian"
+        );
+        assert_eq!(events[0].payload["delta_nonce"], 7);
+        assert_eq!(events[0].payload["new_commitment"], "0xnew_commitment");
+    }
+
+    #[tokio::test]
+    async fn no_release_when_guardian_is_this_server() {
+        let network = MockNetworkClient::new();
+        let network_handle = network.clone();
+        let metadata_store = MockMetadataStore::new();
+        let auditor = CapturingAuditor::new();
+        let state = state_with(network, metadata_store.clone(), auditor.clone()).await;
+
+        // The state's guardian key IS this server's ack key.
+        let own = state
+            .ack
+            .commitment(&guardian_shared::SignatureScheme::Falcon);
+        network_handle
+            .extract_guardian_commitment_responses
+            .lock()
+            .unwrap()
+            .push(Ok(Some(own)));
+
+        release_if_guardian_switched(
+            &state,
+            &miden_meta("acc-1"),
+            &serde_json::json!({}),
+            7,
+            "0xc",
+        )
+        .await;
+
+        assert!(metadata_store.set_released_calls.lock().unwrap().is_empty());
+        assert!(auditor.snapshot().is_empty());
+    }
+
+    #[tokio::test]
+    async fn no_release_when_state_has_no_guardian_binding() {
+        // Default mock response is Ok(None): no guardian slot visible.
+        let network = MockNetworkClient::new();
+        let metadata_store = MockMetadataStore::new();
+        let auditor = CapturingAuditor::new();
+        let state = state_with(network, metadata_store.clone(), auditor.clone()).await;
+
+        release_if_guardian_switched(
+            &state,
+            &miden_meta("acc-1"),
+            &serde_json::json!({}),
+            7,
+            "0xc",
+        )
+        .await;
+
+        assert!(metadata_store.set_released_calls.lock().unwrap().is_empty());
+        assert!(auditor.snapshot().is_empty());
+    }
+
+    #[tokio::test]
+    async fn extraction_error_is_swallowed_without_release() {
+        let network =
+            MockNetworkClient::new().with_extract_guardian_commitment(Err("corrupt state".into()));
+        let metadata_store = MockMetadataStore::new();
+        let auditor = CapturingAuditor::new();
+        let state = state_with(network, metadata_store.clone(), auditor.clone()).await;
+
+        release_if_guardian_switched(
+            &state,
+            &miden_meta("acc-1"),
+            &serde_json::json!({}),
+            7,
+            "0xc",
+        )
+        .await;
+
+        assert!(metadata_store.set_released_calls.lock().unwrap().is_empty());
+        assert!(auditor.snapshot().is_empty());
+    }
+
+    #[tokio::test]
+    async fn evm_accounts_are_skipped() {
+        // Even with a differing commitment queued, EVM accounts must
+        // never release — there is no on-chain guardian binding.
+        let network = MockNetworkClient::new()
+            .with_extract_guardian_commitment(Ok(Some("0xother_guardian".into())));
+        let metadata_store = MockMetadataStore::new();
+        let auditor = CapturingAuditor::new();
+        let state = state_with(network, metadata_store.clone(), auditor.clone()).await;
+
+        let mut meta = miden_meta("evm:1:0xabc");
+        meta.network_config = NetworkConfig::Evm {
+            chain_id: 1,
+            account_address: "0xabc".into(),
+            multisig_validator_address: "0xdef".into(),
+        };
+
+        release_if_guardian_switched(&state, &meta, &serde_json::json!({}), 7, "0xc").await;
+
+        assert!(metadata_store.set_released_calls.lock().unwrap().is_empty());
+        assert!(auditor.snapshot().is_empty());
+    }
+}

--- a/crates/server/src/services/sign_delta_proposal.rs
+++ b/crates/server/src/services/sign_delta_proposal.rs
@@ -215,6 +215,7 @@ mod tests {
             last_auth_timestamp: None,
             paused_at: None,
             paused_reason: None,
+            released_at: None,
         }
     }
 

--- a/crates/server/src/testing/e2e/mod.rs
+++ b/crates/server/src/testing/e2e/mod.rs
@@ -2,3 +2,4 @@
 #![cfg(feature = "e2e")]
 
 mod configure_account;
+mod switch_guardian_canonicalization;

--- a/crates/server/src/testing/e2e/switch_guardian_canonicalization.rs
+++ b/crates/server/src/testing/e2e/switch_guardian_canonicalization.rs
@@ -55,7 +55,9 @@ use crate::services::{
     ConfigureAccountParams, PushDeltaParams, configure_account, process_canonicalizations_now,
     push_delta,
 };
-use crate::testing::helpers::{IntegrationMockNetworkClient, create_test_app_state};
+use crate::testing::helpers::{
+    CapturingAuditor, IntegrationMockNetworkClient, create_test_app_state,
+};
 
 fn commitment_hex(account: &Account) -> String {
     format!("0x{}", hex::encode(account.to_commitment().as_bytes()))
@@ -213,6 +215,10 @@ async fn test_switch_guardian_delta_canonicalizes_and_releases_on_old_guardian()
     integration_client.register_account(account_id_hex.clone(), executed_commitment_hex.clone());
     state.network_client = Arc::new(tokio::sync::Mutex::new(integration_client));
 
+    // Capture audit emissions so the release event can be asserted.
+    let auditor = CapturingAuditor::new();
+    state.auditor = Arc::new(auditor.clone());
+
     // Onboard the account on this (soon to be old) guardian.
     let api_pubkey_hex = cosigner_pubkeys[0].clone().into_hex();
     let api_commitment_hex = format!(
@@ -332,6 +338,26 @@ async fn test_switch_guardian_delta_canonicalizes_and_releases_on_old_guardian()
     assert!(
         metadata.released_at.is_some(),
         "canonicalized guardian switch must release the account"
+    );
+
+    // The release must be recorded on the audit trail.
+    let release_events: Vec<_> = auditor
+        .snapshot()
+        .into_iter()
+        .filter(|e| e.action_kind == crate::audit::kinds::ACCOUNTS_RELEASE)
+        .collect();
+    assert_eq!(
+        release_events.len(),
+        1,
+        "release must emit exactly one accounts.release audit event"
+    );
+    assert_eq!(
+        release_events[0].target_account_id.as_deref(),
+        Some(account_id_hex.as_str())
+    );
+    assert_eq!(
+        release_events[0].payload["new_guardian_commitment"],
+        new_guardian_commitment_hex
     );
 
     // Mutations are refused with the release-specific error...

--- a/crates/server/src/testing/e2e/switch_guardian_canonicalization.rs
+++ b/crates/server/src/testing/e2e/switch_guardian_canonicalization.rs
@@ -1,0 +1,415 @@
+//! End-to-end confirmation of the issue #305 mechanism.
+//!
+//! Since #287, the multisig client's `execute_proposal` pushes a
+//! `SwitchGuardian` delta (the abort `TransactionSummary`) to the
+//! **pre-switch** guardian via the regular `push_delta` path. This test
+//! reproduces that flow against a real mock chain and asserts the pushed
+//! delta canonicalizes on the old guardian:
+//!
+//! 1. Build a real 2-of-2 multisig account whose guardian key is THIS
+//!    server's ack key — the same binding `/configure` enforces in
+//!    production.
+//! 2. Execute `update_guardian_public_key` on a mock chain twice, exactly
+//!    like `test_switch_guardian_server_reconstruction_matches_execution`
+//!    (crates/contracts/tests/auth/multisig.rs): an abort run to obtain the
+//!    summary the wallet pushes, and a signed run for the authoritative
+//!    on-chain result.
+//! 3. Configure the account on the server, push the switch delta with the
+//!    client's exact payload shape, and run the canonicalization worker with
+//!    the executed commitment registered as the on-chain answer.
+//! 4. Assert the delta canonicalizes, the stored state converges to the
+//!    executed post-switch commitment, and the stored state's guardian
+//!    public key no longer matches this server's ack key.
+//! 5. Assert the release-on-switch reaction: the account transitions to
+//!    `released` (mutations refused, reads still served) and re-onboarding
+//!    via `/configure` reactivates it.
+
+use std::sync::Arc;
+
+use guardian_shared::auth_request_message::AuthRequestMessage;
+use guardian_shared::auth_request_payload::AuthRequestPayload;
+use guardian_shared::hex::IntoHex;
+use guardian_shared::{FromJson, SignatureScheme, ToJson};
+use miden_confidential_contracts::masm_builder::get_guardian_library;
+use miden_confidential_contracts::multisig_guardian::{
+    MultisigGuardianBuilder, MultisigGuardianConfig,
+};
+use miden_protocol::account::auth::AuthSecretKey;
+use miden_protocol::account::{Account, AccountType};
+use miden_protocol::crypto::dsa::falcon512_poseidon2::SecretKey;
+use miden_protocol::utils::serde::{Deserializable, Serializable};
+use miden_protocol::vm::AdviceInputs;
+use miden_protocol::{Felt, Word};
+use miden_standards::code_builder::CodeBuilder;
+use miden_testing::MockChainBuilder;
+use miden_tx::TransactionExecutorError;
+use miden_tx::auth::{BasicAuthenticator, SigningInputs, TransactionAuthenticator};
+
+use crate::delta_object::DeltaObject;
+use crate::metadata::NetworkConfig;
+use crate::metadata::auth::{Auth, Credentials};
+use crate::network::NetworkType;
+use crate::network::miden::MidenNetworkClient;
+use crate::network::miden::account_inspector::MidenAccountInspector;
+use crate::services::{
+    ConfigureAccountParams, PushDeltaParams, configure_account, process_canonicalizations_now,
+    push_delta,
+};
+use crate::testing::helpers::{IntegrationMockNetworkClient, create_test_app_state};
+
+fn commitment_hex(account: &Account) -> String {
+    format!("0x{}", hex::encode(account.to_commitment().as_bytes()))
+}
+
+fn word_from_hex(hex_str: &str) -> Word {
+    let bytes = hex::decode(hex_str.trim_start_matches("0x")).expect("valid hex");
+    Word::read_from_bytes(&bytes).expect("valid word bytes")
+}
+
+fn falcon_credentials(
+    key: &SecretKey,
+    pubkey_hex: &str,
+    account_id_hex: &str,
+    timestamp: i64,
+) -> Credentials {
+    let message = AuthRequestMessage::from_account_id_hex(
+        account_id_hex,
+        timestamp,
+        AuthRequestPayload::empty(),
+    )
+    .expect("valid account ID")
+    .to_word();
+    let signature = key.sign(message);
+    let signature_hex = format!("0x{}", hex::encode(signature.to_bytes()));
+    Credentials::signature(pubkey_hex.to_string(), signature_hex, timestamp)
+}
+
+#[tokio::test]
+async fn test_switch_guardian_delta_canonicalizes_and_releases_on_old_guardian() {
+    let mut state = create_test_app_state().await;
+
+    // The account's guardian key is this server's ack key, mirroring the
+    // binding `/configure` enforces in production.
+    let scheme = SignatureScheme::Falcon;
+    let ack_commitment_hex = state.ack.commitment(&scheme);
+    let ack_commitment_word = word_from_hex(&ack_commitment_hex);
+
+    let cosigner_keys: Vec<SecretKey> = (0..2).map(|_| SecretKey::new()).collect();
+    let cosigner_pubkeys: Vec<_> = cosigner_keys.iter().map(|k| k.public_key()).collect();
+    let signer_commitments: Vec<Word> = cosigner_pubkeys
+        .iter()
+        .map(|pk| pk.to_commitment())
+        .collect();
+
+    let config = MultisigGuardianConfig::new(2, signer_commitments, ack_commitment_word)
+        .with_account_type(AccountType::Public)
+        .with_guardian_enabled(true)
+        .with_signature_scheme(SignatureScheme::Falcon);
+    let multisig_account = MultisigGuardianBuilder::new(config)
+        .build_existing()
+        .expect("multisig account builds");
+
+    let pre_inspector = MidenAccountInspector::new(&multisig_account);
+    assert_eq!(
+        pre_inspector.extract_guardian_public_key().as_deref(),
+        Some(ack_commitment_hex.as_str()),
+        "pre-switch state must carry this server's guardian key"
+    );
+
+    let account_id_hex = multisig_account.id().to_hex();
+    let pre_switch_commitment = commitment_hex(&multisig_account);
+
+    let mock_chain = MockChainBuilder::with_accounts([multisig_account.clone()])
+        .expect("mock chain accepts account")
+        .build()
+        .expect("mock chain builds");
+
+    // The switch target: a fresh guardian key unrelated to this server.
+    let new_guardian_key = SecretKey::new();
+    let new_guardian_commitment = new_guardian_key.public_key().to_commitment();
+    let new_guardian_commitment_hex =
+        format!("0x{}", hex::encode(new_guardian_commitment.to_bytes()));
+
+    let advice_inputs =
+        AdviceInputs::default().with_stack(new_guardian_commitment.as_elements().iter().copied());
+    let guardian_library = get_guardian_library().expect("guardian library compiles");
+    let tx_script_code = r#"
+    use oz_guardian::guardian
+    begin
+        call.guardian::update_guardian_public_key
+    end
+    "#;
+    let tx_script = CodeBuilder::new()
+        .with_dynamically_linked_library(&guardian_library)
+        .expect("library links")
+        .compile_tx_script(tx_script_code)
+        .expect("tx script compiles");
+    let salt = Word::from([Felt::new_unchecked(7); 4]);
+
+    // No-signature execution: the TransactionSummary the wallet pushes to the
+    // pre-switch guardian as the delta payload.
+    let abort_summary = match mock_chain
+        .build_tx_context(multisig_account.id(), &[], &[])
+        .expect("tx context builds")
+        .authenticator(None)
+        .tx_script(tx_script.clone())
+        .extend_advice_inputs(advice_inputs.clone())
+        .auth_args(salt)
+        .build()
+        .expect("tx builds")
+        .execute()
+        .await
+        .unwrap_err()
+    {
+        TransactionExecutorError::Unauthorized(tx_effects) => tx_effects,
+        error => panic!("expected abort with tx effects: {error:?}"),
+    };
+
+    let msg = abort_summary.as_ref().to_commitment();
+    // The exact payload shape the client pushes: `tx_summary.to_json()`.
+    let delta_payload = abort_summary.as_ref().to_json();
+
+    let signing = SigningInputs::TransactionSummary(abort_summary);
+    let authenticator_1 =
+        BasicAuthenticator::new(&[AuthSecretKey::Falcon512Poseidon2(cosigner_keys[0].clone())]);
+    let authenticator_2 =
+        BasicAuthenticator::new(&[AuthSecretKey::Falcon512Poseidon2(cosigner_keys[1].clone())]);
+    let sig_1 = authenticator_1
+        .get_signature(cosigner_pubkeys[0].to_commitment().into(), &signing)
+        .await
+        .expect("cosigner 1 signs");
+    let sig_2 = authenticator_2
+        .get_signature(cosigner_pubkeys[1].to_commitment().into(), &signing)
+        .await
+        .expect("cosigner 2 signs");
+
+    // Real signed execution: the authoritative on-chain result.
+    let executed_tx = mock_chain
+        .build_tx_context(multisig_account.id(), &[], &[])
+        .expect("tx context builds")
+        .authenticator(None)
+        .tx_script(tx_script)
+        .add_signature(cosigner_pubkeys[0].clone().into(), msg, sig_1)
+        .add_signature(cosigner_pubkeys[1].clone().into(), msg, sig_2)
+        .auth_args(salt)
+        .extend_advice_inputs(advice_inputs)
+        .build()
+        .expect("tx builds")
+        .execute()
+        .await
+        .expect("signed switch executes");
+
+    let mut executed_account = multisig_account.clone();
+    executed_account
+        .apply_delta(executed_tx.account_delta())
+        .expect("executed delta applies");
+    let executed_commitment_hex = commitment_hex(&executed_account);
+    let executed_nonce = executed_account.nonce().as_canonical_u64();
+
+    // Network client with real commitment computation; the executed
+    // post-switch commitment is the registered on-chain answer.
+    let miden_client = MidenNetworkClient::lazy_for_test(NetworkType::MidenLocal);
+    let mut integration_client = IntegrationMockNetworkClient::new(miden_client);
+    integration_client.register_account(account_id_hex.clone(), executed_commitment_hex.clone());
+    state.network_client = Arc::new(tokio::sync::Mutex::new(integration_client));
+
+    // Onboard the account on this (soon to be old) guardian.
+    let api_pubkey_hex = cosigner_pubkeys[0].clone().into_hex();
+    let api_commitment_hex = format!(
+        "0x{}",
+        hex::encode(cosigner_pubkeys[0].to_commitment().to_bytes())
+    );
+    let timestamp = chrono::Utc::now().timestamp_millis();
+
+    configure_account(
+        &state,
+        ConfigureAccountParams {
+            account_id: account_id_hex.clone(),
+            auth: Auth::MidenFalconRpo {
+                cosigner_commitments: vec![api_commitment_hex],
+            },
+            network_config: NetworkConfig::miden_default(),
+            initial_state: multisig_account.to_json(),
+            credential: falcon_credentials(
+                &cosigner_keys[0],
+                &api_pubkey_hex,
+                &account_id_hex,
+                timestamp,
+            ),
+        },
+    )
+    .await
+    .expect("configure_account succeeds");
+
+    // Push the switch delta exactly as `execute_proposal` does client-side.
+    let push_result = push_delta(
+        &state,
+        PushDeltaParams {
+            delta: DeltaObject {
+                account_id: account_id_hex.clone(),
+                nonce: executed_nonce,
+                prev_commitment: pre_switch_commitment.clone(),
+                new_commitment: None,
+                delta_payload,
+                ack_sig: String::new(),
+                ack_pubkey: String::new(),
+                ack_scheme: String::new(),
+                status: Default::default(),
+                metadata: None,
+            },
+            credentials: falcon_credentials(
+                &cosigner_keys[0],
+                &api_pubkey_hex,
+                &account_id_hex,
+                timestamp + 1,
+            ),
+        },
+    )
+    .await
+    .expect("push_delta accepts the switch delta");
+
+    assert!(
+        push_result.delta.status.is_candidate(),
+        "delta should await canonicalization, got {:?}",
+        push_result.delta.status
+    );
+
+    process_canonicalizations_now(&state)
+        .await
+        .expect("canonicalization run succeeds");
+
+    let deltas = state
+        .storage
+        .pull_deltas_after(&account_id_hex, 0)
+        .await
+        .expect("deltas readable");
+    let switch_delta = deltas
+        .iter()
+        .find(|d| d.nonce == executed_nonce)
+        .expect("switch delta stored");
+    assert!(
+        switch_delta.status.is_canonical(),
+        "switch delta should canonicalize against the executed on-chain \
+         commitment, got {:?}",
+        switch_delta.status
+    );
+
+    let final_state = state
+        .storage
+        .pull_state(&account_id_hex)
+        .await
+        .expect("state readable");
+    assert_eq!(
+        final_state.commitment, executed_commitment_hex,
+        "old guardian's state must converge to the executed post-switch commitment"
+    );
+
+    // The predicate the release-on-switch transition keys off: the stored
+    // state's guardian key is no longer this server's ack key.
+    let final_account =
+        Account::from_json(&final_state.state_json).expect("stored state deserializes");
+    let post_inspector = MidenAccountInspector::new(&final_account);
+    let guardian_after = post_inspector
+        .extract_guardian_public_key()
+        .expect("guardian pubkey slot present");
+    assert_eq!(
+        guardian_after, new_guardian_commitment_hex,
+        "post-switch state must carry the NEW guardian's key"
+    );
+    assert_ne!(
+        guardian_after, ack_commitment_hex,
+        "post-switch guardian key must differ from this server's ack key"
+    );
+
+    // Release-on-switch (issue #305): canonicalizing the switch delta must
+    // have transitioned the account to `released`.
+    let metadata = state
+        .metadata
+        .get(&account_id_hex)
+        .await
+        .expect("metadata readable")
+        .expect("metadata present");
+    assert!(
+        metadata.released_at.is_some(),
+        "canonicalized guardian switch must release the account"
+    );
+
+    // Mutations are refused with the release-specific error...
+    let rejected = push_delta(
+        &state,
+        PushDeltaParams {
+            delta: DeltaObject {
+                account_id: account_id_hex.clone(),
+                nonce: executed_nonce + 1,
+                prev_commitment: executed_commitment_hex.clone(),
+                new_commitment: None,
+                delta_payload: serde_json::json!({}),
+                ack_sig: String::new(),
+                ack_pubkey: String::new(),
+                ack_scheme: String::new(),
+                status: Default::default(),
+                metadata: None,
+            },
+            credentials: falcon_credentials(
+                &cosigner_keys[0],
+                &api_pubkey_hex,
+                &account_id_hex,
+                timestamp + 2,
+            ),
+        },
+    )
+    .await
+    .expect_err("released account must refuse mutations");
+    assert!(
+        matches!(
+            rejected,
+            crate::error::GuardianError::AccountReleased { .. }
+        ),
+        "expected AccountReleased, got {rejected:?}"
+    );
+
+    // ...while reads keep working so the wallet/operator can fetch final state.
+    let readable = state
+        .storage
+        .pull_state(&account_id_hex)
+        .await
+        .expect("released account state must remain readable");
+    assert_eq!(readable.commitment, executed_commitment_hex);
+
+    // Re-onboarding via /configure reactivates the account (the switch-back
+    // case). Guardian-binding validation is stubbed Ok by the integration
+    // client, mirroring a wallet that switched back to this server.
+    configure_account(
+        &state,
+        ConfigureAccountParams {
+            account_id: account_id_hex.clone(),
+            auth: Auth::MidenFalconRpo {
+                cosigner_commitments: vec![format!(
+                    "0x{}",
+                    hex::encode(cosigner_pubkeys[0].to_commitment().to_bytes())
+                )],
+            },
+            network_config: NetworkConfig::miden_default(),
+            initial_state: executed_account.to_json(),
+            credential: falcon_credentials(
+                &cosigner_keys[0],
+                &api_pubkey_hex,
+                &account_id_hex,
+                timestamp + 3,
+            ),
+        },
+    )
+    .await
+    .expect("re-onboarding a released account succeeds");
+
+    let metadata = state
+        .metadata
+        .get(&account_id_hex)
+        .await
+        .expect("metadata readable")
+        .expect("metadata present");
+    assert!(
+        metadata.released_at.is_none(),
+        "re-onboarding via /configure must clear the released state"
+    );
+}

--- a/crates/server/src/testing/helpers.rs
+++ b/crates/server/src/testing/helpers.rs
@@ -149,6 +149,13 @@ impl NetworkClient for IntegrationMockNetworkClient {
         Ok(())
     }
 
+    fn extract_guardian_commitment(
+        &self,
+        state_json: &serde_json::Value,
+    ) -> Result<Option<String>, String> {
+        self.miden_client.extract_guardian_commitment(state_json)
+    }
+
     async fn should_update_auth(
         &mut self,
         state_json: &serde_json::Value,

--- a/crates/server/src/testing/integration/lookup_helpers.rs
+++ b/crates/server/src/testing/integration/lookup_helpers.rs
@@ -27,6 +27,7 @@ pub fn falcon_account(account_id: &str, cosigner_commitments: Vec<String>) -> Ac
         last_auth_timestamp: None,
         paused_at: None,
         paused_reason: None,
+        released_at: None,
     }
 }
 
@@ -43,6 +44,7 @@ pub fn ecdsa_account(account_id: &str, cosigner_commitments: Vec<String>) -> Acc
         last_auth_timestamp: None,
         paused_at: None,
         paused_reason: None,
+        released_at: None,
     }
 }
 
@@ -57,6 +59,7 @@ pub fn evm_account(account_id: &str, signers: Vec<String>) -> AccountMetadata {
         last_auth_timestamp: None,
         paused_at: None,
         paused_reason: None,
+        released_at: None,
     }
 }
 

--- a/crates/server/src/testing/mocks.rs
+++ b/crates/server/src/testing/mocks.rs
@@ -12,6 +12,7 @@ use std::sync::{Arc, Mutex as StdMutex};
 type StdResult<T, E> = std::result::Result<T, E>;
 type ApplyDeltaResult = StdResult<(serde_json::Value, String), String>;
 type ShouldUpdateAuthResult = StdResult<Option<Auth>, String>;
+type ExtractGuardianCommitmentResult = StdResult<Option<String>, String>;
 type PullDeltasResult = StdResult<Vec<DeltaObject>, String>;
 type GetMetadataResult = StdResult<Option<crate::metadata::AccountMetadata>, String>;
 type ListResult = StdResult<Vec<String>, String>;
@@ -35,6 +36,7 @@ pub struct MockNetworkClient {
     pub verify_delta_responses: Arc<StdMutex<Vec<StdResult<(), String>>>>,
     pub apply_delta_responses: Arc<StdMutex<Vec<ApplyDeltaResult>>>,
     pub should_update_auth_responses: Arc<StdMutex<Vec<ShouldUpdateAuthResult>>>,
+    pub extract_guardian_commitment_responses: Arc<StdMutex<Vec<ExtractGuardianCommitmentResult>>>,
 }
 
 impl MockNetworkClient {
@@ -73,6 +75,17 @@ impl MockNetworkClient {
 
     pub fn with_verify_delta(self, response: StdResult<(), String>) -> Self {
         self.verify_delta_responses.lock().unwrap().push(response);
+        self
+    }
+
+    pub fn with_extract_guardian_commitment(
+        self,
+        response: StdResult<Option<String>, String>,
+    ) -> Self {
+        self.extract_guardian_commitment_responses
+            .lock()
+            .unwrap()
+            .push(response);
         self
     }
 
@@ -199,6 +212,19 @@ impl NetworkClient for MockNetworkClient {
             .unwrap()
             .pop()
             .unwrap_or(Ok(()))
+    }
+
+    fn extract_guardian_commitment(
+        &self,
+        _state_json: &serde_json::Value,
+    ) -> StdResult<Option<String>, String> {
+        // Default `Ok(None)` ("no guardian binding visible") keeps the
+        // release-on-switch hook inert in tests that don't opt in.
+        self.extract_guardian_commitment_responses
+            .lock()
+            .unwrap()
+            .pop()
+            .unwrap_or(Ok(None))
     }
 
     async fn should_update_auth(
@@ -715,6 +741,8 @@ pub struct MockMetadataStore {
     pub update_timestamp_cas_responses: Arc<StdMutex<Vec<StdResult<bool, String>>>>,
     pub find_by_cosigner_commitment_responses: Arc<StdMutex<Vec<ListResult>>>,
     pub find_by_cosigner_commitment_calls: Arc<StdMutex<Vec<String>>>,
+    pub set_released_calls: Arc<StdMutex<Vec<String>>>,
+    pub clear_released_calls: Arc<StdMutex<Vec<String>>>,
     /// Reported by [`MetadataStore::pool_status`]. Defaults to `None`;
     /// set via [`Self::with_pool_status`].
     pub pool_status: Option<crate::storage::PoolStatus>,
@@ -910,5 +938,25 @@ impl MetadataStore for MockMetadataStore {
             paused_at: None,
             paused_reason: None,
         })
+    }
+
+    async fn set_released(
+        &self,
+        account_id: &str,
+        _now: chrono::DateTime<chrono::Utc>,
+    ) -> StdResult<bool, String> {
+        self.set_released_calls
+            .lock()
+            .unwrap()
+            .push(account_id.to_string());
+        Ok(true)
+    }
+
+    async fn clear_released(&self, account_id: &str) -> StdResult<(), String> {
+        self.clear_released_calls
+            .lock()
+            .unwrap()
+            .push(account_id.to_string());
+        Ok(())
     }
 }

--- a/crates/server/src/testing/mocks.rs
+++ b/crates/server/src/testing/mocks.rs
@@ -743,6 +743,7 @@ pub struct MockMetadataStore {
     pub find_by_cosigner_commitment_calls: Arc<StdMutex<Vec<String>>>,
     pub set_released_calls: Arc<StdMutex<Vec<String>>>,
     pub clear_released_calls: Arc<StdMutex<Vec<String>>>,
+    pub clear_released_responses: Arc<StdMutex<Vec<StdResult<(), String>>>>,
     /// Reported by [`MetadataStore::pool_status`]. Defaults to `None`;
     /// set via [`Self::with_pool_status`].
     pub pool_status: Option<crate::storage::PoolStatus>,
@@ -800,6 +801,11 @@ impl MockMetadataStore {
             .lock()
             .unwrap()
             .push(response);
+        self
+    }
+
+    pub fn with_clear_released(self, response: StdResult<(), String>) -> Self {
+        self.clear_released_responses.lock().unwrap().push(response);
         self
     }
 
@@ -957,6 +963,10 @@ impl MetadataStore for MockMetadataStore {
             .lock()
             .unwrap()
             .push(account_id.to_string());
-        Ok(())
+        self.clear_released_responses
+            .lock()
+            .unwrap()
+            .pop()
+            .unwrap_or(Ok(()))
     }
 }

--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -196,6 +196,7 @@ flowchart TB
 | Candidate discarded | Delta status flips `candidate` → `discarded` | Refetch state, rebuild and resubmit. Usually means the Miden proof was never submitted or the on-chain commitment diverged. |
 | Operator censors / withholds | Other cosigners see stale state | Use the user's cold key to rotate Guardian; the new operator inherits canonical state from Miden. |
 | Account paused by operator | State-transition, proposal, and EVM mutation paths return `409 GUARDIAN_ACCOUNT_PAUSED` with `paused_reason` (reads and `ConfigureAccount` keep working) | Operator-driven safety lever, not a fault. An operator with `accounts:pause` clears it via `POST /dashboard/accounts/{id}/unpause`. See [`DASHBOARD.md`](./DASHBOARD.md#account-pausing). |
+| Account switched to another guardian | After the `switch_guardian` delta canonicalizes on this server, mutation paths return `409 GUARDIAN_ACCOUNT_RELEASED` with `released_at` (reads and `ConfigureAccount` keep working); the dashboard shows `released_at` | Expected outcome of a guardian switch, not a fault. Terminal until the wallet re-onboards via `/configure`, which re-validates the guardian binding. An operator unpause never reactivates a released account. |
 | Pubkey changed unexpectedly | `/pubkey` returns a key your client doesn't pin | Treat as compromise. Halt, verify rotation through an out-of-band channel. |
 
 ## Provider rotation

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -265,6 +265,7 @@ come from
 | `pending_proposals_limit` | 409 | Account hit `GUARDIAN_MAX_PENDING_PROPOSALS_PER_ACCOUNT` (default 20). |
 | `proposal_already_signed` | 409 | This signer already signed this proposal. |
 | `GUARDIAN_ACCOUNT_PAUSED` | 409 (gRPC `FailedPrecondition`) | Account is paused by an operator. Response body includes the operator-supplied `paused_reason`. Unpause via `POST /dashboard/accounts/{id}/unpause` (requires `accounts:pause`). See [`DASHBOARD.md`](./DASHBOARD.md#account-pausing). |
+| `GUARDIAN_ACCOUNT_RELEASED` | 409 (gRPC `FailedPrecondition`) | The account switched to a different guardian (a canonicalized `switch_guardian` delta moved the guardian key away from this server) and this server released it. Response body includes `released_at`. Reads keep working; mutations stay refused until the wallet re-onboards via `/configure`. |
 
 ### Validation
 

--- a/docs/openapi-client.json
+++ b/docs/openapi-client.json
@@ -978,6 +978,13 @@
             ],
             "description": "Pause reason. Present only for `GUARDIAN_ACCOUNT_PAUSED`."
           },
+          "released_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "RFC 3339 timestamp of the guardian-switch release. Present only\nfor `GUARDIAN_ACCOUNT_RELEASED`."
+          },
           "retry_after_secs": {
             "type": [
               "integer",
@@ -992,7 +999,7 @@
               "boolean",
               "null"
             ],
-            "description": "`false` for permission denials and `GUARDIAN_ACCOUNT_PAUSED`."
+            "description": "`false` for permission denials, `GUARDIAN_ACCOUNT_PAUSED`, and\n`GUARDIAN_ACCOUNT_RELEASED`."
           },
           "success": {
             "type": "boolean",

--- a/docs/openapi-dashboard.json
+++ b/docs/openapi-dashboard.json
@@ -1525,6 +1525,13 @@
             ],
             "description": "Reason captured at first pause; `None` when active."
           },
+          "released_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "RFC 3339 UTC timestamp at which this server detected the account\nswitched to a different guardian and released it; `None` while\nthis server is the account's guardian."
+          },
           "state_created_at": {
             "type": [
               "string",
@@ -1626,6 +1633,12 @@
             ]
           },
           "paused_reason": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "released_at": {
             "type": [
               "string",
               "null"
@@ -2510,6 +2523,12 @@
                   ]
                 },
                 "paused_reason": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "released_at": {
                   "type": [
                     "string",
                     "null"

--- a/docs/openapi-dashboard.json
+++ b/docs/openapi-dashboard.json
@@ -1391,6 +1391,13 @@
             ],
             "description": "Pause reason. Present only for `GUARDIAN_ACCOUNT_PAUSED`."
           },
+          "released_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "RFC 3339 timestamp of the guardian-switch release. Present only\nfor `GUARDIAN_ACCOUNT_RELEASED`."
+          },
           "retry_after_secs": {
             "type": [
               "integer",
@@ -1405,7 +1412,7 @@
               "boolean",
               "null"
             ],
-            "description": "`false` for permission denials and `GUARDIAN_ACCOUNT_PAUSED`."
+            "description": "`false` for permission denials, `GUARDIAN_ACCOUNT_PAUSED`, and\n`GUARDIAN_ACCOUNT_RELEASED`."
           },
           "success": {
             "type": "boolean",

--- a/docs/openapi-evm.json
+++ b/docs/openapi-evm.json
@@ -832,6 +832,13 @@
             ],
             "description": "Pause reason. Present only for `GUARDIAN_ACCOUNT_PAUSED`."
           },
+          "released_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "RFC 3339 timestamp of the guardian-switch release. Present only\nfor `GUARDIAN_ACCOUNT_RELEASED`."
+          },
           "retry_after_secs": {
             "type": [
               "integer",
@@ -846,7 +853,7 @@
               "boolean",
               "null"
             ],
-            "description": "`false` for permission denials and `GUARDIAN_ACCOUNT_PAUSED`."
+            "description": "`false` for permission denials, `GUARDIAN_ACCOUNT_PAUSED`, and\n`GUARDIAN_ACCOUNT_RELEASED`."
           },
           "success": {
             "type": "boolean",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3093,6 +3093,13 @@
             ],
             "description": "Pause reason. Present only for `GUARDIAN_ACCOUNT_PAUSED`."
           },
+          "released_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "RFC 3339 timestamp of the guardian-switch release. Present only\nfor `GUARDIAN_ACCOUNT_RELEASED`."
+          },
           "retry_after_secs": {
             "type": [
               "integer",
@@ -3107,7 +3114,7 @@
               "boolean",
               "null"
             ],
-            "description": "`false` for permission denials and `GUARDIAN_ACCOUNT_PAUSED`."
+            "description": "`false` for permission denials, `GUARDIAN_ACCOUNT_PAUSED`, and\n`GUARDIAN_ACCOUNT_RELEASED`."
           },
           "success": {
             "type": "boolean",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3487,6 +3487,13 @@
             ],
             "description": "Reason captured at first pause; `None` when active."
           },
+          "released_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "RFC 3339 UTC timestamp at which this server detected the account\nswitched to a different guardian and released it; `None` while\nthis server is the account's guardian."
+          },
           "state_created_at": {
             "type": [
               "string",
@@ -3588,6 +3595,12 @@
             ]
           },
           "paused_reason": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "released_at": {
             "type": [
               "string",
               "null"
@@ -4942,6 +4955,12 @@
                   ]
                 },
                 "paused_reason": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "released_at": {
                   "type": [
                     "string",
                     "null"

--- a/packages/guardian-client/src/http.test.ts
+++ b/packages/guardian-client/src/http.test.ts
@@ -69,6 +69,49 @@ describe('GuardianHttpClient', () => {
       expect(error).toBeInstanceOf(GuardianHttpError);
       expect(error.status).toBe(500);
       expect(error.statusText).toBe('Internal Server Error');
+      // Non-JSON body: no typed envelope fields.
+      expect(error.code).toBeNull();
+      expect(error.releasedAt).toBeNull();
+    });
+
+    it('exposes code and released_at from a GUARDIAN_ACCOUNT_RELEASED envelope', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        statusText: 'Conflict',
+        text: async () =>
+          JSON.stringify({
+            success: false,
+            code: 'GUARDIAN_ACCOUNT_RELEASED',
+            error: 'Account was released',
+            retryable: false,
+            released_at: '2026-07-06T10:00:00Z',
+          }),
+      });
+
+      const error = await client.getPubkey().catch((e) => e);
+      expect(error).toBeInstanceOf(GuardianHttpError);
+      expect(error.status).toBe(409);
+      expect(error.code).toBe('GUARDIAN_ACCOUNT_RELEASED');
+      expect(error.releasedAt).toBe('2026-07-06T10:00:00Z');
+    });
+
+    it('exposes code without releasedAt for other envelope errors', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        text: async () =>
+          JSON.stringify({
+            success: false,
+            code: 'account_not_found',
+            error: "Account '0xabc' not found",
+          }),
+      });
+
+      const error = await client.getPubkey().catch((e) => e);
+      expect(error.code).toBe('account_not_found');
+      expect(error.releasedAt).toBeNull();
     });
   });
 

--- a/packages/guardian-client/src/http.ts
+++ b/packages/guardian-client/src/http.ts
@@ -41,6 +41,22 @@ import {
  * Error thrown by the GUARDIAN HTTP client.
  */
 export class GuardianHttpError extends Error {
+  /**
+   * Stable machine-readable error code from the server's JSON error
+   * envelope (e.g. `GUARDIAN_ACCOUNT_RELEASED`, `GUARDIAN_ACCOUNT_PAUSED`,
+   * `commitment_mismatch`), or `null` when the body is not a JSON
+   * envelope. Callers SHOULD branch on this rather than on `body` text
+   * or the HTTP status alone.
+   */
+  public readonly code: string | null;
+  /**
+   * RFC 3339 UTC timestamp at which the guardian released the account
+   * after it switched to a different guardian. Present only when
+   * `code === 'GUARDIAN_ACCOUNT_RELEASED'` (HTTP 409); the account is
+   * terminal on this server until re-onboarded via `configure`.
+   */
+  public readonly releasedAt: string | null;
+
   constructor(
     public readonly status: number,
     public readonly statusText: string,
@@ -48,6 +64,24 @@ export class GuardianHttpError extends Error {
   ) {
     super(`GUARDIAN HTTP error ${status}: ${statusText} - ${body}`);
     this.name = 'GuardianHttpError';
+    let code: string | null = null;
+    let releasedAt: string | null = null;
+    try {
+      const parsed: unknown = JSON.parse(body);
+      if (parsed !== null && typeof parsed === 'object') {
+        const record = parsed as Record<string, unknown>;
+        if (typeof record['code'] === 'string') {
+          code = record['code'];
+        }
+        if (typeof record['released_at'] === 'string') {
+          releasedAt = record['released_at'];
+        }
+      }
+    } catch {
+      // Non-JSON body (e.g. proxy HTML error page): keep raw `body` only.
+    }
+    this.code = code;
+    this.releasedAt = releasedAt;
   }
 }
 

--- a/packages/guardian-operator-client/src/http.test.ts
+++ b/packages/guardian-operator-client/src/http.test.ts
@@ -114,6 +114,7 @@ describe('GuardianOperatorHttpClient', () => {
             updated_at: '2026-04-22T11:00:00Z',
             paused_at: null,
             paused_reason: null,
+            released_at: null,
           },
         ],
         next_cursor: null,
@@ -136,6 +137,7 @@ describe('GuardianOperatorHttpClient', () => {
           updatedAt: '2026-04-22T11:00:00Z',
           pausedAt: null,
           pausedReason: null,
+          releasedAt: null,
         },
       ],
       nextCursor: null,
@@ -294,6 +296,7 @@ describe('GuardianOperatorHttpClient', () => {
       state_updated_at: null,
       paused_at: null,
       paused_reason: null,
+      released_at: null,
     }));
 
     const client = new GuardianOperatorHttpClient('https://guardian.example/api');
@@ -1719,6 +1722,21 @@ describe('GuardianOperatorHttpClient — account pausing (feature 001)', () => {
   });
 });
 
+describe('parseErrorBody — account_released', () => {
+  it('maps GUARDIAN_ACCOUNT_RELEASED to account_released with releasedAt and retryable=false', async () => {
+    const parsed = await parseErrorBody({
+      success: false,
+      code: 'GUARDIAN_ACCOUNT_RELEASED',
+      error: 'account was released',
+      released_at: '2026-07-06T10:00:00Z',
+    });
+    expect(parsed.code).toBe('account_released');
+    expect(parsed.releasedAt).toBe('2026-07-06T10:00:00Z');
+    expect(parsed.retryable).toBe(false);
+    expect(isDashboardErrorCode('account_released')).toBe(true);
+  });
+});
+
 describe('GuardianOperatorHttpClient — account pause/unpause', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', mockFetch);
@@ -1901,6 +1919,53 @@ describe('GuardianOperatorHttpClient — account pause/unpause', () => {
 
     expect(err.data?.code).toBe('account_paused');
     expect(err.data?.pausedReason).toBeNull();
+  });
+
+  it('normalizes a 409 GUARDIAN_ACCOUNT_RELEASED into code account_released with releasedAt', async () => {
+    mockFetch.mockResolvedValueOnce(
+      errorResponse({
+        status: 409,
+        statusText: 'Conflict',
+        body: {
+          success: false,
+          code: 'GUARDIAN_ACCOUNT_RELEASED',
+          error: 'account was released',
+          released_at: '2026-07-06T10:00:00Z',
+          retryable: false,
+        },
+      }),
+    );
+    const client = new GuardianOperatorHttpClient('https://guardian.example');
+    const err = (await client
+      .pauseAccount('0xabc', 'reason')
+      .catch((v) => v)) as GuardianOperatorHttpError;
+
+    expect(err).toBeInstanceOf(GuardianOperatorHttpError);
+    expect(err.status).toBe(409);
+    expect(err.data?.code).toBe('account_released');
+    expect(err.data?.releasedAt).toBe('2026-07-06T10:00:00Z');
+    expect(err.data?.retryable).toBe(false);
+  });
+
+  it('drops parsed details when an account_released error omits released_at (contract drift)', async () => {
+    mockFetch.mockResolvedValueOnce(
+      errorResponse({
+        status: 409,
+        statusText: 'Conflict',
+        body: {
+          success: false,
+          code: 'GUARDIAN_ACCOUNT_RELEASED',
+          error: 'account was released',
+        },
+      }),
+    );
+    const client = new GuardianOperatorHttpClient('https://guardian.example');
+    const err = (await client
+      .pauseAccount('0xabc', 'reason')
+      .catch((v) => v)) as GuardianOperatorHttpError;
+    expect(err).toBeInstanceOf(GuardianOperatorHttpError);
+    expect(err.status).toBe(409);
+    expect(err.data).toBeNull();
   });
 
   it('drops parsed details when an account_paused error omits paused_at (contract drift)', async () => {

--- a/packages/guardian-operator-client/src/http.ts
+++ b/packages/guardian-operator-client/src/http.ts
@@ -88,6 +88,9 @@ const DASHBOARD_ERROR_CODES = new Set<DashboardErrorCode>([
   'insufficient_operator_permission',
   // Same wire-form / TS-form mapping as `insufficient_operator_permission`.
   'account_paused',
+  // Same wire-form / TS-form mapping; wire string is
+  // `GUARDIAN_ACCOUNT_RELEASED`.
+  'account_released',
 ]);
 
 /** Server-emitted wire form for the permission-denial error code. */
@@ -96,6 +99,9 @@ const WIRE_INSUFFICIENT_OPERATOR_PERMISSION =
 
 /** Server-emitted wire form for the account-paused error code. */
 const WIRE_ACCOUNT_PAUSED = 'GUARDIAN_ACCOUNT_PAUSED';
+
+/** Server-emitted wire form for the account-released error code. */
+const WIRE_ACCOUNT_RELEASED = 'GUARDIAN_ACCOUNT_RELEASED';
 
 /**
  * Map a server-emitted error `code` to the typed
@@ -109,6 +115,9 @@ function mapDashboardErrorCode(raw: string | null): string | null {
   }
   if (raw === WIRE_ACCOUNT_PAUSED) {
     return 'account_paused';
+  }
+  if (raw === WIRE_ACCOUNT_RELEASED) {
+    return 'account_released';
   }
   return raw;
 }
@@ -146,6 +155,12 @@ export interface ParsedErrorBody {
    * non-null reason).
    */
   pausedReason?: string | null;
+  /**
+   * Populated only when `code === 'account_released'`. RFC 3339 UTC
+   * timestamp at which the server detected the account switched to a
+   * different guardian and released it.
+   */
+  releasedAt?: string;
 }
 
 /**
@@ -219,6 +234,7 @@ export async function parseErrorBody(
   let retryable: boolean | undefined;
   let pausedAt: string | undefined;
   let pausedReason: string | null | undefined;
+  let releasedAt: string | undefined;
   if (code === 'insufficient_operator_permission') {
     const missingRaw = record['missing_permissions'];
     if (
@@ -240,6 +256,12 @@ export async function parseErrorBody(
       pausedReason = null;
     }
     retryable = false;
+  } else if (code === 'account_released') {
+    const releasedAtRaw = record['released_at'];
+    if (typeof releasedAtRaw === 'string') {
+      releasedAt = releasedAtRaw;
+    }
+    retryable = false;
   }
 
   return {
@@ -250,6 +272,7 @@ export async function parseErrorBody(
     retryable,
     pausedAt,
     pausedReason,
+    releasedAt,
   };
 }
 
@@ -968,6 +991,7 @@ function parseAccountSummary(
     updatedAt: requireString(record, 'updated_at', context),
     pausedAt: requireNullableString(record, 'paused_at', context),
     pausedReason: requireNullableString(record, 'paused_reason', context),
+    releasedAt: requireNullableString(record, 'released_at', context),
   };
   if (record.account_id_bech32 !== undefined && record.account_id_bech32 !== null) {
     if (typeof record.account_id_bech32 !== 'string') {
@@ -1087,6 +1111,7 @@ function parseErrorResponse(value: unknown): GuardianOperatorHttpErrorData {
   let retryable: boolean | undefined;
   let pausedAt: string | undefined;
   let pausedReason: string | null | undefined;
+  let releasedAt: string | undefined;
   if (code === 'insufficient_operator_permission') {
     const missingRaw = record.missing_permissions;
     if (missingRaw !== undefined) {
@@ -1140,6 +1165,23 @@ function parseErrorResponse(value: unknown): GuardianOperatorHttpErrorData {
       );
     }
     retryable = false;
+  } else if (code === 'account_released') {
+    const releasedAtRaw = record.released_at;
+    if (typeof releasedAtRaw !== 'string') {
+      throw new GuardianOperatorContractError(
+        'error response',
+        'released_at must be a string for account_released',
+      );
+    }
+    releasedAt = releasedAtRaw;
+    const retryableRaw = record.retryable;
+    if (retryableRaw !== undefined && retryableRaw !== false) {
+      throw new GuardianOperatorContractError(
+        'error response',
+        'retryable must be false for account_released',
+      );
+    }
+    retryable = false;
   }
 
   return {
@@ -1151,6 +1193,7 @@ function parseErrorResponse(value: unknown): GuardianOperatorHttpErrorData {
     retryable,
     pausedAt,
     pausedReason,
+    releasedAt,
   };
 }
 

--- a/packages/guardian-operator-client/src/index.ts
+++ b/packages/guardian-operator-client/src/index.ts
@@ -18,6 +18,7 @@ export type { OperatorPermission } from './permissions.js';
 
 export type {
   AccountPausedErrorDetails,
+  AccountReleasedErrorDetails,
   AccountStatus,
   DashboardAccountDetail,
   DashboardAccountResponse,

--- a/packages/guardian-operator-client/src/server-types.ts
+++ b/packages/guardian-operator-client/src/server-types.ts
@@ -36,6 +36,12 @@ export interface GuardianDashboardAccountSummary {
   paused_at: string | null;
   /** Reason captured at first pause; `null` when active. */
   paused_reason: string | null;
+  /**
+   * RFC 3339 UTC timestamp at which this server detected the account
+   * switched to a different guardian and released it; `null` while
+   * this server is the account's guardian.
+   */
+  released_at: string | null;
 }
 
 export interface GuardianDashboardAccountDetail extends GuardianDashboardAccountSummary {
@@ -70,6 +76,18 @@ export const GUARDIAN_ACCOUNT_PAUSED = 'GUARDIAN_ACCOUNT_PAUSED' as const;
 export interface GuardianAccountPausedErrorDetails {
   paused_at: string;
   paused_reason: string | null;
+}
+
+/**
+ * Stable error code returned by mutating endpoints when the target
+ * account was released after switching to a different guardian.
+ * HTTP 409, gRPC FAILED_PRECONDITION. Terminal until the wallet
+ * re-onboards via `/configure`.
+ */
+export const GUARDIAN_ACCOUNT_RELEASED = 'GUARDIAN_ACCOUNT_RELEASED' as const;
+
+export interface GuardianAccountReleasedErrorDetails {
+  released_at: string;
 }
 
 export interface GuardianDashboardAccountsResponse {

--- a/packages/guardian-operator-client/src/types.ts
+++ b/packages/guardian-operator-client/src/types.ts
@@ -41,6 +41,12 @@ export interface GuardianOperatorHttpErrorData {
    * for forward compatibility).
    */
   pausedReason?: string | null;
+  /**
+   * Populated only for `account_released` responses. RFC 3339 UTC
+   * timestamp at which the server detected the account switched to a
+   * different guardian and released it.
+   */
+  releasedAt?: string;
 }
 
 export interface GuardianOperatorHttpClientOptions {
@@ -110,6 +116,12 @@ export interface DashboardAccountSummary {
   pausedAt: string | null;
   /** Reason captured at first pause; `null` when active. */
   pausedReason: string | null;
+  /**
+   * RFC 3339 UTC timestamp at which this server detected the account
+   * switched to a different guardian and released it; `null` while
+   * this server is the account's guardian.
+   */
+  releasedAt: string | null;
 }
 
 export interface DashboardAccountDetail extends DashboardAccountSummary {
@@ -140,6 +152,11 @@ export interface UnpauseAccountResponse {
 export interface AccountPausedErrorDetails {
   pausedAt: string;
   pausedReason: string | null;
+}
+
+/** Typed details carried on the `GUARDIAN_ACCOUNT_RELEASED` error envelope. */
+export interface AccountReleasedErrorDetails {
+  releasedAt: string;
 }
 
 /**
@@ -209,7 +226,12 @@ export type DashboardErrorCode =
   // paused. Exposed as snake_case to match the rest of the
   // vocabulary; server wire string is `GUARDIAN_ACCOUNT_PAUSED` and
   // the http.ts mapping layer translates between the two.
-  | 'account_paused';
+  | 'account_paused'
+  // Surfaced from mutating endpoints when the target account switched
+  // to a different guardian and was released (issue #305). Same
+  // wire-form / TS-form mapping as `account_paused`; server wire
+  // string is `GUARDIAN_ACCOUNT_RELEASED`.
+  | 'account_released';
 
 export interface PagedResult<T> {
   items: T[];


### PR DESCRIPTION
## Summary

Fixes #305 — after a wallet switches guardians, the old guardian kept listing the account and accepting mutations, producing split-brain state.

Since #287, both multisig clients already push the `SwitchGuardian` delta to the **pre-switch** guardian, best-effort, so it canonicalizes there like any other delta. The missing piece was the server-side reaction — this PR adds it, per the approach discussed in the issue: **recognize-and-release, no new endpoint.**

## How it works

After a delta commits (optimistic mode) or canonicalizes (candidate mode — already verified against the on-chain commitment by the worker), the server compares the guardian public key commitment in the resulting state (same extraction `validate_guardian_commitment` uses in `/configure`) against its own ack key. On mismatch, the account transitions to a terminal **released** state:

- Mutating endpoints (`push_delta`, `push_delta_proposal`, `sign_delta_proposal`) refuse with `409 GUARDIAN_ACCOUNT_RELEASED` (gRPC `FailedPrecondition`), carrying `released_at`. Reads keep working so the wallet/operator can fetch final state.
- An `accounts.release` audit event records the new guardian commitment, delta nonce, and commitment.
- The dashboard account list/detail expose `released_at`.
- Only re-onboarding via `/configure` — which re-validates the guardian binding — reactivates the account. Released is orthogonal to pause, so an operator unpause can never resurrect a switched-away account; `/configure` clears released but preserves pause (deliberate, tested asymmetry).
- Like pause, released state is owned by dedicated `set_released`/`clear_released` metadata methods (filesystem + Postgres, with migration); generic metadata writes never change it.

Because the trigger is a commitment-bound, chain-verified delta, there is no new authenticated surface and nothing to replay — and the old guardian converges to the exact post-switch commitment instead of freezing stale, so dashboards on both guardians show the same commitment, one marked released.

## Testing

New e2e test (`--features e2e`) exercises the full production flow: a real `update_guardian_public_key` executed on a mock chain (mirroring `test_switch_guardian_server_reconstruction_matches_execution`), the client's exact `tx_summary.to_json()` payload pushed through the real `push_delta` service, the canonicalization worker verifying against the executed on-chain commitment, then the release lifecycle — released set, mutation refused, reads served, `/configure` reactivation. Unit tests cover the hook (mismatch/match/no-binding/error/EVM), the chokepoint (released wins over paused), first-writer-wins and set()-preservation semantics, and `/configure` clearing.

## Out of scope (follow-ups)

- TS operator-client typing for `released_at` / `account_released` (server changes are backward-compatible without it).
- Chain-reconciliation sweep for clients that never push (the push is best-effort by design — `ProposalResult::Offline` lets a switch proceed with an unreachable old guardian), and longer-term the node-side filtered-events API. The release transition takes any detection source, so both plug in later.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking when an account is released after switching guardians.
  * Dashboard account summaries and details now include a `released_at` timestamp.
  * Mutation responses now return a clear account-released error with timestamp details.
  * Re-onboarding via configure now restores released accounts.

* **Bug Fixes**
  * Released status is now preserved correctly during account updates.
  * Release state is handled consistently across dashboard, API, and storage paths.

* **Documentation**
  * Updated troubleshooting, concepts, and API schemas to reflect the new released-account behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->