### PR TITLE
fix(server): release diverged canonicalization candidates instead of …

### DIFF
--- a/crates/server/src/builder/canonicalization.rs
+++ b/crates/server/src/builder/canonicalization.rs
@@ -13,6 +13,14 @@ pub struct CanonicalizationConfig {
 
     /// Minimum age a candidate must reach before verification failures consume retry budget.
     pub submission_grace_period_seconds: u64,
+
+    /// Consecutive worker ticks that must observe the on-chain commitment at
+    /// neither the candidate's previous nor its expected new commitment before
+    /// the candidate is discarded as diverged (the account advanced past the
+    /// state it was built on, so it can never verify). Values above 1 shield
+    /// against acting on a single stale RPC read; the divergence discard
+    /// bypasses the submission grace period.
+    pub divergence_confirmations: u32,
 }
 
 impl Default for CanonicalizationConfig {
@@ -21,6 +29,7 @@ impl Default for CanonicalizationConfig {
             check_interval_seconds: 10,           // Try every 10 seconds
             max_retries: 18,                      // 18 attempts (total: ~3 minutes)
             submission_grace_period_seconds: 600, // Allow proving/submission to settle first
+            divergence_confirmations: 2,          // Two ticks to rule out a stale read
         }
     }
 }
@@ -32,6 +41,7 @@ impl CanonicalizationConfig {
             check_interval_seconds,
             max_retries,
             submission_grace_period_seconds: Self::default().submission_grace_period_seconds,
+            divergence_confirmations: Self::default().divergence_confirmations,
         }
     }
 
@@ -49,5 +59,12 @@ impl CanonicalizationConfig {
     /// Get submission grace period as Duration
     pub fn submission_grace_period(&self) -> Duration {
         Duration::from_secs(self.submission_grace_period_seconds)
+    }
+
+    /// Override the number of consecutive diverged observations required
+    /// before a candidate is discarded.
+    pub fn with_divergence_confirmations(mut self, confirmations: u32) -> Self {
+        self.divergence_confirmations = confirmations;
+        self
     }
 }

--- a/crates/server/src/builder/startup.rs
+++ b/crates/server/src/builder/startup.rs
@@ -149,6 +149,7 @@ mod tests {
                 check_interval_seconds: 10,
                 max_retries: 48,
                 submission_grace_period_seconds: 600,
+                divergence_confirmations: 2,
             }),
             3,
             true,

--- a/crates/server/src/delta_object.rs
+++ b/crates/server/src/delta_object.rs
@@ -25,9 +25,10 @@ pub enum DeltaStatus {
         /// Consecutive canonicalization ticks that observed the on-chain
         /// commitment at neither this delta's `prev_commitment` nor its
         /// expected new commitment — i.e. the account advanced past the
-        /// state this candidate was built on. Requiring more than one
-        /// observation before discarding shields against a single stale
-        /// RPC read.
+        /// state this candidate was built on. Reset to zero whenever a
+        /// read shows the account still at the candidate's base, so only
+        /// an unbroken streak counts. Requiring more than one observation
+        /// before discarding shields against stale RPC reads.
         #[serde(default)]
         divergence_count: u32,
     },
@@ -141,6 +142,21 @@ impl DeltaStatus {
                 timestamp: timestamp.clone(),
                 retry_count: *retry_count,
                 divergence_count: divergence_count + 1,
+            },
+            _ => self.clone(),
+        }
+    }
+
+    pub fn with_reset_divergence(&self) -> Self {
+        match self {
+            Self::Candidate {
+                timestamp,
+                retry_count,
+                divergence_count: _,
+            } => Self::Candidate {
+                timestamp: timestamp.clone(),
+                retry_count: *retry_count,
+                divergence_count: 0,
             },
             _ => self.clone(),
         }

--- a/crates/server/src/delta_object.rs
+++ b/crates/server/src/delta_object.rs
@@ -22,6 +22,14 @@ pub enum DeltaStatus {
         timestamp: String,
         #[serde(default)]
         retry_count: u32,
+        /// Consecutive canonicalization ticks that observed the on-chain
+        /// commitment at neither this delta's `prev_commitment` nor its
+        /// expected new commitment — i.e. the account advanced past the
+        /// state this candidate was built on. Requiring more than one
+        /// observation before discarding shields against a single stale
+        /// RPC read.
+        #[serde(default)]
+        divergence_count: u32,
     },
     Canonical {
         timestamp: String,
@@ -44,6 +52,7 @@ impl DeltaStatus {
         Self::Candidate {
             timestamp,
             retry_count: 0,
+            divergence_count: 0,
         }
     }
 
@@ -51,6 +60,7 @@ impl DeltaStatus {
         Self::Candidate {
             timestamp,
             retry_count,
+            divergence_count: 0,
         }
     }
 
@@ -94,18 +104,44 @@ impl DeltaStatus {
         }
     }
 
+    pub fn divergence_count(&self) -> u32 {
+        match self {
+            Self::Candidate {
+                divergence_count, ..
+            } => *divergence_count,
+            _ => 0,
+        }
+    }
+
     pub fn with_incremented_retry(&self, new_timestamp: String) -> Self {
         match self {
             Self::Candidate {
                 timestamp,
                 retry_count,
+                divergence_count,
             } => {
                 let _ = new_timestamp;
                 Self::Candidate {
                     timestamp: timestamp.clone(),
                     retry_count: retry_count + 1,
+                    divergence_count: *divergence_count,
                 }
             }
+            _ => self.clone(),
+        }
+    }
+
+    pub fn with_incremented_divergence(&self) -> Self {
+        match self {
+            Self::Candidate {
+                timestamp,
+                retry_count,
+                divergence_count,
+            } => Self::Candidate {
+                timestamp: timestamp.clone(),
+                retry_count: *retry_count,
+                divergence_count: divergence_count + 1,
+            },
             _ => self.clone(),
         }
     }
@@ -116,6 +152,7 @@ impl Default for DeltaStatus {
         Self::Candidate {
             timestamp: String::new(),
             retry_count: 0,
+            divergence_count: 0,
         }
     }
 }
@@ -364,6 +401,7 @@ mod tests {
         let candidate = DeltaStatus::Candidate {
             timestamp: "2024-01-02".to_string(),
             retry_count: 0,
+            divergence_count: 0,
         };
         assert!(!candidate.is_pending());
         assert!(candidate.is_candidate());

--- a/crates/server/src/jobs/canonicalization/processor.rs
+++ b/crates/server/src/jobs/canonicalization/processor.rs
@@ -182,8 +182,11 @@ impl DeltasProcessorBase {
             }
             // On-chain still shows the candidate's base state: the
             // transaction simply has not landed yet. Defer within the
-            // grace period, then consume retry budget, as before.
+            // grace period, then consume retry budget, as before. This
+            // read also proves any earlier diverged observation was
+            // stale, so the divergence streak starts over.
             Ok(StateVerification::Mismatch { on_chain }) => {
+                let delta = self.reset_divergence_streak(delta).await?;
                 self.handle_unverified_candidate(
                     delta,
                     &format!("on-chain commitment still at candidate base {on_chain}"),
@@ -191,10 +194,40 @@ impl DeltasProcessorBase {
                 .await
             }
             // The comparison itself failed (RPC error, malformed state):
-            // indistinguishable from transient trouble, so keep the
-            // grace/retry behavior.
+            // no observation was made, so the divergence streak is left
+            // untouched and the grace/retry behavior applies.
             Err(e) => self.handle_unverified_candidate(delta, &e).await,
         }
+    }
+
+    /// Reset a candidate's persisted divergence streak after a read showed
+    /// the account still at the candidate's base: divergence must be
+    /// observed on *consecutive* ticks, so a non-diverged observation in
+    /// between restarts the count. No-op (and no storage write) unless a
+    /// streak was in progress.
+    async fn reset_divergence_streak(&self, mut delta: DeltaObject) -> Result<DeltaObject> {
+        if delta.status.divergence_count() == 0 {
+            return Ok(delta);
+        }
+
+        tracing::info!(
+            account_id = %delta.account_id,
+            nonce = delta.nonce,
+            divergence_count = delta.status.divergence_count(),
+            "On-chain commitment back at candidate base; resetting divergence streak"
+        );
+
+        let new_status = delta.status.with_reset_divergence();
+        self.state
+            .storage
+            .update_delta_status(&delta.account_id, delta.nonce, new_status.clone())
+            .await
+            .map_err(|e| {
+                GuardianError::StorageError(format!("Failed to update delta status: {e}"))
+            })?;
+        delta.status = new_status;
+
+        Ok(delta)
     }
 
     /// Handle a candidate whose account moved past its base state on-chain.
@@ -1137,6 +1170,88 @@ mod tests {
             vec![(account_id.to_string(), 1)]
         );
         assert!(storage.get_update_delta_status_calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_divergence_streak_resets_on_base_observation() {
+        // diverged -> base -> diverged must NOT accumulate to the threshold:
+        // the base read proves the earlier diverged read was stale, so the
+        // streak restarts and the candidate survives all three ticks.
+        let account_id = "0xtest_account";
+
+        let fresh = create_candidate_delta(account_id, 1);
+        let mut once_diverged = create_candidate_delta(account_id, 1);
+        once_diverged.status = DeltaStatus::Candidate {
+            timestamp: "2024-01-01T00:00:00Z".to_string(),
+            retry_count: 0,
+            divergence_count: 1,
+        };
+
+        // Response queues are LIFO (`Vec::pop`), so tick 3's responses are
+        // pushed first and tick 1's last. Ticks 2 and 3 pull the candidate
+        // as the previous tick persisted it (the mock store is stateless).
+        let storage = Arc::new(
+            MockStorageBackend::new()
+                // tick 3: streak was reset on tick 2
+                .with_pull_deltas_after(Ok(vec![fresh.clone()]))
+                .with_pull_state(Ok(create_test_state(account_id)))
+                // tick 2: streak of 1 persisted by tick 1
+                .with_pull_deltas_after(Ok(vec![once_diverged]))
+                .with_pull_state(Ok(create_test_state(account_id)))
+                // tick 1: fresh candidate
+                .with_pull_deltas_after(Ok(vec![fresh]))
+                .with_pull_state(Ok(create_test_state(account_id))),
+        );
+
+        let mock_network = MockNetworkClient::new()
+            // tick 3: diverged again
+            .with_verify_state(Ok(StateVerification::Mismatch {
+                on_chain: "0xsome_other_commitment".to_string(),
+            }))
+            // tick 2: back at the candidate's base
+            .with_verify_state(Ok(StateVerification::Mismatch {
+                on_chain: "prev_commitment".to_string(),
+            }))
+            // tick 1: diverged
+            .with_verify_state(Ok(StateVerification::Mismatch {
+                on_chain: "0xsome_other_commitment".to_string(),
+            }));
+
+        let mock_metadata = MockMetadataStore::new()
+            .with_list_with_pending_candidates(Ok(vec![account_id.to_string()]))
+            .with_list_with_pending_candidates(Ok(vec![account_id.to_string()]))
+            .with_list_with_pending_candidates(Ok(vec![account_id.to_string()]))
+            .with_get(Ok(Some(create_test_metadata(account_id))));
+        let metadata = Arc::new(mock_metadata);
+
+        let clock = Arc::new(MockClock::new(
+            Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 5).unwrap(),
+        ));
+        let state = create_test_app_state_with_clock(
+            storage.clone(),
+            Arc::new(tokio::sync::Mutex::new(mock_network)),
+            metadata.clone(),
+            clock,
+        );
+
+        let config = CanonicalizationConfig::new(10, 18).with_submission_grace_period_seconds(600);
+        let processor = DeltasProcessor::new(state, config);
+
+        for _ in 0..3 {
+            let result = processor.process_all_accounts().await;
+            assert!(result.is_ok());
+        }
+
+        // Tick 1 starts a streak, tick 2 resets it, tick 3 starts over —
+        // never reaching the threshold of 2.
+        let observed: Vec<u32> = storage
+            .get_update_delta_status_calls()
+            .iter()
+            .map(|(_, _, status)| status.divergence_count())
+            .collect();
+        assert_eq!(observed, vec![1, 0, 1]);
+        assert!(storage.get_delete_delta_calls().is_empty());
+        assert!(metadata.get_set_calls().is_empty());
     }
 
     #[tokio::test]

--- a/crates/server/src/jobs/canonicalization/processor.rs
+++ b/crates/server/src/jobs/canonicalization/processor.rs
@@ -1,6 +1,7 @@
 use crate::canonicalization::CanonicalizationConfig;
 use crate::delta_object::{DeltaObject, DeltaStatus};
 use crate::error::{GuardianError, Result};
+use crate::network::StateVerification;
 use crate::state::AppState;
 use crate::state_object::StateObject;
 use async_trait::async_trait;
@@ -38,6 +39,7 @@ struct DeltasProcessorBase {
     state: AppState,
     max_retries: u32,
     submission_grace_period_seconds: u64,
+    divergence_confirmations: u32,
 }
 
 impl DeltasProcessorBase {
@@ -156,7 +158,7 @@ impl DeltasProcessorBase {
         };
 
         match verify_result {
-            Ok(()) => {
+            Ok(StateVerification::Match) => {
                 if let Some(new_commitment) = delta.new_commitment.clone() {
                     self.canonicalize_verified_delta(delta, new_state_json, new_commitment)
                         .await
@@ -169,135 +171,214 @@ impl DeltasProcessorBase {
                     Ok(())
                 }
             }
-            Err(e) => {
-                let now = self.state.clock.now();
-                if let Some(candidate_age_seconds) = self.candidate_age_seconds(&delta, now)
-                    && candidate_age_seconds < self.submission_grace_period_seconds
-                {
-                    tracing::info!(
-                        account_id = %delta.account_id,
-                        nonce = delta.nonce,
-                        candidate_age_seconds,
-                        submission_grace_period_seconds = self.submission_grace_period_seconds,
-                        error = %e,
-                        "Delta verification failed during submission grace period; will retry without consuming retry budget"
-                    );
-                    record_candidate_outcome(
-                        crate::metrics::labels::CandidateOutcome::GraceDeferred,
-                    );
+            // The account advanced past the state this candidate was built
+            // on: its transaction is anchored to `prev_commitment`, so it can
+            // never land anymore and the expected commitment is permanently
+            // unsatisfiable. Waiting out the grace period would only keep the
+            // account locked (every new proposal 409s meanwhile) — discard as
+            // soon as the divergence is confirmed.
+            Ok(StateVerification::Mismatch { on_chain }) if on_chain != delta.prev_commitment => {
+                self.handle_diverged_candidate(delta, &on_chain).await
+            }
+            // On-chain still shows the candidate's base state: the
+            // transaction simply has not landed yet. Defer within the
+            // grace period, then consume retry budget, as before.
+            Ok(StateVerification::Mismatch { on_chain }) => {
+                self.handle_unverified_candidate(
+                    delta,
+                    &format!("on-chain commitment still at candidate base {on_chain}"),
+                )
+                .await
+            }
+            // The comparison itself failed (RPC error, malformed state):
+            // indistinguishable from transient trouble, so keep the
+            // grace/retry behavior.
+            Err(e) => self.handle_unverified_candidate(delta, &e).await,
+        }
+    }
 
-                    return Ok(());
-                }
+    /// Handle a candidate whose account moved past its base state on-chain.
+    ///
+    /// Discarding is gated on `divergence_confirmations` consecutive
+    /// observations: a single read can come from a lagging RPC node whose
+    /// stale commitment looks diverged while the candidate's transaction
+    /// actually landed. The counter is persisted on the delta status so
+    /// confirmation survives worker restarts.
+    async fn handle_diverged_candidate(&self, delta: DeltaObject, on_chain: &str) -> Result<()> {
+        let observations = delta.status.divergence_count() + 1;
 
-                let current_retry = delta.status.retry_count();
-                let new_retry = current_retry + 1;
-                let now = now.to_rfc3339();
+        if observations < self.divergence_confirmations {
+            tracing::info!(
+                account_id = %delta.account_id,
+                nonce = delta.nonce,
+                on_chain = %on_chain,
+                prev_commitment = %delta.prev_commitment,
+                observations,
+                divergence_confirmations = self.divergence_confirmations,
+                "On-chain commitment matches neither candidate base nor expected state; \
+                 deferring discard until divergence is confirmed"
+            );
 
-                if new_retry >= self.max_retries {
+            let new_status = delta.status.with_incremented_divergence();
+            self.state
+                .storage
+                .update_delta_status(&delta.account_id, delta.nonce, new_status)
+                .await
+                .map_err(|e| {
+                    GuardianError::StorageError(format!("Failed to update delta status: {e}"))
+                })?;
+            record_candidate_outcome(crate::metrics::labels::CandidateOutcome::DivergenceDeferred);
+
+            return Ok(());
+        }
+
+        tracing::warn!(
+            account_id = %delta.account_id,
+            nonce = delta.nonce,
+            on_chain = %on_chain,
+            prev_commitment = %delta.prev_commitment,
+            observations,
+            "Account advanced past candidate's base state on-chain; discarding \
+             unsatisfiable candidate and releasing the account"
+        );
+
+        let now = self.state.clock.now().to_rfc3339();
+        self.remove_candidate(&delta, &now).await?;
+        record_candidate_outcome(crate::metrics::labels::CandidateOutcome::Diverged);
+
+        Ok(())
+    }
+
+    /// Handle a candidate whose expected state was not (yet) observed
+    /// on-chain: defer within the submission grace period, then consume
+    /// retry budget and discard once exhausted.
+    async fn handle_unverified_candidate(&self, delta: DeltaObject, reason: &str) -> Result<()> {
+        let now = self.state.clock.now();
+        if let Some(candidate_age_seconds) = self.candidate_age_seconds(&delta, now)
+            && candidate_age_seconds < self.submission_grace_period_seconds
+        {
+            tracing::info!(
+                account_id = %delta.account_id,
+                nonce = delta.nonce,
+                candidate_age_seconds,
+                submission_grace_period_seconds = self.submission_grace_period_seconds,
+                error = %reason,
+                "Delta verification failed during submission grace period; will retry without consuming retry budget"
+            );
+            record_candidate_outcome(crate::metrics::labels::CandidateOutcome::GraceDeferred);
+
+            return Ok(());
+        }
+
+        let current_retry = delta.status.retry_count();
+        let new_retry = current_retry + 1;
+        let now = now.to_rfc3339();
+
+        if new_retry >= self.max_retries {
+            tracing::warn!(
+                account_id = %delta.account_id,
+                nonce = delta.nonce,
+                retries = new_retry,
+                max_retries = self.max_retries,
+                error = %reason,
+                "Delta verification failed after max retries, discarding"
+            );
+
+            self.remove_candidate(&delta, &now).await?;
+            record_candidate_outcome(crate::metrics::labels::CandidateOutcome::Discarded);
+        } else {
+            tracing::info!(
+                account_id = %delta.account_id,
+                nonce = delta.nonce,
+                retry = new_retry,
+                max_retries = self.max_retries,
+                error = %reason,
+                "Delta verification failed, will retry"
+            );
+
+            let new_status = delta.status.with_incremented_retry(now);
+
+            self.state
+                .storage
+                .update_delta_status(&delta.account_id, delta.nonce, new_status)
+                .await
+                .map_err(|e| {
+                    GuardianError::StorageError(format!("Failed to update delta status: {e}"))
+                })?;
+            record_candidate_outcome(crate::metrics::labels::CandidateOutcome::Retried);
+            metrics::counter!(crate::metrics::names::CANONICALIZATION_RETRIES_TOTAL).increment(1);
+        }
+
+        Ok(())
+    }
+
+    /// Delete a candidate that can never be canonicalized, delete its
+    /// matching proposal, and release the account's pending-candidate lock.
+    async fn remove_candidate(&self, delta: &DeltaObject, now: &str) -> Result<()> {
+        let storage_backend = self.state.storage.clone();
+
+        storage_backend
+            .delete_delta(&delta.account_id, delta.nonce)
+            .await
+            .map_err(|e| GuardianError::StorageError(format!("Failed to delete delta: {e}")))?;
+
+        // A discarded candidate can never be canonicalized, so delete its proposal:
+        // leaving it would strand it as `pending` forever and let clients re-submit a
+        // stale intent.
+        let proposal_id = {
+            let client = self.state.network_client.lock().await;
+            match client.delta_proposal_id(&delta.account_id, delta.nonce, &delta.delta_payload) {
+                Ok(id) => Some(id),
+                Err(e) => {
                     tracing::warn!(
                         account_id = %delta.account_id,
                         nonce = delta.nonce,
-                        retries = new_retry,
-                        max_retries = self.max_retries,
                         error = %e,
-                        "Delta verification failed after max retries, discarding"
+                        "Could not derive proposal id for discarded delta; \
+                         its proposal may remain stranded as pending"
                     );
-
-                    storage_backend
-                        .delete_delta(&delta.account_id, delta.nonce)
-                        .await
-                        .map_err(|e| {
-                            GuardianError::StorageError(format!("Failed to delete delta: {e}"))
-                        })?;
-                    record_candidate_outcome(crate::metrics::labels::CandidateOutcome::Discarded);
-
-                    // A discarded candidate can never be canonicalized, so delete its proposal:
-                    // leaving it would strand it as `pending` forever and let clients re-submit a
-                    // stale intent.
-                    let proposal_id = {
-                        let client = self.state.network_client.lock().await;
-                        match client.delta_proposal_id(
-                            &delta.account_id,
-                            delta.nonce,
-                            &delta.delta_payload,
-                        ) {
-                            Ok(id) => Some(id),
-                            Err(e) => {
-                                tracing::warn!(
-                                    account_id = %delta.account_id,
-                                    nonce = delta.nonce,
-                                    error = %e,
-                                    "Could not derive proposal id for discarded delta; \
-                                     its proposal may remain stranded as pending"
-                                );
-                                None
-                            }
-                        }
-                    };
-                    if let Some(ref id) = proposal_id
-                        && let Ok(_existing_proposal) = storage_backend
-                            .pull_delta_proposal(&delta.account_id, id)
-                            .await
-                    {
-                        tracing::warn!(
-                            account_id = %delta.account_id,
-                            proposal_id = %id,
-                            "Deleting matching proposal as its delta was discarded"
-                        );
-                        if let Err(e) = storage_backend
-                            .delete_delta_proposal(&delta.account_id, id)
-                            .await
-                        {
-                            tracing::warn!(
-                                account_id = %delta.account_id,
-                                proposal_id = %id,
-                                error = %e,
-                                "Failed to delete proposal after discard, but continuing"
-                            );
-                        }
-                    }
-
-                    // Clear the pending candidate flag after discard
-                    if let Err(e) = self
-                        .state
-                        .metadata
-                        .set_has_pending_candidate(&delta.account_id, false, &now)
-                        .await
-                    {
-                        tracing::warn!(
-                            account_id = %delta.account_id,
-                            error = %e,
-                            "Failed to clear has_pending_candidate flag after discard"
-                        );
-                    }
-                } else {
-                    tracing::info!(
-                        account_id = %delta.account_id,
-                        nonce = delta.nonce,
-                        retry = new_retry,
-                        max_retries = self.max_retries,
-                        error = %e,
-                        "Delta verification failed, will retry"
-                    );
-
-                    let new_status = delta.status.with_incremented_retry(now);
-
-                    storage_backend
-                        .update_delta_status(&delta.account_id, delta.nonce, new_status)
-                        .await
-                        .map_err(|e| {
-                            GuardianError::StorageError(format!(
-                                "Failed to update delta status: {e}"
-                            ))
-                        })?;
-                    record_candidate_outcome(crate::metrics::labels::CandidateOutcome::Retried);
-                    metrics::counter!(crate::metrics::names::CANONICALIZATION_RETRIES_TOTAL)
-                        .increment(1);
+                    None
                 }
-
-                Ok(())
+            }
+        };
+        if let Some(ref id) = proposal_id
+            && let Ok(_existing_proposal) = storage_backend
+                .pull_delta_proposal(&delta.account_id, id)
+                .await
+        {
+            tracing::warn!(
+                account_id = %delta.account_id,
+                proposal_id = %id,
+                "Deleting matching proposal as its delta was discarded"
+            );
+            if let Err(e) = storage_backend
+                .delete_delta_proposal(&delta.account_id, id)
+                .await
+            {
+                tracing::warn!(
+                    account_id = %delta.account_id,
+                    proposal_id = %id,
+                    error = %e,
+                    "Failed to delete proposal after discard, but continuing"
+                );
             }
         }
+
+        // Clear the pending candidate flag after discard
+        if let Err(e) = self
+            .state
+            .metadata
+            .set_has_pending_candidate(&delta.account_id, false, now)
+            .await
+        {
+            tracing::warn!(
+                account_id = %delta.account_id,
+                error = %e,
+                "Failed to clear has_pending_candidate flag after discard"
+            );
+        }
+
+        Ok(())
     }
 
     async fn canonicalize_verified_delta(
@@ -458,6 +539,7 @@ impl DeltasProcessor {
                 state,
                 max_retries: config.max_retries,
                 submission_grace_period_seconds: config.submission_grace_period_seconds,
+                divergence_confirmations: config.divergence_confirmations,
             },
         }
     }
@@ -485,6 +567,7 @@ impl TestDeltasProcessor {
                 state,
                 max_retries: u32::MAX, // Test processor doesn't discard on retries
                 submission_grace_period_seconds: 0,
+                divergence_confirmations: u32::MAX, // ...nor on divergence
             },
         }
     }
@@ -742,7 +825,7 @@ mod tests {
                 serde_json::json!({"new": "state"}),
                 "new_commitment".to_string(),
             )))
-            .with_verify_state(Ok(()))
+            .with_verify_state(Ok(StateVerification::Match))
             .with_should_update_auth(Ok(None));
 
         let mock_metadata = MockMetadataStore::new()
@@ -842,6 +925,221 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_mismatch_at_candidate_base_defers_within_grace() {
+        // On-chain still shows the candidate's prev_commitment: the tx has
+        // not landed yet, so the grace period applies and nothing is written.
+        let account_id = "0xtest_account";
+        let candidate = create_candidate_delta(account_id, 1);
+
+        let storage = Arc::new(
+            MockStorageBackend::new()
+                .with_pull_deltas_after(Ok(vec![candidate]))
+                .with_pull_state(Ok(create_test_state(account_id))),
+        );
+
+        let mock_network = MockNetworkClient::new()
+            .with_apply_delta(Ok((
+                serde_json::json!({"new": "state"}),
+                "new_commitment".to_string(),
+            )))
+            .with_verify_state(Ok(StateVerification::Mismatch {
+                on_chain: "prev_commitment".to_string(),
+            }));
+
+        let mock_metadata = MockMetadataStore::new()
+            .with_list_with_pending_candidates(Ok(vec![account_id.to_string()]))
+            .with_get(Ok(Some(create_test_metadata(account_id))));
+        let metadata = Arc::new(mock_metadata);
+
+        let clock = Arc::new(MockClock::new(
+            Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 5).unwrap(),
+        ));
+        let state = create_test_app_state_with_clock(
+            storage.clone(),
+            Arc::new(tokio::sync::Mutex::new(mock_network)),
+            metadata.clone(),
+            clock,
+        );
+
+        let config = CanonicalizationConfig::new(10, 18).with_submission_grace_period_seconds(30);
+        let processor = DeltasProcessor::new(state, config);
+
+        let result = processor.process_all_accounts().await;
+        assert!(result.is_ok());
+        assert!(storage.get_update_delta_status_calls().is_empty());
+        assert!(storage.get_delete_delta_calls().is_empty());
+        assert!(metadata.get_set_calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_diverged_candidate_first_observation_defers() {
+        // On-chain matches neither the candidate's base nor its expected new
+        // commitment. A single observation could be a stale RPC read, so the
+        // candidate is kept and only the persisted divergence counter grows —
+        // grace period notwithstanding, no discard yet.
+        let account_id = "0xtest_account";
+        let candidate = create_candidate_delta(account_id, 1);
+
+        let storage = Arc::new(
+            MockStorageBackend::new()
+                .with_pull_deltas_after(Ok(vec![candidate]))
+                .with_pull_state(Ok(create_test_state(account_id))),
+        );
+
+        let mock_network = MockNetworkClient::new()
+            .with_apply_delta(Ok((
+                serde_json::json!({"new": "state"}),
+                "new_commitment".to_string(),
+            )))
+            .with_verify_state(Ok(StateVerification::Mismatch {
+                on_chain: "0xsome_other_commitment".to_string(),
+            }));
+
+        let mock_metadata = MockMetadataStore::new()
+            .with_list_with_pending_candidates(Ok(vec![account_id.to_string()]))
+            .with_get(Ok(Some(create_test_metadata(account_id))));
+        let metadata = Arc::new(mock_metadata);
+
+        let clock = Arc::new(MockClock::new(
+            Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 5).unwrap(),
+        ));
+        let state = create_test_app_state_with_clock(
+            storage.clone(),
+            Arc::new(tokio::sync::Mutex::new(mock_network)),
+            metadata.clone(),
+            clock,
+        );
+
+        let config = CanonicalizationConfig::new(10, 18).with_submission_grace_period_seconds(600);
+        let processor = DeltasProcessor::new(state, config);
+
+        let result = processor.process_all_accounts().await;
+        assert!(result.is_ok());
+
+        let status_updates = storage.get_update_delta_status_calls();
+        assert_eq!(status_updates.len(), 1);
+        assert_eq!(status_updates[0].2.divergence_count(), 1);
+        assert_eq!(status_updates[0].2.retry_count(), 0);
+        assert!(storage.get_delete_delta_calls().is_empty());
+        assert!(metadata.get_set_calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_diverged_candidate_confirmed_discards_and_releases() {
+        // Second consecutive diverged observation reaches the default
+        // confirmation threshold (2): the unsatisfiable candidate is deleted
+        // and the account lock released immediately, well within the grace
+        // period.
+        let account_id = "0xtest_account";
+        let mut candidate = create_candidate_delta(account_id, 1);
+        candidate.status = DeltaStatus::Candidate {
+            timestamp: "2024-01-01T00:00:00Z".to_string(),
+            retry_count: 0,
+            divergence_count: 1,
+        };
+
+        let storage = Arc::new(
+            MockStorageBackend::new()
+                .with_pull_deltas_after(Ok(vec![candidate]))
+                .with_pull_state(Ok(create_test_state(account_id))),
+        );
+
+        let mock_network = MockNetworkClient::new()
+            .with_apply_delta(Ok((
+                serde_json::json!({"new": "state"}),
+                "new_commitment".to_string(),
+            )))
+            .with_verify_state(Ok(StateVerification::Mismatch {
+                on_chain: "0xsome_other_commitment".to_string(),
+            }));
+
+        let mock_metadata = MockMetadataStore::new()
+            .with_list_with_pending_candidates(Ok(vec![account_id.to_string()]))
+            .with_get(Ok(Some(create_test_metadata(account_id))))
+            .with_set(Ok(()));
+        let metadata = Arc::new(mock_metadata);
+
+        let clock = Arc::new(MockClock::new(
+            Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 5).unwrap(),
+        ));
+        let state = create_test_app_state_with_clock(
+            storage.clone(),
+            Arc::new(tokio::sync::Mutex::new(mock_network)),
+            metadata.clone(),
+            clock,
+        );
+
+        let config = CanonicalizationConfig::new(10, 18).with_submission_grace_period_seconds(600);
+        let processor = DeltasProcessor::new(state, config);
+
+        let result = processor.process_all_accounts().await;
+        assert!(result.is_ok());
+
+        assert_eq!(
+            storage.get_delete_delta_calls(),
+            vec![(account_id.to_string(), 1)]
+        );
+        assert!(storage.get_update_delta_status_calls().is_empty());
+        assert!(
+            metadata
+                .get_set_calls()
+                .iter()
+                .any(|m| !m.has_pending_candidate)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_divergence_confirmations_of_one_discards_immediately() {
+        let account_id = "0xtest_account";
+        let candidate = create_candidate_delta(account_id, 1);
+
+        let storage = Arc::new(
+            MockStorageBackend::new()
+                .with_pull_deltas_after(Ok(vec![candidate]))
+                .with_pull_state(Ok(create_test_state(account_id))),
+        );
+
+        let mock_network = MockNetworkClient::new()
+            .with_apply_delta(Ok((
+                serde_json::json!({"new": "state"}),
+                "new_commitment".to_string(),
+            )))
+            .with_verify_state(Ok(StateVerification::Mismatch {
+                on_chain: "0xsome_other_commitment".to_string(),
+            }));
+
+        let mock_metadata = MockMetadataStore::new()
+            .with_list_with_pending_candidates(Ok(vec![account_id.to_string()]))
+            .with_get(Ok(Some(create_test_metadata(account_id))))
+            .with_set(Ok(()));
+        let metadata = Arc::new(mock_metadata);
+
+        let clock = Arc::new(MockClock::new(
+            Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 5).unwrap(),
+        ));
+        let state = create_test_app_state_with_clock(
+            storage.clone(),
+            Arc::new(tokio::sync::Mutex::new(mock_network)),
+            metadata.clone(),
+            clock,
+        );
+
+        let config = CanonicalizationConfig::new(10, 18)
+            .with_submission_grace_period_seconds(600)
+            .with_divergence_confirmations(1);
+        let processor = DeltasProcessor::new(state, config);
+
+        let result = processor.process_all_accounts().await;
+        assert!(result.is_ok());
+
+        assert_eq!(
+            storage.get_delete_delta_calls(),
+            vec![(account_id.to_string(), 1)]
+        );
+        assert!(storage.get_update_delta_status_calls().is_empty());
+    }
+
+    #[tokio::test]
     async fn test_process_candidate_max_retries_discards() {
         let account_id = "0xtest_account";
         // Create a candidate that has already been retried max_retries times
@@ -894,7 +1192,7 @@ mod tests {
                 serde_json::json!({"new": "state"}),
                 "new_commitment".to_string(),
             )))
-            .with_verify_state(Ok(()));
+            .with_verify_state(Ok(StateVerification::Match));
 
         let mock_metadata = MockMetadataStore::new()
             .with_list_with_pending_candidates(Ok(vec![account_id.to_string()]))
@@ -967,7 +1265,7 @@ mod tests {
                 serde_json::json!({"new": "state"}),
                 "new_commitment".to_string(),
             )))
-            .with_verify_state(Ok(()))
+            .with_verify_state(Ok(StateVerification::Match))
             .with_should_update_auth(Ok(Some(new_auth)));
 
         let mock_metadata = MockMetadataStore::new()
@@ -1117,7 +1415,7 @@ mod tests {
                 serde_json::json!({"new": "state"}),
                 "new_commitment".to_string(),
             )))
-            .with_verify_state(Ok(()))
+            .with_verify_state(Ok(StateVerification::Match))
             .with_should_update_auth(Ok(None));
 
         let mock_metadata = MockMetadataStore::new()
@@ -1159,7 +1457,7 @@ mod tests {
                 serde_json::json!({"new": "state"}),
                 "new_commitment".to_string(),
             )))
-            .with_verify_state(Ok(()))
+            .with_verify_state(Ok(StateVerification::Match))
             .with_should_update_auth(Ok(None));
 
         let mock_metadata = MockMetadataStore::new()

--- a/crates/server/src/metrics/labels.rs
+++ b/crates/server/src/metrics/labels.rs
@@ -77,6 +77,13 @@ pub enum CandidateOutcome {
     Retried,
     Discarded,
     GraceDeferred,
+    /// The on-chain commitment matched neither the candidate's previous
+    /// nor its expected new commitment, but not yet on enough consecutive
+    /// ticks to discard; deferred for another confirmation.
+    DivergenceDeferred,
+    /// Discarded because the account advanced past the candidate's base
+    /// state on-chain, making verification permanently unsatisfiable.
+    Diverged,
 }
 
 impl CandidateOutcome {
@@ -86,6 +93,8 @@ impl CandidateOutcome {
             Self::Retried => "retried",
             Self::Discarded => "discarded",
             Self::GraceDeferred => "grace_deferred",
+            Self::DivergenceDeferred => "divergence_deferred",
+            Self::Diverged => "diverged",
         }
     }
 }

--- a/crates/server/src/metrics/names.rs
+++ b/crates/server/src/metrics/names.rs
@@ -244,7 +244,8 @@ pub const REGISTRY: &[MetricDef] = &[
         kind: MetricKind::Counter,
         labels: &[LABEL_OUTCOME],
         help: "Candidate deltas processed by the canonicalization worker, by outcome \
-               (canonicalized, retried, discarded, grace_deferred).",
+               (canonicalized, retried, discarded, grace_deferred, divergence_deferred, \
+               diverged).",
     },
     MetricDef {
         name: CANONICALIZATION_RETRIES_TOTAL,

--- a/crates/server/src/network/miden/mod.rs
+++ b/crates/server/src/network/miden/mod.rs
@@ -2,7 +2,7 @@ pub mod account_inspector;
 
 use crate::metadata::auth::{Auth, Credentials};
 use crate::network::miden::account_inspector::{MidenAccountInspector, OZ_GUARDIAN_PUBLIC_KEY};
-use crate::network::{NetworkClient, NetworkType};
+use crate::network::{NetworkClient, NetworkType, StateVerification};
 use async_trait::async_trait;
 use guardian_shared::{FromJson, ToJson};
 use miden_protocol::Word;
@@ -87,7 +87,7 @@ impl NetworkClient for MidenNetworkClient {
         &mut self,
         account_id: &str,
         state_json: &serde_json::Value,
-    ) -> Result<(), String> {
+    ) -> Result<StateVerification, String> {
         let account_id = AccountId::from_hex(account_id).map_err(|e| {
             tracing::error!(
                 account_id = %account_id,
@@ -129,18 +129,18 @@ impl NetworkClient for MidenNetworkClient {
         })?;
 
         if local_commitment_hex != on_chain_commitment {
-            tracing::error!(
+            tracing::warn!(
                 account_id = %account_id.to_hex(),
                 local = %local_commitment_hex,
                 on_chain = %on_chain_commitment,
                 "Commitment mismatch during state verification"
             );
-            return Err(format!(
-                "Commitment mismatch for account '{account_id}': local={local_commitment_hex}, on-chain={on_chain_commitment}"
-            ));
+            return Ok(StateVerification::Mismatch {
+                on_chain: on_chain_commitment,
+            });
         }
 
-        Ok(())
+        Ok(StateVerification::Match)
     }
 
     fn verify_delta(

--- a/crates/server/src/network/mod.rs
+++ b/crates/server/src/network/mod.rs
@@ -3,6 +3,20 @@ pub mod miden;
 use crate::metadata::auth::{Auth, Credentials};
 use async_trait::async_trait;
 
+/// Outcome of comparing a locally-computed state commitment against the
+/// on-chain one. A mismatch is a legitimate observation (the tx has not
+/// landed yet, or the account advanced past the expected state), not an
+/// error: `Err` from [`NetworkClient::verify_state`] is reserved for
+/// failures to make the comparison at all (RPC failure, malformed state).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StateVerification {
+    /// The on-chain commitment equals the locally-computed one.
+    Match,
+    /// The on-chain commitment differs; carries the observed on-chain
+    /// value so callers can classify the mismatch.
+    Mismatch { on_chain: String },
+}
+
 #[async_trait]
 pub trait NetworkClient: Send + Sync {
     /// Get state commitment in hex format from JSON
@@ -12,12 +26,14 @@ pub trait NetworkClient: Send + Sync {
         state_json: &serde_json::Value,
     ) -> Result<String, String>;
 
-    /// Verify state commitment matches on-chain state
+    /// Compare the commitment of `state_json` against the on-chain
+    /// account commitment. Returns `Err` only when the comparison could
+    /// not be made (RPC failure, malformed state JSON).
     async fn verify_state(
         &mut self,
         account_id: &str,
         state_json: &serde_json::Value,
-    ) -> Result<(), String>;
+    ) -> Result<StateVerification, String>;
 
     /// Verify delta is valid for given state
     fn verify_delta(

--- a/crates/server/src/services/dashboard_account_deltas.rs
+++ b/crates/server/src/services/dashboard_account_deltas.rs
@@ -85,6 +85,7 @@ pub(crate) fn decode_delta_status(
         DeltaStatus::Candidate {
             timestamp,
             retry_count,
+            ..
         } => Some((
             DashboardDeltaStatus::Candidate,
             Some(*retry_count),
@@ -244,6 +245,7 @@ mod tests {
             DeltaStatus::Candidate {
                 timestamp: format!("2026-05-08T12:0{nonce}:00Z"),
                 retry_count: retries,
+                divergence_count: 0,
             },
         )
     }

--- a/crates/server/src/services/dashboard_info.rs
+++ b/crates/server/src/services/dashboard_info.rs
@@ -620,6 +620,7 @@ mod tests {
             check_interval_seconds: 7,
             max_retries: 13,
             submission_grace_period_seconds: 42,
+            divergence_confirmations: 2,
         });
         let info = get_dashboard_info(&state).await.unwrap();
         let cfg = info.backend.canonicalization.expect("config present");

--- a/crates/server/src/services/push_delta_proposal.rs
+++ b/crates/server/src/services/push_delta_proposal.rs
@@ -825,6 +825,7 @@ mod tests {
             status: DeltaStatus::Candidate {
                 timestamp: "2024-11-14T12:00:00Z".to_string(),
                 retry_count: 0,
+                divergence_count: 0,
             },
             metadata: None,
         };

--- a/crates/server/src/testing/helpers.rs
+++ b/crates/server/src/testing/helpers.rs
@@ -6,7 +6,7 @@ use crate::api::grpc::GuardianService;
 use crate::dashboard::DashboardState;
 use crate::metadata::auth::Auth;
 use crate::metadata::filesystem::FilesystemMetadataStore;
-use crate::network::NetworkClient;
+use crate::network::{NetworkClient, StateVerification};
 use crate::state::AppState;
 use crate::storage::StorageBackend;
 use crate::storage::filesystem::FilesystemService;
@@ -68,7 +68,7 @@ impl NetworkClient for IntegrationMockNetworkClient {
         &mut self,
         account_id: &str,
         state_json: &serde_json::Value,
-    ) -> Result<(), String> {
+    ) -> Result<StateVerification, String> {
         use miden_protocol::account::Account;
 
         let account = Account::from_json(state_json)
@@ -79,16 +79,16 @@ impl NetworkClient for IntegrationMockNetworkClient {
 
         if let Some(on_chain_commitment) = self.initial_commitments.get(account_id) {
             if &local_commitment_hex != on_chain_commitment {
-                return Err(format!(
-                    "Commitment mismatch for account '{account_id}': local={local_commitment_hex}, on-chain={on_chain_commitment}"
-                ));
+                return Ok(StateVerification::Mismatch {
+                    on_chain: on_chain_commitment.clone(),
+                });
             }
         } else {
             self.initial_commitments
                 .insert(account_id.to_string(), local_commitment_hex.clone());
         }
 
-        Ok(())
+        Ok(StateVerification::Match)
     }
 
     fn verify_delta(

--- a/crates/server/src/testing/mocks.rs
+++ b/crates/server/src/testing/mocks.rs
@@ -1,7 +1,7 @@
 use crate::delta_object::DeltaObject;
 use crate::metadata::MetadataStore;
 use crate::metadata::auth::{Auth, Credentials};
-use crate::network::NetworkClient;
+use crate::network::{NetworkClient, StateVerification};
 use crate::state_object::StateObject;
 use crate::storage::StorageBackend;
 use async_trait::async_trait;
@@ -26,7 +26,7 @@ fn delta_to_proposal_record(proposal: DeltaObject) -> crate::storage::ProposalRe
 
 #[derive(Clone, Default)]
 pub struct MockNetworkClient {
-    pub verify_state_responses: Arc<StdMutex<Vec<StdResult<(), String>>>>,
+    pub verify_state_responses: Arc<StdMutex<Vec<StdResult<StateVerification, String>>>>,
     pub verify_state_calls: Arc<StdMutex<Vec<(String, serde_json::Value)>>>,
     pub get_state_commitment_responses: Arc<StdMutex<Vec<StdResult<String, String>>>>,
     pub get_state_commitment_calls: Arc<StdMutex<Vec<(String, serde_json::Value)>>>,
@@ -42,7 +42,7 @@ impl MockNetworkClient {
         Self::default()
     }
 
-    pub fn with_verify_state(self, response: StdResult<(), String>) -> Self {
+    pub fn with_verify_state(self, response: StdResult<StateVerification, String>) -> Self {
         self.verify_state_responses.lock().unwrap().push(response);
         self
     }
@@ -127,7 +127,7 @@ impl NetworkClient for MockNetworkClient {
         &mut self,
         account_id: &str,
         state_json: &serde_json::Value,
-    ) -> StdResult<(), String> {
+    ) -> StdResult<StateVerification, String> {
         self.verify_state_calls
             .lock()
             .unwrap()
@@ -137,7 +137,7 @@ impl NetworkClient for MockNetworkClient {
             .lock()
             .unwrap()
             .pop()
-            .unwrap_or_else(|| Ok(()))
+            .unwrap_or(Ok(StateVerification::Match))
     }
 
     fn verify_delta(
@@ -251,6 +251,9 @@ pub struct MockStorageBackend {
     pub update_delta_proposal_calls: Arc<StdMutex<Vec<(String, DeltaObject)>>>,
     pub delete_delta_proposal_responses: Arc<StdMutex<Vec<StdResult<(), String>>>>,
     pub delete_delta_proposal_calls: Arc<StdMutex<Vec<(String, String)>>>,
+    pub delete_delta_calls: Arc<StdMutex<Vec<(String, u64)>>>,
+    pub update_delta_status_calls:
+        Arc<StdMutex<Vec<(String, u64, crate::delta_object::DeltaStatus)>>>,
     // Dashboard read APIs (feature `005-operator-dashboard-metrics`).
     // Each queue is consumed LIFO via `Vec::pop`, mirroring the
     // existing helpers — callers either push N identical responses or
@@ -385,6 +388,16 @@ impl MockStorageBackend {
 
     pub fn get_delete_delta_proposal_calls(&self) -> Vec<(String, String)> {
         self.delete_delta_proposal_calls.lock().unwrap().clone()
+    }
+
+    pub fn get_delete_delta_calls(&self) -> Vec<(String, u64)> {
+        self.delete_delta_calls.lock().unwrap().clone()
+    }
+
+    pub fn get_update_delta_status_calls(
+        &self,
+    ) -> Vec<(String, u64, crate::delta_object::DeltaStatus)> {
+        self.update_delta_status_calls.lock().unwrap().clone()
     }
 
     // Dashboard read APIs (feature `005-operator-dashboard-metrics`).
@@ -607,16 +620,25 @@ impl StorageBackend for MockStorageBackend {
             .unwrap_or(Ok(()))
     }
 
-    async fn delete_delta(&self, _account_id: &str, _nonce: u64) -> Result<(), String> {
+    async fn delete_delta(&self, account_id: &str, nonce: u64) -> Result<(), String> {
+        self.delete_delta_calls
+            .lock()
+            .unwrap()
+            .push((account_id.to_string(), nonce));
         Ok(())
     }
 
     async fn update_delta_status(
         &self,
-        _account_id: &str,
-        _nonce: u64,
-        _status: crate::delta_object::DeltaStatus,
+        account_id: &str,
+        nonce: u64,
+        status: crate::delta_object::DeltaStatus,
     ) -> Result<(), String> {
+        self.update_delta_status_calls.lock().unwrap().push((
+            account_id.to_string(),
+            nonce,
+            status,
+        ));
         Ok(())
     }
 

--- a/docs/openapi-client.json
+++ b/docs/openapi-client.json
@@ -1402,6 +1402,12 @@
               "status"
             ],
             "properties": {
+              "divergence_count": {
+                "type": "integer",
+                "format": "int32",
+                "description": "Consecutive canonicalization ticks that observed the on-chain\ncommitment at neither this delta's `prev_commitment` nor its\nexpected new commitment — i.e. the account advanced past the\nstate this candidate was built on. Reset to zero whenever a\nread shows the account still at the candidate's base, so only\nan unbroken streak counts. Requiring more than one observation\nbefore discarding shields against stale RPC reads.",
+                "minimum": 0
+              },
               "retry_count": {
                 "type": "integer",
                 "format": "int32",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4515,6 +4515,12 @@
               "status"
             ],
             "properties": {
+              "divergence_count": {
+                "type": "integer",
+                "format": "int32",
+                "description": "Consecutive canonicalization ticks that observed the on-chain\ncommitment at neither this delta's `prev_commitment` nor its\nexpected new commitment — i.e. the account advanced past the\nstate this candidate was built on. Reset to zero whenever a\nread shows the account still at the candidate's base, so only\nan unbroken streak counts. Requiring more than one observation\nbefore discarding shields against stale RPC reads.",
+                "minimum": 0
+              },
               "retry_count": {
                 "type": "integer",
                 "format": "int32",

--- a/spec/processes.md
+++ b/spec/processes.md
@@ -223,7 +223,8 @@ sequenceDiagram
 
 ### Configuration
 - Current server builder defaults: submission_grace_period_seconds = 600
-  (10m), check_interval_seconds = 10, max_retries = 48.
+  (10m), check_interval_seconds = 10, max_retries = 48,
+  divergence_confirmations = 2.
 - These values are configured in code, not through server env vars.
 
 ### Worker Behavior
@@ -231,12 +232,23 @@ sequenceDiagram
  - For each account:
   - Pull all deltas and select ready candidates (candidate_at >= delay_seconds); process in nonce order.
   - Apply delta locally to compute expected state and commitment.
-  - Verify on-chain commitment. If it matches `new_commitment`:
-    - Persist new state (atomic with delta status update when possible).
-    - Optionally update auth from chain via `should_update_auth`.
-    - Set delta status to `canonical`.
-    - Delete matching Miden delta proposal identified via `delta_proposal_id(account_id, nonce, delta_payload)`.
-  - Else set delta status to `discarded`.
+  - Fetch the on-chain commitment and classify:
+    - Matches the expected new commitment: canonicalize —
+      persist new state (atomic with delta status update when possible),
+      optionally update auth from chain via `should_update_auth`, set delta
+      status to `canonical`, and delete the matching Miden delta proposal
+      identified via `delta_proposal_id(account_id, nonce, delta_payload)`.
+    - Matches the candidate's `prev_commitment` (its transaction has not
+      landed yet), or the comparison itself failed (RPC error): defer within
+      `submission_grace_period_seconds`, then consume retry budget each tick
+      and discard after `max_retries`.
+    - Matches neither — the account advanced past the candidate's base
+      state, so the candidate can never verify: after
+      `divergence_confirmations` consecutive such observations (default 2,
+      to tolerate a single stale RPC read) discard immediately, bypassing
+      the grace period, delete the matching proposal, and clear the
+      account's pending-candidate flag so new proposals stop returning
+      `409 conflict_pending_delta`.
 
 EVM proposals are not processed by Miden canonicalization. They are stored in the EVM proposal store and deleted lazily when expired or when the configured EntryPoint nonce indicates finality.
 
@@ -258,12 +270,14 @@ sequenceDiagram
       W->>ST: pull_state(account_id)
       W->>N: apply_delta(prev_state, delta)\n(new_state, expected_commitment)
       W->>N: verify_state(account_id, new_state)\n(on_chain_commitment)
-      alt commitments match
+      alt on-chain matches expected commitment
         W->>ST: submit_state(new_state)
         W->>W: maybe update_auth(should_update_auth)
         W->>ST: submit_delta(canonical)
-      else mismatch
-        W->>ST: submit_delta(discarded)
+      else on-chain still at prev_commitment (not landed)
+        W->>W: defer (grace period), then consume retry budget
+      else diverged (matches neither)
+        W->>ST: delete_delta + delete matching proposal\nclear pending-candidate flag (after confirmation)
       end
     end
   end


### PR DESCRIPTION
Fixes #303

## Problem

When a guardian-cosigned account advances on-chain past the state a candidate delta was built on, the worker's expected commitment (`stored_base + this_delta`) can never match on-chain again. The candidate burned the full 600s submission grace, then 48 retries (~480s more), while `has_pending_candidate` kept the account locked — every new proposal got `409 conflict_pending_delta` for up to ~18 minutes

## Root cause

`verify_state` returned an opaque `Err` for *any* mismatch, so the worker could not distinguish "transaction hasn't landed yet" (grace is the right response) from "the account moved past this candidate's base" (waiting can never succeed). Both cases deferred until grace + retry budget were exhausted.

## Fix

`NetworkClient::verify_state` now returns a typed outcome — `Match` / `Mismatch { on_chain }` — with `Err` reserved for failures to make the comparison at all (RPC error, malformed state). The canonicalization worker classifies a mismatch against the candidate's own commitments:

| on-chain commitment | meaning | action |
|---|---|---|
| `== prev_commitment` | tx not landed yet | defer within grace, then consume retry budget (unchanged) |
| `== expected new commitment` | tx landed | canonicalize (unchanged) |
| neither | account advanced past the candidate's base; its tx is anchored to `prev_commitment` and can never land | discard, delete matching proposal, clear `has_pending_candidate` — account released immediately |

The divergence discard bypasses the grace period, collapsing the lock from ~18 minutes to ~2 worker ticks (~20 seconds).

## Safety measures

- **Stale-read shield**: discarding requires `divergence_confirmations` (default 2) *consecutive* diverged observations. The counter is persisted as `divergence_count` on `DeltaStatus::Candidate` (`#[serde(default)]`, so existing JSONB rows deserialize unchanged), so confirmation survives worker restarts. A single read from a lagging RPC node cannot discard a candidate whose tx actually landed.
- **Full release, not a flag flip**: the diverged path reuses the same discard routine as the max-retries path (delete delta + delete matching proposal + clear flag), so no zombie candidate rows and no stranded pending proposals that would let clients re-submit a stale intent.
- **RPC errors don't classify**: only a *successful* read that matches neither commitment counts toward divergence; fetch failures keep today's grace/retry behavior.
- `TestDeltasProcessor` uses `u32::MAX` confirmations, preserving its never-discard semantics for integration/e2e tests.

## Observability

New outcome labels on `guardian_canonicalization_candidates_total`: `diverged` (released) and `divergence_deferred` (observed once, awaiting confirmation). `spec/processes.md` updated to describe the three-way classification.

## Testing

- Four new worker tests: on-chain-at-base defers within grace with no writes; first diverged observation persists the counter without discarding; second observation discards and releases inside the grace window; `divergence_confirmations = 1` discards immediately.

## Residual limitations (out of scope)

- A candidate whose tx **never lands at all** (e.g. the wallet's tx failed locally after acking — see 0xMiden/wallet#313) leaves on-chain at `prev_commitment`, indistinguishable from slow proving, so it still holds the account for grace + retries. Releasing that faster would need a client-initiated abandon/withdraw endpoint — happy to file a follow-up.
- A *permanently* lagging RPC node could produce two consecutive stale reads and discard a landed candidate, leaving the guardian's stored state behind on-chain until the client re-pushes the landed delta. Such a node breaks canonicalization today as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable divergence confirmation handling during canonicalization, letting the system wait for repeated divergence before discarding a candidate.
  * Improved state-check reporting so mismatches are tracked separately from successful matches.

* **Bug Fixes**
  * Candidate items now preserve and expose divergence progress across retries.
  * Divergence-related outcomes are now reflected more accurately in metrics and dashboard-facing data.

* **Tests**
  * Updated and expanded test coverage for retry, grace-period, and divergence scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->