### PR TITLE
chore: release v0.15.1

### DIFF
--- a/.agents/skills/smoke-test-rust-multisig-sdk/SKILL.md
+++ b/.agents/skills/smoke-test-rust-multisig-sdk/SKILL.md
@@ -39,8 +39,8 @@ Record the returned commitment — you'll paste it into the demo's "GUARDIAN com
 2. Declare the published crates as registry dependencies pinned to the release under test:
    ```toml
    [dependencies]
-   miden-multisig-client = "0.15.0"
-   guardian-client       = "0.15.0"
+   miden-multisig-client = "0.15.1"
+   guardian-client       = "0.15.1"
    miden-client          = "0.15.0"
    tokio                 = { version = "1", features = ["full"] }
    ```

--- a/.agents/skills/smoke-test-ts-multisig-sdk/SKILL.md
+++ b/.agents/skills/smoke-test-ts-multisig-sdk/SKILL.md
@@ -36,8 +36,8 @@ If the commitment does not round-trip into `status().multisig.guardianPubkey` af
    ```json
    {
      "dependencies": {
-       "@openzeppelin/miden-multisig-client": "0.15.0",
-       "@openzeppelin/guardian-client": "0.15.0",
+       "@openzeppelin/miden-multisig-client": "0.15.1",
+       "@openzeppelin/guardian-client": "0.15.1",
        "@miden-sdk/miden-sdk": "0.15.0"
      }
    }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3131,7 +3131,7 @@ dependencies = [
 
 [[package]]
 name = "guardian-client"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "chrono",
  "guardian-shared",
@@ -3211,7 +3211,7 @@ dependencies = [
 
 [[package]]
 name = "guardian-server"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "aes-gcm",
  "alloy",
@@ -3300,7 +3300,7 @@ dependencies = [
 
 [[package]]
 name = "guardian-shared"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "base64",
  "hex",
@@ -4508,7 +4508,7 @@ dependencies = [
 
 [[package]]
 name = "miden-confidential-contracts"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4765,7 +4765,7 @@ dependencies = [
 
 [[package]]
 name = "miden-multisig-client"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.15.0"
+version = "0.15.1"
 edition = "2024"
 rust-version = "1.93"
 authors = ["OpenZeppelin"]

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -11,7 +11,7 @@ description = "Client library for Guardian"
 include = ["src/**/*", "proto/**/*", "build.rs", "Cargo.toml", "LICENSE", "README.md"]
 
 [dependencies]
-guardian-shared = { version = "=0.15.0", path = "../shared" }
+guardian-shared = { version = "=0.15.1", path = "../shared" }
 miden-protocol = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/contracts/Cargo.toml
+++ b/crates/contracts/Cargo.toml
@@ -18,7 +18,7 @@ miden-testing = { workspace = true }
 
 anyhow = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "net", "macros", "fs"] }
-guardian-shared = { version = "=0.15.0", path = "../shared" }
+guardian-shared = { version = "=0.15.1", path = "../shared" }
 
 [dev-dependencies]
 miden-client = { workspace = true, features = ["testing", "tonic"] }

--- a/crates/miden-multisig-client/Cargo.toml
+++ b/crates/miden-multisig-client/Cargo.toml
@@ -11,9 +11,9 @@ description = "High-level SDK for interacting with multisig accounts on Miden vi
 
 [dependencies]
 # Internal crates
-guardian-client = { version = "=0.15.0", path = "../client" }
-guardian-shared = { version = "=0.15.0", path = "../shared" }
-miden-confidential-contracts = { version = "=0.15.0", path = "../contracts" }
+guardian-client = { version = "=0.15.1", path = "../client" }
+guardian-shared = { version = "=0.15.1", path = "../shared" }
+miden-confidential-contracts = { version = "=0.15.1", path = "../contracts" }
 
 # Miden
 miden-client = { workspace = true, features = ["tonic"] }

--- a/docs/MULTISIG_SDK.md
+++ b/docs/MULTISIG_SDK.md
@@ -33,7 +33,7 @@ npm install @openzeppelin/miden-multisig-client @miden-sdk/miden-sdk
 **Rust (Cargo.toml)**
 ```toml
 [dependencies]
-miden-multisig-client = "0.15.0"
+miden-multisig-client = "0.15.1"
 miden-client = "0.15.0"
 ```
 
@@ -1041,8 +1041,8 @@ cd packages/miden-multisig-client && npm publish --access public
 1. Tag the release:
 
 ```bash
-git tag v0.15.0
-git push origin v0.15.0
+git tag v0.15.1
+git push origin v0.15.1
 ```
 
 2. Create a GitHub release from the tag with release notes.

--- a/docs/openapi-client.json
+++ b/docs/openapi-client.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0",
       "identifier": "AGPL-3.0"
     },
-    "version": "0.15.0"
+    "version": "0.15.1"
   },
   "paths": {
     "/configure": {

--- a/docs/openapi-dashboard.json
+++ b/docs/openapi-dashboard.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0",
       "identifier": "AGPL-3.0"
     },
-    "version": "0.15.0"
+    "version": "0.15.1"
   },
   "paths": {
     "/auth/challenge": {

--- a/docs/openapi-evm.json
+++ b/docs/openapi-evm.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0",
       "identifier": "AGPL-3.0"
     },
-    "version": "0.15.0"
+    "version": "0.15.1"
   },
   "paths": {
     "/evm/accounts": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0",
       "identifier": "AGPL-3.0"
     },
-    "version": "0.15.0"
+    "version": "0.15.1"
   },
   "paths": {
     "/auth/challenge": {

--- a/packages/guardian-client/package-lock.json
+++ b/packages/guardian-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openzeppelin/guardian-client",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openzeppelin/guardian-client",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.7.2",
@@ -1231,7 +1231,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/packages/guardian-client/package.json
+++ b/packages/guardian-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/guardian-client",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "TypeScript HTTP client for Guardian server",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/guardian-evm-client/package-lock.json
+++ b/packages/guardian-evm-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openzeppelin/guardian-evm-client",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openzeppelin/guardian-evm-client",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
         "viem": "^2.47.5"
@@ -1320,7 +1320,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1363,7 +1362,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -1525,7 +1523,6 @@
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/packages/guardian-evm-client/package.json
+++ b/packages/guardian-evm-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/guardian-evm-client",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "TypeScript EVM client for Guardian server proposal workflows",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/guardian-operator-client/package-lock.json
+++ b/packages/guardian-operator-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openzeppelin/guardian-operator-client",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openzeppelin/guardian-operator-client",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.7.2",
@@ -1188,7 +1188,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/packages/guardian-operator-client/package.json
+++ b/packages/guardian-operator-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/guardian-operator-client",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "TypeScript HTTP client for Guardian operator dashboard endpoints",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/miden-multisig-client/package-lock.json
+++ b/packages/miden-multisig-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openzeppelin/miden-multisig-client",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openzeppelin/miden-multisig-client",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
         "@miden-sdk/miden-sdk": "^0.15.0",
@@ -1710,7 +1710,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/packages/miden-multisig-client/package.json
+++ b/packages/miden-multisig-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/miden-multisig-client",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "TypeScript SDK for Miden multisig accounts with GUARDIAN integration",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Release v0.15.1

Coordinated version bump `0.15.0` → `0.15.1` across the workspace, SDK manifests, lockfiles, OpenAPI specs, and docs — same surface as the v0.15.0 release PR (#297).

### Included since v0.15.0
- feat(server): release accounts on canonicalized guardian switch (#311)
- fix(server): release diverged canonicalization candidates (#312)
- feat(server): file-based ACK secret provider for stable identity without AWS (#309)
- feat: storage encryption support (#293)
- feat(server): public `GET /status` endpoint + client `getStatus()` (#290)
- docs(speckit): human-readable wallet error messages spec (#292)

### Notes
- Miden dependency line unchanged (`miden-client` 0.15.0 et al.) — this is a Guardian-only bump on the 0.15.x line
- `miden-multisig-client`'s `@openzeppelin/guardian-client` range stays `^0.15.0` deliberately: 0.15.1 isn't published to npm (server-only release); the range already covers it if published later
- Deployed to staging from this branch and verified: `guardian-stg.openzeppelin.com/status` reports `0.15.1 @ 78513103e4f7`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped multiple packages and workspace metadata to version `0.15.1`.
  * Updated related dependency pins so Rust and TypeScript smoke-test instructions use the latest released SDK versions.
  * Refreshed API documentation and install/tagging examples to match the new release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->