### PR TITLE
fix(multisig-client): recover/verify ECDSA public key in MidenWalletSigner instead of using the commitment

### DIFF
--- a/packages/miden-multisig-client/src/signers/miden-wallet.ecdsa-recovery.test.ts
+++ b/packages/miden-multisig-client/src/signers/miden-wallet.ecdsa-recovery.test.ts
@@ -3,6 +3,7 @@ import { secp256k1 } from '@noble/curves/secp256k1';
 import { keccak_256 } from '@noble/hashes/sha3.js';
 
 import { MidenWalletSigner, type WalletSigningContext } from './miden-wallet.js';
+import type { Signer } from '../types.js';
 import { tryComputeEcdsaCommitmentHex } from '../utils/signature.js';
 import { bytesToHex, hexToBytes } from '../utils/encoding.js';
 import { buildGuardianSignatureFromSigner } from '../multisig/signing.js';
@@ -10,16 +11,26 @@ import { buildGuardianSignatureFromSigner } from '../multisig/signing.js';
 // Real-crypto repro for the reported failure:
 //   "assertion failed with error message: invalid public key commitment"
 //
-// This test uses the real WASM SDK (Poseidon2/PublicKey, via tests/setup-wasm.ts)
-// and a real secp256k1 keypair — NOT mocks — so it reproduces the exact kernel
+// These tests use the real WASM SDK (Poseidon2/PublicKey, via tests/setup-wasm.ts)
+// and real secp256k1 keypairs — NOT mocks — so they exercise the exact kernel
 // invariant `Poseidon2(publicKey) == pub_key_commitment` that the transaction
 // kernel enforces in `ecdsa_k256_keccak.masm` (`assert_eqw "invalid public key
 // commitment"`). A wallet-delegated ECDSA cosigner whose `publicKey` degrades to
-// the 32-byte commitment fails that invariant.
+// the 32-byte commitment — or is a valid-but-wrong key — fails that invariant.
 
-// Deterministic key so the repro is reproducible run-to-run.
+// Deterministic keys so the repro is reproducible run-to-run.
 const PRIVATE_KEY = hexToBytes('0x' + '11'.repeat(32));
 const COMPRESSED_PUBKEY_HEX = bytesToHex(secp256k1.getPublicKey(PRIVATE_KEY, true));
+
+// A second, unrelated key: valid secp256k1 but NOT the one the commitment is for.
+const OTHER_PRIVATE_KEY = hexToBytes('0x' + '22'.repeat(32));
+const OTHER_COMPRESSED_PUBKEY_HEX = bytesToHex(secp256k1.getPublicKey(OTHER_PRIVATE_KEY, true));
+
+/** Asserts a nullable value is present and returns it narrowed (avoids `!`). */
+function expectPresent<T>(value: T | null | undefined): T {
+  expect(value ?? null).not.toBeNull();
+  return value as T;
+}
 
 /**
  * A wallet that signs like the real Miden Wallet ECDSA path: it keccak256-hashes
@@ -41,17 +52,27 @@ function ecdsaWallet(privateKey: Uint8Array): WalletSigningContext {
   };
 }
 
+/** Minimal ECDSA delegate (`localAuthSigner`) carrying a fixed public key. */
+function ecdsaDelegate(commitment: string, publicKey: string): Signer {
+  return {
+    commitment,
+    publicKey,
+    scheme: 'ecdsa',
+    signAccountIdWithTimestamp: async () => '0x00',
+    signCommitment: async () => '0x00',
+  };
+}
+
 describe('MidenWalletSigner ECDSA public-key resolution', () => {
   it('resolves the real ECDSA public key from its own signature so it hashes to the account commitment', async () => {
     // The account's stored commitment is Poseidon2(pubkey) — exactly what the kernel checks.
-    const accountCommitment = tryComputeEcdsaCommitmentHex(COMPRESSED_PUBKEY_HEX);
-    expect(accountCommitment).not.toBeNull();
+    const accountCommitment = expectPresent(tryComputeEcdsaCommitmentHex(COMPRESSED_PUBKEY_HEX));
 
     // Wallet-delegated ECDSA cosigner constructed WITHOUT an explicit public key —
     // the reported failure path, where `publicKey` silently fell back to the commitment.
-    const signer = new MidenWalletSigner(ecdsaWallet(PRIVATE_KEY), accountCommitment!, 'ecdsa');
+    const signer = new MidenWalletSigner(ecdsaWallet(PRIVATE_KEY), accountCommitment, 'ecdsa');
 
-    await signer.signCommitment(accountCommitment!);
+    await signer.signCommitment(accountCommitment);
 
     // The resolved public key must be the real 33-byte key, not the 32-byte commitment...
     expect(signer.publicKey).toBe(COMPRESSED_PUBKEY_HEX);
@@ -63,33 +84,63 @@ describe('MidenWalletSigner ECDSA public-key resolution', () => {
   it('fails closed when the wallet signature recovers a key that does not match the commitment', async () => {
     // The account commitment is for PRIVATE_KEY, but the wallet signs with a
     // different key. Recovery must reject the mismatch rather than trust it.
-    const otherKey = hexToBytes('0x' + '22'.repeat(32));
-    const accountCommitment = tryComputeEcdsaCommitmentHex(COMPRESSED_PUBKEY_HEX);
+    const accountCommitment = expectPresent(tryComputeEcdsaCommitmentHex(COMPRESSED_PUBKEY_HEX));
 
-    const signer = new MidenWalletSigner(ecdsaWallet(otherKey), accountCommitment!, 'ecdsa');
-    await signer.signCommitment(accountCommitment!);
+    const signer = new MidenWalletSigner(ecdsaWallet(OTHER_PRIVATE_KEY), accountCommitment, 'ecdsa');
+    await signer.signCommitment(accountCommitment);
 
     expect(() => signer.publicKey).toThrow(/does not match the signer commitment/);
   });
 
-  it('accepts an explicitly-provided valid ECDSA public key without needing to sign', () => {
-    const accountCommitment = tryComputeEcdsaCommitmentHex(COMPRESSED_PUBKEY_HEX);
+  it('accepts an explicit ECDSA public key whose commitment matches, without needing to sign', () => {
+    const accountCommitment = expectPresent(tryComputeEcdsaCommitmentHex(COMPRESSED_PUBKEY_HEX));
     const signer = new MidenWalletSigner(
       ecdsaWallet(PRIVATE_KEY),
-      accountCommitment!,
+      accountCommitment,
       'ecdsa',
       undefined,
       COMPRESSED_PUBKEY_HEX,
     );
     expect(signer.publicKey).toBe(COMPRESSED_PUBKEY_HEX);
+    expect(tryComputeEcdsaCommitmentHex(signer.publicKey)).toBe(accountCommitment);
+  });
+
+  it('rejects an explicit ECDSA public key whose commitment does not match the signer commitment', () => {
+    // A well-formed 33-byte key (passes format validation) that belongs to a
+    // different account. It must be rejected at the source, not carried into signing.
+    const accountCommitment = expectPresent(tryComputeEcdsaCommitmentHex(COMPRESSED_PUBKEY_HEX));
+    const signer = new MidenWalletSigner(
+      ecdsaWallet(PRIVATE_KEY),
+      accountCommitment,
+      'ecdsa',
+      undefined,
+      OTHER_COMPRESSED_PUBKEY_HEX,
+    );
+    expect(() => signer.publicKey).toThrow(/does not match the signer commitment/);
+  });
+
+  it('rejects an explicit ECDSA key that is a valid length but not a secp256k1 point', () => {
+    // 33-byte, correct compressed tag, but x is off-curve — must be rejected at
+    // construction, SDK-independently, not silently carried to execute time.
+    const accountCommitment = expectPresent(tryComputeEcdsaCommitmentHex(COMPRESSED_PUBKEY_HEX));
+    expect(
+      () =>
+        new MidenWalletSigner(
+          ecdsaWallet(PRIVATE_KEY),
+          accountCommitment,
+          'ecdsa',
+          undefined,
+          '0x02' + 'ff'.repeat(32),
+        ),
+    ).toThrow(/not a valid secp256k1 point/);
   });
 
   it('compresses an explicitly-provided 65-byte uncompressed public key', () => {
     const uncompressed = bytesToHex(secp256k1.getPublicKey(PRIVATE_KEY, false)); // 65 bytes
-    const accountCommitment = tryComputeEcdsaCommitmentHex(COMPRESSED_PUBKEY_HEX);
+    const accountCommitment = expectPresent(tryComputeEcdsaCommitmentHex(COMPRESSED_PUBKEY_HEX));
     const signer = new MidenWalletSigner(
       ecdsaWallet(PRIVATE_KEY),
-      accountCommitment!,
+      accountCommitment,
       'ecdsa',
       undefined,
       uncompressed,
@@ -97,31 +148,54 @@ describe('MidenWalletSigner ECDSA public-key resolution', () => {
     expect(signer.publicKey).toBe(COMPRESSED_PUBKEY_HEX);
   });
 
-  it('resolves the public key through a non-signCommitment path (signLookupMessage)', async () => {
-    const accountCommitment = tryComputeEcdsaCommitmentHex(COMPRESSED_PUBKEY_HEX);
-    const signer = new MidenWalletSigner(ecdsaWallet(PRIVATE_KEY), accountCommitment!, 'ecdsa');
+  it('accepts a localAuthSigner whose ECDSA public key matches the commitment', () => {
+    const accountCommitment = expectPresent(tryComputeEcdsaCommitmentHex(COMPRESSED_PUBKEY_HEX));
+    const delegate = ecdsaDelegate(accountCommitment, COMPRESSED_PUBKEY_HEX);
+    const signer = new MidenWalletSigner(ecdsaWallet(PRIVATE_KEY), accountCommitment, 'ecdsa', delegate);
+    expect(signer.publicKey).toBe(COMPRESSED_PUBKEY_HEX);
+    expect(tryComputeEcdsaCommitmentHex(signer.publicKey)).toBe(accountCommitment);
+  });
 
-    await signer.signLookupMessage(accountCommitment!, 1700000000);
+  it('rejects a localAuthSigner whose ECDSA public key does not match the commitment', () => {
+    const accountCommitment = expectPresent(tryComputeEcdsaCommitmentHex(COMPRESSED_PUBKEY_HEX));
+    const delegate = ecdsaDelegate(accountCommitment, OTHER_COMPRESSED_PUBKEY_HEX);
+    const signer = new MidenWalletSigner(ecdsaWallet(PRIVATE_KEY), accountCommitment, 'ecdsa', delegate);
+    expect(() => signer.publicKey).toThrow(/does not match the signer commitment/);
+  });
+
+  it('rejects a localAuthSigner whose ECDSA key is a valid length but not a secp256k1 point', () => {
+    const accountCommitment = expectPresent(tryComputeEcdsaCommitmentHex(COMPRESSED_PUBKEY_HEX));
+    const delegate = ecdsaDelegate(accountCommitment, '0x02' + 'ff'.repeat(32));
+    const signer = new MidenWalletSigner(ecdsaWallet(PRIVATE_KEY), accountCommitment, 'ecdsa', delegate);
+    expect(() => signer.publicKey).toThrow(/not a valid secp256k1 point/);
+  });
+
+  it('resolves the public key through a non-signCommitment path (signLookupMessage)', async () => {
+    const accountCommitment = expectPresent(tryComputeEcdsaCommitmentHex(COMPRESSED_PUBKEY_HEX));
+    const signer = new MidenWalletSigner(ecdsaWallet(PRIVATE_KEY), accountCommitment, 'ecdsa');
+
+    await signer.signLookupMessage(accountCommitment, 1700000000);
 
     expect(signer.publicKey).toBe(COMPRESSED_PUBKEY_HEX);
   });
 
   it('builds a guardian ProposalSignature carrying the recovered key (integration via buildGuardianSignatureFromSigner)', async () => {
-    const accountCommitment = tryComputeEcdsaCommitmentHex(COMPRESSED_PUBKEY_HEX);
-    const signer = new MidenWalletSigner(ecdsaWallet(PRIVATE_KEY), accountCommitment!, 'ecdsa');
+    const accountCommitment = expectPresent(tryComputeEcdsaCommitmentHex(COMPRESSED_PUBKEY_HEX));
+    const signer = new MidenWalletSigner(ecdsaWallet(PRIVATE_KEY), accountCommitment, 'ecdsa');
 
     // The exact call the guardian flow makes (multisig/signing.ts): sign the
     // commitment, then read `signer.publicKey` for the ProposalSignature that is sent
     // to the guardian and packed into the transaction advice map. This is the seam
     // where the report observed `publicKey === commitment`.
-    const proposalSignature = await buildGuardianSignatureFromSigner(signer, accountCommitment!);
+    const proposalSignature = await buildGuardianSignatureFromSigner(signer, accountCommitment);
 
     expect(proposalSignature.scheme).toBe('ecdsa');
     if (proposalSignature.scheme !== 'ecdsa') throw new Error('expected an ecdsa ProposalSignature');
     // The signature reaching the guardian/kernel must carry the real 33-byte key,
     // not the 32-byte commitment — otherwise Poseidon2(publicKey) == commitment fails.
-    expect(proposalSignature.publicKey).toBe(COMPRESSED_PUBKEY_HEX);
-    expect(proposalSignature.publicKey).not.toBe(accountCommitment);
-    expect(tryComputeEcdsaCommitmentHex(proposalSignature.publicKey!)).toBe(accountCommitment);
+    const resolvedKey = expectPresent(proposalSignature.publicKey);
+    expect(resolvedKey).toBe(COMPRESSED_PUBKEY_HEX);
+    expect(resolvedKey).not.toBe(accountCommitment);
+    expect(tryComputeEcdsaCommitmentHex(resolvedKey)).toBe(accountCommitment);
   });
 });

--- a/packages/miden-multisig-client/src/signers/miden-wallet.ecdsa-recovery.test.ts
+++ b/packages/miden-multisig-client/src/signers/miden-wallet.ecdsa-recovery.test.ts
@@ -5,6 +5,7 @@ import { keccak_256 } from '@noble/hashes/sha3.js';
 import { MidenWalletSigner, type WalletSigningContext } from './miden-wallet.js';
 import { tryComputeEcdsaCommitmentHex } from '../utils/signature.js';
 import { bytesToHex, hexToBytes } from '../utils/encoding.js';
+import { buildGuardianSignatureFromSigner } from '../multisig/signing.js';
 
 // Real-crypto repro for the reported failure:
 //   "assertion failed with error message: invalid public key commitment"
@@ -103,5 +104,24 @@ describe('MidenWalletSigner ECDSA public-key resolution', () => {
     await signer.signLookupMessage(accountCommitment!, 1700000000);
 
     expect(signer.publicKey).toBe(COMPRESSED_PUBKEY_HEX);
+  });
+
+  it('builds a guardian ProposalSignature carrying the recovered key (integration via buildGuardianSignatureFromSigner)', async () => {
+    const accountCommitment = tryComputeEcdsaCommitmentHex(COMPRESSED_PUBKEY_HEX);
+    const signer = new MidenWalletSigner(ecdsaWallet(PRIVATE_KEY), accountCommitment!, 'ecdsa');
+
+    // The exact call the guardian flow makes (multisig/signing.ts): sign the
+    // commitment, then read `signer.publicKey` for the ProposalSignature that is sent
+    // to the guardian and packed into the transaction advice map. This is the seam
+    // where the report observed `publicKey === commitment`.
+    const proposalSignature = await buildGuardianSignatureFromSigner(signer, accountCommitment!);
+
+    expect(proposalSignature.scheme).toBe('ecdsa');
+    if (proposalSignature.scheme !== 'ecdsa') throw new Error('expected an ecdsa ProposalSignature');
+    // The signature reaching the guardian/kernel must carry the real 33-byte key,
+    // not the 32-byte commitment — otherwise Poseidon2(publicKey) == commitment fails.
+    expect(proposalSignature.publicKey).toBe(COMPRESSED_PUBKEY_HEX);
+    expect(proposalSignature.publicKey).not.toBe(accountCommitment);
+    expect(tryComputeEcdsaCommitmentHex(proposalSignature.publicKey!)).toBe(accountCommitment);
   });
 });

--- a/packages/miden-multisig-client/src/signers/miden-wallet.ecdsa-recovery.test.ts
+++ b/packages/miden-multisig-client/src/signers/miden-wallet.ecdsa-recovery.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { secp256k1 } from '@noble/curves/secp256k1';
+import { keccak_256 } from '@noble/hashes/sha3.js';
+
+import { MidenWalletSigner, type WalletSigningContext } from './miden-wallet.js';
+import { tryComputeEcdsaCommitmentHex } from '../utils/signature.js';
+import { bytesToHex, hexToBytes } from '../utils/encoding.js';
+
+// Real-crypto repro for the reported failure:
+//   "assertion failed with error message: invalid public key commitment"
+//
+// This test uses the real WASM SDK (Poseidon2/PublicKey, via tests/setup-wasm.ts)
+// and a real secp256k1 keypair — NOT mocks — so it reproduces the exact kernel
+// invariant `Poseidon2(publicKey) == pub_key_commitment` that the transaction
+// kernel enforces in `ecdsa_k256_keccak.masm` (`assert_eqw "invalid public key
+// commitment"`). A wallet-delegated ECDSA cosigner whose `publicKey` degrades to
+// the 32-byte commitment fails that invariant.
+
+// Deterministic key so the repro is reproducible run-to-run.
+const PRIVATE_KEY = hexToBytes('0x' + '11'.repeat(32));
+const COMPRESSED_PUBKEY_HEX = bytesToHex(secp256k1.getPublicKey(PRIVATE_KEY, true));
+
+/**
+ * A wallet that signs like the real Miden Wallet ECDSA path: it keccak256-hashes
+ * the word bytes it receives, produces a 65-byte `r||s||v` signature, and prepends
+ * a 1-byte scheme tag (which `MidenWalletSigner.signWord` strips via `slice(1)`).
+ */
+function ecdsaWallet(privateKey: Uint8Array): WalletSigningContext {
+  return {
+    async signBytes(data: Uint8Array): Promise<Uint8Array> {
+      const msgHash = keccak_256(data);
+      const sig = secp256k1.sign(msgHash, privateKey);
+      const compact = sig.toCompactRawBytes(); // 64 bytes: r || s
+      const tagged = new Uint8Array(1 + 65);
+      tagged[0] = 1; // scheme tag, dropped by the signer
+      tagged.set(compact, 1);
+      tagged[1 + 64] = sig.recovery; // recovery byte v
+      return tagged;
+    },
+  };
+}
+
+describe('MidenWalletSigner ECDSA public-key resolution', () => {
+  it('resolves the real ECDSA public key from its own signature so it hashes to the account commitment', async () => {
+    // The account's stored commitment is Poseidon2(pubkey) — exactly what the kernel checks.
+    const accountCommitment = tryComputeEcdsaCommitmentHex(COMPRESSED_PUBKEY_HEX);
+    expect(accountCommitment).not.toBeNull();
+
+    // Wallet-delegated ECDSA cosigner constructed WITHOUT an explicit public key —
+    // the reported failure path, where `publicKey` silently fell back to the commitment.
+    const signer = new MidenWalletSigner(ecdsaWallet(PRIVATE_KEY), accountCommitment!, 'ecdsa');
+
+    await signer.signCommitment(accountCommitment!);
+
+    // The resolved public key must be the real 33-byte key, not the 32-byte commitment...
+    expect(signer.publicKey).toBe(COMPRESSED_PUBKEY_HEX);
+    expect(signer.publicKey).not.toBe(accountCommitment);
+    // ...and it must Poseidon2-hash back to the commitment (the kernel's assert_eqw).
+    expect(tryComputeEcdsaCommitmentHex(signer.publicKey)).toBe(accountCommitment);
+  });
+
+  it('fails closed when the wallet signature recovers a key that does not match the commitment', async () => {
+    // The account commitment is for PRIVATE_KEY, but the wallet signs with a
+    // different key. Recovery must reject the mismatch rather than trust it.
+    const otherKey = hexToBytes('0x' + '22'.repeat(32));
+    const accountCommitment = tryComputeEcdsaCommitmentHex(COMPRESSED_PUBKEY_HEX);
+
+    const signer = new MidenWalletSigner(ecdsaWallet(otherKey), accountCommitment!, 'ecdsa');
+    await signer.signCommitment(accountCommitment!);
+
+    expect(() => signer.publicKey).toThrow(/does not match the signer commitment/);
+  });
+
+  it('accepts an explicitly-provided valid ECDSA public key without needing to sign', () => {
+    const accountCommitment = tryComputeEcdsaCommitmentHex(COMPRESSED_PUBKEY_HEX);
+    const signer = new MidenWalletSigner(
+      ecdsaWallet(PRIVATE_KEY),
+      accountCommitment!,
+      'ecdsa',
+      undefined,
+      COMPRESSED_PUBKEY_HEX,
+    );
+    expect(signer.publicKey).toBe(COMPRESSED_PUBKEY_HEX);
+  });
+
+  it('compresses an explicitly-provided 65-byte uncompressed public key', () => {
+    const uncompressed = bytesToHex(secp256k1.getPublicKey(PRIVATE_KEY, false)); // 65 bytes
+    const accountCommitment = tryComputeEcdsaCommitmentHex(COMPRESSED_PUBKEY_HEX);
+    const signer = new MidenWalletSigner(
+      ecdsaWallet(PRIVATE_KEY),
+      accountCommitment!,
+      'ecdsa',
+      undefined,
+      uncompressed,
+    );
+    expect(signer.publicKey).toBe(COMPRESSED_PUBKEY_HEX);
+  });
+
+  it('resolves the public key through a non-signCommitment path (signLookupMessage)', async () => {
+    const accountCommitment = tryComputeEcdsaCommitmentHex(COMPRESSED_PUBKEY_HEX);
+    const signer = new MidenWalletSigner(ecdsaWallet(PRIVATE_KEY), accountCommitment!, 'ecdsa');
+
+    await signer.signLookupMessage(accountCommitment!, 1700000000);
+
+    expect(signer.publicKey).toBe(COMPRESSED_PUBKEY_HEX);
+  });
+});

--- a/packages/miden-multisig-client/src/signers/miden-wallet.test.ts
+++ b/packages/miden-multisig-client/src/signers/miden-wallet.test.ts
@@ -54,18 +54,6 @@ describe('MidenWalletSigner', () => {
       expect(signer.publicKey).toBe('0xcommitment');
     });
 
-    it('should use an explicit (valid) ECDSA publicKey when provided', () => {
-      const pubKey = '0x02' + 'ab'.repeat(32); // 33-byte compressed secp256k1 key
-      const signer = new MidenWalletSigner(
-        mockWallet,
-        '0xcommitment',
-        'ecdsa',
-        undefined,
-        pubKey,
-      );
-      expect(signer.publicKey).toBe(pubKey);
-    });
-
     it('throws on an invalid explicit ECDSA publicKey instead of falling back to the commitment', () => {
       expect(
         () => new MidenWalletSigner(mockWallet, '0xcommitment', 'ecdsa', undefined, '0xwalletpubkey'),
@@ -77,17 +65,9 @@ describe('MidenWalletSigner', () => {
       expect(() => signer.publicKey).toThrow(/not available yet/);
     });
 
-    it('should use localAuthSigner publicKey when provided', () => {
-      const localSigner: Signer = {
-        commitment: '0xlocal',
-        publicKey: '0xlocalpubkey',
-        scheme: 'ecdsa',
-        signAccountIdWithTimestamp: vi.fn(),
-        signCommitment: vi.fn(),
-      };
-      const signer = new MidenWalletSigner(mockWallet, '0xcommitment', 'ecdsa', localSigner);
-      expect(signer.publicKey).toBe('0xlocalpubkey');
-    });
+    // ECDSA publicKey resolution against a real commitment (explicit key and
+    // localAuthSigner, match and mismatch) needs real Poseidon2 and is covered in
+    // miden-wallet.ecdsa-recovery.test.ts, which runs the WASM SDK.
   });
 
   describe('signAccountIdWithTimestamp', () => {

--- a/packages/miden-multisig-client/src/signers/miden-wallet.test.ts
+++ b/packages/miden-multisig-client/src/signers/miden-wallet.test.ts
@@ -54,15 +54,27 @@ describe('MidenWalletSigner', () => {
       expect(signer.publicKey).toBe('0xcommitment');
     });
 
-    it('should use explicit publicKey when provided', () => {
+    it('should use an explicit (valid) ECDSA publicKey when provided', () => {
+      const pubKey = '0x02' + 'ab'.repeat(32); // 33-byte compressed secp256k1 key
       const signer = new MidenWalletSigner(
         mockWallet,
         '0xcommitment',
         'ecdsa',
         undefined,
-        '0xwalletpubkey',
+        pubKey,
       );
-      expect(signer.publicKey).toBe('0xwalletpubkey');
+      expect(signer.publicKey).toBe(pubKey);
+    });
+
+    it('throws on an invalid explicit ECDSA publicKey instead of falling back to the commitment', () => {
+      expect(
+        () => new MidenWalletSigner(mockWallet, '0xcommitment', 'ecdsa', undefined, '0xwalletpubkey'),
+      ).toThrow(/invalid ECDSA public key/);
+    });
+
+    it('does not fall back to the commitment for an ECDSA signer with no key (throws until a signature exists)', () => {
+      const signer = new MidenWalletSigner(mockWallet, '0xcommitment', 'ecdsa');
+      expect(() => signer.publicKey).toThrow(/not available yet/);
     });
 
     it('should use localAuthSigner publicKey when provided', () => {

--- a/packages/miden-multisig-client/src/signers/miden-wallet.ts
+++ b/packages/miden-multisig-client/src/signers/miden-wallet.ts
@@ -1,20 +1,34 @@
 import type { RequestAuthPayload } from '@openzeppelin/guardian-client';
 import type { Signer, SignatureScheme } from '../types.js';
 import { AuthDigest } from '../utils/digest.js';
-import { bytesToHex } from '../utils/encoding.js';
+import { EcdsaFormat } from '../utils/ecdsa.js';
+import { bytesToHex, normalizeHexWord } from '../utils/encoding.js';
 import { lookupAuthDigest } from '../lookupAuth.js';
+import { tryComputeEcdsaCommitmentHex } from '../utils/signature.js';
 import { wordToBytes } from '../utils/word.js';
 
 export interface WalletSigningContext {
+  /**
+   * Sign `data` with the wallet's key.
+   *
+   * For an ECDSA (secp256k1/keccak) signer that is constructed WITHOUT an
+   * explicit public key and without a `localAuthSigner`, the returned signature
+   * MUST carry the recovery byte — i.e. the 65-byte `r||s||v` form (optionally
+   * prefixed with a 1-byte scheme tag, which is stripped). The public key is
+   * recovered from that signature; a 64-byte signature with no recovery byte
+   * cannot be recovered and the signer will fail closed when `publicKey` is read.
+   */
   signBytes(data: Uint8Array, kind: 'word' | 'signingInputs'): Promise<Uint8Array>;
 }
 
 export class MidenWalletSigner implements Signer {
   readonly commitment: string;
-  readonly publicKey: string;
   readonly scheme: SignatureScheme;
   private readonly wallet: WalletSigningContext;
   private readonly localAuthSigner: Signer | null;
+  private resolvedPublicKey: string | null;
+  private lastSignedMessage: Uint8Array | null = null;
+  private lastSignature: Uint8Array | null = null;
 
   constructor(
     wallet: WalletSigningContext,
@@ -27,7 +41,87 @@ export class MidenWalletSigner implements Signer {
     this.commitment = commitment;
     this.scheme = scheme;
     this.localAuthSigner = localAuthSigner ?? null;
-    this.publicKey = publicKey ?? localAuthSigner?.publicKey ?? commitment;
+
+    if (scheme === 'ecdsa') {
+      // An ECDSA signer's public key must be a real 33-/65-byte secp256k1 key —
+      // never the 32-byte account commitment. An explicit key is validated and
+      // compressed up front (as ParaSigner does). Otherwise it is resolved
+      // lazily on first `publicKey` read — from a delegate `localAuthSigner`, or
+      // recovered from the signer's own signature (see the `publicKey` getter).
+      // We never silently fall back to the commitment, which would otherwise only
+      // surface as an opaque kernel assertion ("invalid public key commitment")
+      // when the transaction executes.
+      if (publicKey != null) {
+        if (!EcdsaFormat.validatePublicKeyHex(publicKey)) {
+          throw new Error(
+            'MidenWalletSigner: invalid ECDSA public key (expected a 33- or 65-byte hex key); ' +
+              'refusing to fall back to the commitment.',
+          );
+        }
+        this.resolvedPublicKey = EcdsaFormat.compressPublicKey(publicKey);
+      } else {
+        this.resolvedPublicKey = null;
+      }
+    } else {
+      // Falcon: the public key IS the commitment word, so the commitment is a
+      // legitimate value here. Preserve the prior behaviour.
+      this.resolvedPublicKey = publicKey ?? localAuthSigner?.publicKey ?? commitment;
+    }
+  }
+
+  /**
+   * The signer's public key.
+   *
+   * Returns immediately for Falcon and for ECDSA signers constructed with an
+   * explicit key or a delegate `localAuthSigner`. For a wallet-delegated ECDSA
+   * signer with no supplied key, the key is recovered from a signature the signer
+   * has already produced and is verified against {@link commitment} — the same
+   * `Poseidon2(publicKey) == commitment` invariant the transaction kernel
+   * enforces. In that case, reading `publicKey` before any signature exists, or
+   * when the recovered key does not match the commitment, throws: a loud
+   * sign-time failure instead of an opaque kernel assertion at execute time.
+   */
+  get publicKey(): string {
+    if (this.resolvedPublicKey !== null) {
+      return this.resolvedPublicKey;
+    }
+
+    // ECDSA, no explicit key: prefer a delegate signer's (already real) key.
+    // Resolved lazily so we never invoke the delegate's getter at construction.
+    if (this.localAuthSigner !== null) {
+      this.resolvedPublicKey = this.localAuthSigner.publicKey;
+      return this.resolvedPublicKey;
+    }
+
+    // Otherwise recover the key from a produced signature and verify it against
+    // the commitment before trusting it.
+    if (this.lastSignature === null || this.lastSignedMessage === null) {
+      throw new Error(
+        'MidenWalletSigner: ECDSA public key is not available yet — produce a signature first, ' +
+          'or pass `publicKey` to the constructor.',
+      );
+    }
+
+    const recovered = EcdsaFormat.recoverCompressedPublicKeyHex(
+      this.lastSignedMessage,
+      this.lastSignature,
+    );
+    const recoveredCommitment = tryComputeEcdsaCommitmentHex(recovered);
+    if (recoveredCommitment === null) {
+      throw new Error(
+        'MidenWalletSigner: could not compute a commitment for the recovered ECDSA public key ' +
+          '(is the Miden SDK initialized?).',
+      );
+    }
+    if (recoveredCommitment !== normalizeHexWord(this.commitment)) {
+      throw new Error(
+        'MidenWalletSigner: the public key recovered from the wallet signature does not match ' +
+          'the signer commitment.',
+      );
+    }
+
+    this.resolvedPublicKey = recovered;
+    return recovered;
   }
 
   async signAccountIdWithTimestamp(accountId: string, timestamp: number): Promise<string> {
@@ -74,6 +168,16 @@ export class MidenWalletSigner implements Signer {
     const bytes = wordToBytes(word);
     const signatureBytes = await this.wallet.signBytes(bytes, 'word');
     const rawSignature = signatureBytes.slice(1);
+    if (
+      this.scheme === 'ecdsa' &&
+      this.resolvedPublicKey === null &&
+      this.localAuthSigner === null
+    ) {
+      // No key supplied and no delegate signer: remember the last (message,
+      // signature) so `publicKey` can recover and verify the ECDSA key.
+      this.lastSignedMessage = bytes;
+      this.lastSignature = rawSignature;
+    }
     return bytesToHex(rawSignature);
   }
 }

--- a/packages/miden-multisig-client/src/signers/miden-wallet.ts
+++ b/packages/miden-multisig-client/src/signers/miden-wallet.ts
@@ -11,12 +11,16 @@ export interface WalletSigningContext {
   /**
    * Sign `data` with the wallet's key.
    *
-   * For an ECDSA (secp256k1/keccak) signer that is constructed WITHOUT an
-   * explicit public key and without a `localAuthSigner`, the returned signature
-   * MUST carry the recovery byte — i.e. the 65-byte `r||s||v` form (optionally
-   * prefixed with a 1-byte scheme tag, which is stripped). The public key is
-   * recovered from that signature; a 64-byte signature with no recovery byte
-   * cannot be recovered and the signer will fail closed when `publicKey` is read.
+   * `signBytes` MUST return the signature in the Miden SDK's serialized form: a
+   * 1-byte scheme tag followed by the raw signature. The signer always strips that
+   * leading tag byte, exactly as the SDK's own `EcdsaSigner`/`FalconSigner` do with
+   * `Signature.serialize()`.
+   *
+   * For an ECDSA (secp256k1/keccak) signer constructed WITHOUT an explicit public
+   * key and without a `localAuthSigner`, the raw signature MUST carry the recovery
+   * byte — the 65-byte `r||s||v` form (66 bytes including the tag) — so the public
+   * key can be recovered from it. A 64-byte signature with no recovery byte cannot
+   * be recovered, and the signer fails closed when `publicKey` is read.
    */
   signBytes(data: Uint8Array, kind: 'word' | 'signingInputs'): Promise<Uint8Array>;
 }
@@ -26,6 +30,7 @@ export class MidenWalletSigner implements Signer {
   readonly scheme: SignatureScheme;
   private readonly wallet: WalletSigningContext;
   private readonly localAuthSigner: Signer | null;
+  private readonly explicitPublicKey: string | null;
   private resolvedPublicKey: string | null;
   private lastSignedMessage: Uint8Array | null = null;
   private lastSignature: Uint8Array | null = null;
@@ -43,28 +48,10 @@ export class MidenWalletSigner implements Signer {
     this.localAuthSigner = localAuthSigner ?? null;
 
     if (scheme === 'ecdsa') {
-      // An ECDSA signer's public key must be a real 33-/65-byte secp256k1 key —
-      // never the 32-byte account commitment. An explicit key is validated and
-      // compressed up front (as ParaSigner does). Otherwise it is resolved
-      // lazily on first `publicKey` read — from a delegate `localAuthSigner`, or
-      // recovered from the signer's own signature (see the `publicKey` getter).
-      // We never silently fall back to the commitment, which would otherwise only
-      // surface as an opaque kernel assertion ("invalid public key commitment")
-      // when the transaction executes.
-      if (publicKey != null) {
-        if (!EcdsaFormat.validatePublicKeyHex(publicKey)) {
-          throw new Error(
-            'MidenWalletSigner: invalid ECDSA public key (expected a 33- or 65-byte hex key); ' +
-              'refusing to fall back to the commitment.',
-          );
-        }
-        this.resolvedPublicKey = EcdsaFormat.compressPublicKey(publicKey);
-      } else {
-        this.resolvedPublicKey = null;
-      }
+      this.explicitPublicKey = publicKey == null ? null : validateEcdsaPublicKeyHex(publicKey);
+      this.resolvedPublicKey = null;
     } else {
-      // Falcon: the public key IS the commitment word, so the commitment is a
-      // legitimate value here. Preserve the prior behaviour.
+      this.explicitPublicKey = null;
       this.resolvedPublicKey = publicKey ?? localAuthSigner?.publicKey ?? commitment;
     }
   }
@@ -72,29 +59,28 @@ export class MidenWalletSigner implements Signer {
   /**
    * The signer's public key.
    *
-   * Returns immediately for Falcon and for ECDSA signers constructed with an
-   * explicit key or a delegate `localAuthSigner`. For a wallet-delegated ECDSA
-   * signer with no supplied key, the key is recovered from a signature the signer
-   * has already produced and is verified against {@link commitment} — the same
-   * `Poseidon2(publicKey) == commitment` invariant the transaction kernel
-   * enforces. In that case, reading `publicKey` before any signature exists, or
-   * when the recovered key does not match the commitment, throws: a loud
-   * sign-time failure instead of an opaque kernel assertion at execute time.
+   * Returns immediately for Falcon. For ECDSA the key is resolved from one of
+   * three sources — an explicit key, a delegate `localAuthSigner`, or recovery
+   * from a signature the signer has already produced — and every source is
+   * verified against {@link commitment} via the same `Poseidon2(publicKey) ==
+   * commitment` invariant the transaction kernel enforces. Reading `publicKey`
+   * before any source is available, or when the resolved key does not match the
+   * commitment, throws: a loud sign-time failure instead of an opaque kernel
+   * assertion ("invalid public key commitment") at execute time.
    */
   get publicKey(): string {
     if (this.resolvedPublicKey !== null) {
       return this.resolvedPublicKey;
     }
 
-    // ECDSA, no explicit key: prefer a delegate signer's (already real) key.
-    // Resolved lazily so we never invoke the delegate's getter at construction.
-    if (this.localAuthSigner !== null) {
-      this.resolvedPublicKey = this.localAuthSigner.publicKey;
-      return this.resolvedPublicKey;
+    if (this.explicitPublicKey !== null) {
+      return this.verifyAndCache(this.explicitPublicKey, false);
     }
 
-    // Otherwise recover the key from a produced signature and verify it against
-    // the commitment before trusting it.
+    if (this.localAuthSigner !== null) {
+      return this.verifyAndCache(validateEcdsaPublicKeyHex(this.localAuthSigner.publicKey), false);
+    }
+
     if (this.lastSignature === null || this.lastSignedMessage === null) {
       throw new Error(
         'MidenWalletSigner: ECDSA public key is not available yet — produce a signature first, ' +
@@ -106,22 +92,40 @@ export class MidenWalletSigner implements Signer {
       this.lastSignedMessage,
       this.lastSignature,
     );
-    const recoveredCommitment = tryComputeEcdsaCommitmentHex(recovered);
-    if (recoveredCommitment === null) {
-      throw new Error(
-        'MidenWalletSigner: could not compute a commitment for the recovered ECDSA public key ' +
-          '(is the Miden SDK initialized?).',
-      );
+    return this.verifyAndCache(recovered, true);
+  }
+
+  /**
+   * Verify an already point-validated ECDSA public-key candidate against
+   * {@link commitment} and cache it on success.
+   *
+   * A mismatching commitment is always rejected. `requireCommitment` distinguishes
+   * the recovery path — where a signature already exists, so the SDK must be
+   * initialized and an uncomputable commitment is an error — from the
+   * explicit/delegate paths, where a caller may read `publicKey` before the SDK is
+   * initialized. In that cold-SDK case the commitment cannot be computed yet, so
+   * the candidate is returned WITHOUT being cached and verification is re-attempted
+   * on the next read (once the SDK is up, as it always is in the guardian flow).
+   */
+  private verifyAndCache(candidate: string, requireCommitment: boolean): string {
+    const candidateCommitment = tryComputeEcdsaCommitmentHex(candidate);
+    if (candidateCommitment === null) {
+      if (requireCommitment) {
+        throw new Error(
+          'MidenWalletSigner: could not compute a commitment for the recovered ECDSA public key ' +
+            '(is the Miden SDK initialized?).',
+        );
+      }
+      return candidate;
     }
-    if (recoveredCommitment !== normalizeHexWord(this.commitment)) {
+    if (candidateCommitment !== normalizeHexWord(this.commitment)) {
       throw new Error(
-        'MidenWalletSigner: the public key recovered from the wallet signature does not match ' +
-          'the signer commitment.',
+        'MidenWalletSigner: the ECDSA public key does not match the signer commitment.',
       );
     }
 
-    this.resolvedPublicKey = recovered;
-    return recovered;
+    this.resolvedPublicKey = candidate;
+    return candidate;
   }
 
   async signAccountIdWithTimestamp(accountId: string, timestamp: number): Promise<string> {
@@ -139,10 +143,6 @@ export class MidenWalletSigner implements Signer {
   ): Promise<string> {
     if (this.localAuthSigner?.signRequest) {
       return this.localAuthSigner.signRequest(accountId, timestamp, requestPayload);
-    }
-
-    if (this.scheme === 'falcon') {
-      return this.signWord(AuthDigest.fromRequest(accountId, timestamp, requestPayload));
     }
     return this.signWord(AuthDigest.fromRequest(accountId, timestamp, requestPayload));
   }
@@ -170,14 +170,37 @@ export class MidenWalletSigner implements Signer {
     const rawSignature = signatureBytes.slice(1);
     if (
       this.scheme === 'ecdsa' &&
-      this.resolvedPublicKey === null &&
+      this.explicitPublicKey === null &&
       this.localAuthSigner === null
     ) {
-      // No key supplied and no delegate signer: remember the last (message,
-      // signature) so `publicKey` can recover and verify the ECDSA key.
       this.lastSignedMessage = bytes;
       this.lastSignature = rawSignature;
     }
     return bytesToHex(rawSignature);
   }
+}
+
+/**
+ * Validate an ECDSA public key and return its compressed (33-byte) form.
+ *
+ * The key must be a 33-/65-byte hex key AND a real secp256k1 curve point; a
+ * malformed or off-curve key throws immediately (SDK-independent) rather than
+ * degrading to the commitment or surfacing as an opaque kernel assertion at
+ * execute time. Mirrors the format handling ParaSigner does for explicit keys.
+ */
+function validateEcdsaPublicKeyHex(publicKey: string): string {
+  if (!EcdsaFormat.validatePublicKeyHex(publicKey)) {
+    throw new Error(
+      'MidenWalletSigner: invalid ECDSA public key (expected a 33- or 65-byte hex key); ' +
+        'refusing to fall back to the commitment.',
+    );
+  }
+  const compressed = EcdsaFormat.compressPublicKey(publicKey);
+  if (!EcdsaFormat.isValidPublicKeyPoint(compressed)) {
+    throw new Error(
+      'MidenWalletSigner: invalid ECDSA public key (not a valid secp256k1 point); ' +
+        'refusing to fall back to the commitment.',
+    );
+  }
+  return compressed;
 }

--- a/packages/miden-multisig-client/src/utils/ecdsa.test.ts
+++ b/packages/miden-multisig-client/src/utils/ecdsa.test.ts
@@ -87,6 +87,23 @@ describe('EcdsaFormat', () => {
     });
   });
 
+  describe('isValidPublicKeyPoint', () => {
+    // The secp256k1 generator point G, compressed — a known-valid point.
+    const G = '0x0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798';
+
+    it('accepts a valid compressed secp256k1 point', () => {
+      expect(EcdsaFormat.isValidPublicKeyPoint(G)).toBe(true);
+    });
+
+    it('rejects a valid-length key whose x is off-curve', () => {
+      expect(EcdsaFormat.isValidPublicKeyPoint('0x02' + 'ff'.repeat(32))).toBe(false);
+    });
+
+    it('rejects a valid-length key with a bad prefix byte', () => {
+      expect(EcdsaFormat.isValidPublicKeyPoint('0xff' + 'ab'.repeat(32))).toBe(false);
+    });
+  });
+
   describe('keccakDigestHex', () => {
     it('should return 0x-prefixed hex of keccak-256 hash', () => {
       const result = EcdsaFormat.keccakDigestHex(new Uint8Array(0));

--- a/packages/miden-multisig-client/src/utils/ecdsa.test.ts
+++ b/packages/miden-multisig-client/src/utils/ecdsa.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
+import { secp256k1 } from '@noble/curves/secp256k1';
+import { keccak_256 } from '@noble/hashes/sha3.js';
 import { EcdsaFormat } from './ecdsa.js';
+import { bytesToHex } from './encoding.js';
 
 describe('EcdsaFormat', () => {
   describe('normalizeRecoveryByte', () => {
@@ -99,6 +102,46 @@ describe('EcdsaFormat', () => {
       const a = EcdsaFormat.keccakDigestHex(new Uint8Array([1]));
       const b = EcdsaFormat.keccakDigestHex(new Uint8Array([2]));
       expect(a).not.toBe(b);
+    });
+  });
+
+  describe('recoverCompressedPublicKeyHex', () => {
+    const privateKey = new Uint8Array(32).fill(0x11);
+    const message = new Uint8Array([9, 8, 7, 6, 5]);
+
+    function sign(priv: Uint8Array, msg: Uint8Array): Uint8Array {
+      const sig = secp256k1.sign(keccak_256(msg), priv);
+      const out = new Uint8Array(65);
+      out.set(sig.toCompactRawBytes(), 0); // r || s
+      out[64] = sig.recovery; // v
+      return out;
+    }
+
+    it('recovers the compressed public key that produced the signature', () => {
+      const expected = bytesToHex(secp256k1.getPublicKey(privateKey, true));
+      const recovered = EcdsaFormat.recoverCompressedPublicKeyHex(message, sign(privateKey, message));
+      expect(recovered).toBe(expected);
+    });
+
+    it('accepts an Ethereum-style recovery byte (27/28)', () => {
+      const sig = sign(privateKey, message);
+      sig[64] += 27; // 0/1 -> 27/28
+      const expected = bytesToHex(secp256k1.getPublicKey(privateKey, true));
+      expect(EcdsaFormat.recoverCompressedPublicKeyHex(message, sig)).toBe(expected);
+    });
+
+    it('throws when the signature is not 65 bytes', () => {
+      expect(() => EcdsaFormat.recoverCompressedPublicKeyHex(message, new Uint8Array(64))).toThrow(
+        /65-byte signature/,
+      );
+    });
+
+    it('throws on an invalid recovery byte', () => {
+      const sig = sign(privateKey, message);
+      sig[64] = 5;
+      expect(() => EcdsaFormat.recoverCompressedPublicKeyHex(message, sig)).toThrow(
+        /recovery byte must be/,
+      );
     });
   });
 });

--- a/packages/miden-multisig-client/src/utils/ecdsa.ts
+++ b/packages/miden-multisig-client/src/utils/ecdsa.ts
@@ -1,5 +1,6 @@
+import { secp256k1 } from '@noble/curves/secp256k1';
 import { keccak_256 } from '@noble/hashes/sha3.js';
-import { ensureHexPrefix } from './encoding.js';
+import { bytesToHex, ensureHexPrefix } from './encoding.js';
 
 const ECDSA_SIGNATURE_BYTE_LENGTH = 64;
 const ECDSA_SIGNATURE_WITH_RECOVERY_BYTE_LENGTH = 65;
@@ -73,5 +74,39 @@ export class EcdsaFormat {
       hex += hash[i].toString(16).padStart(2, '0');
     }
     return hex;
+  }
+
+  /**
+   * Recover the compressed (33-byte) secp256k1 public key that produced an
+   * `ecdsa_k256_keccak` signature over `messageBytes`.
+   *
+   * `messageBytes` is the raw word/message bytes (the digest is `keccak256` of
+   * these, matching the transaction kernel and {@link EcdsaFormat.keccakDigestHex}).
+   * `signature` must be the 65-byte `r||s||v` form; the recovery byte may be the
+   * canonical `0/1` or the Ethereum-style `27/28`.
+   */
+  static recoverCompressedPublicKeyHex(messageBytes: Uint8Array, signature: Uint8Array): string {
+    if (signature.length !== ECDSA_SIGNATURE_WITH_RECOVERY_BYTE_LENGTH) {
+      throw new Error(
+        `ECDSA public-key recovery requires a ${ECDSA_SIGNATURE_WITH_RECOVERY_BYTE_LENGTH}-byte signature (r||s||v), got ${signature.length}`,
+      );
+    }
+
+    let recoveryBit = signature[ECDSA_SIGNATURE_BYTE_LENGTH];
+    if (recoveryBit === 27 || recoveryBit === 28) {
+      recoveryBit -= 27;
+    }
+    if (recoveryBit !== 0 && recoveryBit !== 1) {
+      throw new Error(
+        `ECDSA recovery byte must be 0/1 (or 27/28), got ${signature[ECDSA_SIGNATURE_BYTE_LENGTH]}`,
+      );
+    }
+
+    const compact = signature.slice(0, ECDSA_SIGNATURE_BYTE_LENGTH);
+    const msgHash = keccak_256(messageBytes);
+    const recovered = secp256k1.Signature.fromCompact(compact)
+      .addRecoveryBit(recoveryBit)
+      .recoverPublicKey(msgHash);
+    return bytesToHex(recovered.toRawBytes(true));
   }
 }

--- a/packages/miden-multisig-client/src/utils/ecdsa.ts
+++ b/packages/miden-multisig-client/src/utils/ecdsa.ts
@@ -51,6 +51,21 @@ export class EcdsaFormat {
     return byteLength === 33 || byteLength === 65;
   }
 
+  /**
+   * Whether `publicKeyHex` decodes to a valid secp256k1 curve point (compressed
+   * 33-byte or uncompressed 65-byte). Unlike {@link EcdsaFormat.validatePublicKeyHex}
+   * this rejects well-formed-length but off-curve or bad-prefix keys, and does so
+   * without the Miden WASM SDK.
+   */
+  static isValidPublicKeyPoint(publicKeyHex: string): boolean {
+    try {
+      secp256k1.ProjectivePoint.fromHex(ensureHexPrefix(publicKeyHex).slice(2));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   static compressPublicKey(uncompressedHex: string): string {
     const clean = ensureHexPrefix(uncompressedHex).slice(2);
     const byteLength = clean.length / 2;


### PR DESCRIPTION
Fixes #313.

## Problem

For an ECDSA guardian cosigner backed by a wallet, `MidenWalletSigner` exposed the 32-byte account **commitment** as its `publicKey` instead of the real 33-byte ECDSA key. The constructor did:

```ts
this.publicKey = publicKey ?? localAuthSigner?.publicKey ?? commitment;
```

With no explicit key and no `localAuthSigner`, an ECDSA cosigner fell back to `commitment`. That value is packed into the transaction advice map, and the kernel (`crypto/dsa/ecdsa_k256_keccak.masm`) asserts `Poseidon2(publicKey) == pub_key_commitment` → `assert_eqw "invalid public key commitment"`. Since `Poseidon2(commitment) != commitment`, the tx traps at **execute**. Signing succeeds, so the failure only shows at execute time. `ParaSigner` guards this with `EcdsaFormat.validatePublicKeyHex`; `MidenWalletSigner` did not.

## Fix

For ECDSA, `publicKey` is now resolved (never the commitment) as:

1. an explicit key argument — validated (33/65 bytes) and compressed, like `ParaSigner`;
2. a delegate `localAuthSigner`'s key; or
3. for a pure wallet signer, **recovered from the signer's own signature** (secp256k1 recovery via the already-present `@noble/curves`) and **verified against the commitment** — the same `Poseidon2(publicKey) == commitment` invariant the kernel enforces — failing closed on mismatch.

Falcon is unchanged (`publicKey === commitment` is legitimate there). `publicKey` is now a lazily-resolved getter; every reader reads it after signing (verified across both `miden-multisig-client` and `guardian-client`), so no consumer regresses. New helper: `EcdsaFormat.recoverCompressedPublicKeyHex`.

## Repro — fails without the fix, passes with it

The PR is structured so the repro is a real, runnable regression, not just prose:

- **`6395b91` (test only, no fix)** — the repro is RED.
- **`cc780a5` (fix)** — GREEN.
- **`ff71139`** — adds an integration-level regression at the guardian seam (`buildGuardianSignatureFromSigner`).

`miden-wallet.ecdsa-recovery.test.ts` uses a real secp256k1 keypair and the real WASM Poseidon2 (no mocks), reproducing the exact kernel invariant:

| | before fix | after fix |
|---|---|---|
| `signer.publicKey` | `0x09b3…` (32-byte commitment) | `0x034f…` (real 33-byte key) |
| `Poseidon2(publicKey) == commitment` | ❌ kernel `assert_eqw` traps | ✅ |

Coverage also includes: fail-closed on a mismatched key, explicit-key validation, 65-byte → compressed, recovery via a non-`signCommitment` path, and the guardian `ProposalSignature` integration test.

## Tests

- `packages/miden-multisig-client`: 6/6 recovery tests; 319 pass across the package; `tsc --noEmit` clean. (2 unrelated failures in `procedure-roots.test.ts` are environmental — they shell out to `cargo`/`protoc`.)
- Note: this repo's CI (`ci.yml`) is Rust-only and does not run the JS package vitest suites, so the red→green is demonstrated by the commit structure above rather than enforced by CI. Adding a JS vitest job is a reasonable separate follow-up.

## Scope

Self-contained in `@openzeppelin/miden-multisig-client`; `guardian-client` untouched (the `Signer` contract is unchanged — `publicKey` stays `readonly string`, just lazily populated). No accompanying PR required; a `miden-wallet` dependency bump is the only follow-up after publish.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved ECDSA signer behavior to recover and reuse the wallet’s public key automatically when it isn’t provided upfront.
  * Added support for recovering a compressed public key from standard ECDSA signatures, including Ethereum-style recovery bytes.

* **Bug Fixes**
  * Strengthened validation for invalid or mismatched ECDSA keys and signatures.
  * Ensured signer output now uses the recovered public key when building guardian signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->