### PR TITLE
fix: Improve bech32 address calculation

### DIFF
--- a/crates/server/src/dashboard/config.rs
+++ b/crates/server/src/dashboard/config.rs
@@ -17,9 +17,12 @@ pub(crate) const DEFAULT_PUBKEY_RATE_PER_MIN: u32 = 30;
 /// aggregates may return a degraded marker on filesystem-backed
 /// deployments, per FR-029 of `005-operator-dashboard-metrics`.
 pub(crate) const DEFAULT_FILESYSTEM_AGGREGATE_THRESHOLD: usize = 1_000;
-/// Default deployment environment identifier exposed on
-/// `GET /dashboard/info`.
-pub(crate) const DEFAULT_ENVIRONMENT: &str = "testnet";
+/// Network used by `Default`/`for_tests()` configs only — production
+/// never reads this: every real server resolves `GUARDIAN_NETWORK_TYPE`
+/// once (in `main.rs`) and threads it here through the builder via
+/// [`DashboardConfig::from_env_for_network`], which overrides the field.
+/// Testnet matches the historical default `environment()` label.
+pub(crate) const DEFAULT_NETWORK_TYPE: NetworkType = NetworkType::MidenTestnet;
 
 #[derive(Clone, Debug)]
 pub struct DashboardConfig {
@@ -30,7 +33,13 @@ pub struct DashboardConfig {
     pub(crate) max_outstanding_challenges: usize,
     pub(crate) commitment_rate_limit: RateLimitConfig,
     pub(crate) filesystem_aggregate_threshold: usize,
-    pub(crate) environment: String,
+    /// The Miden network this server is configured against
+    /// (`GUARDIAN_NETWORK_TYPE`, threaded through the server builder).
+    /// A server talks to exactly one Miden network, so
+    /// network-dependent rendering — the `/dashboard/info` environment
+    /// label, bech32 address HRPs — derives from this, never from
+    /// per-account metadata, which clients may omit at registration.
+    pub(crate) network_type: NetworkType,
     /// Optional pre-parsed HMAC secret for the dashboard cursor codec.
     /// When `None`, [`DashboardState`] generates a fresh random secret
     /// per process — fine for single-replica deployments and unit
@@ -54,7 +63,7 @@ impl DashboardConfig {
                 )
             })?;
         Ok(Self {
-            environment: environment_for_network(network_type).to_string(),
+            network_type,
             cursor_secret,
             ..Self::default()
         })
@@ -68,8 +77,12 @@ impl DashboardConfig {
         self.filesystem_aggregate_threshold
     }
 
-    pub(crate) fn environment(&self) -> &str {
-        &self.environment
+    pub(crate) fn environment(&self) -> &'static str {
+        environment_for_network(self.network_type)
+    }
+
+    pub(crate) fn network_type(&self) -> NetworkType {
+        self.network_type
     }
 
     pub(crate) fn take_cursor_secret(&mut self) -> Option<CursorSecret> {
@@ -99,7 +112,7 @@ impl Default for DashboardConfig {
                 per_min: DEFAULT_PUBKEY_RATE_PER_MIN,
             },
             filesystem_aggregate_threshold: DEFAULT_FILESYSTEM_AGGREGATE_THRESHOLD,
-            environment: DEFAULT_ENVIRONMENT.to_string(),
+            network_type: DEFAULT_NETWORK_TYPE,
             cursor_secret: None,
         }
     }

--- a/crates/server/src/dashboard/state.rs
+++ b/crates/server/src/dashboard/state.rs
@@ -414,6 +414,14 @@ impl DashboardState {
         self.config.environment()
     }
 
+    /// The Miden network this server is configured against
+    /// (`GUARDIAN_NETWORK_TYPE`). Network-dependent rendering such as
+    /// bech32 address HRPs must derive from this, not from per-account
+    /// metadata.
+    pub fn network_type(&self) -> NetworkType {
+        self.config.network_type()
+    }
+
     /// Wall-clock time the dashboard state (and effectively the process)
     /// was initialized. Surfaced on `GET /dashboard/info` to identify
     /// the running binary instance.

--- a/crates/server/src/services/dashboard_accounts.rs
+++ b/crates/server/src/services/dashboard_accounts.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::dashboard::cursor::{self, Cursor, CursorKind};
 use crate::error::{GuardianError, Result};
 use crate::metadata::{AccountListCursor, AccountMetadata, auth::Auth};
+use crate::network::NetworkType;
 use crate::services::dashboard_pagination::PagedResult;
 use crate::state::AppState;
 use crate::state_object::StateObject;
@@ -18,10 +19,11 @@ pub enum DashboardAccountStateStatus {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, utoipa::ToSchema)]
 pub struct DashboardAccountSummary {
     pub account_id: String,
-    /// Bech32m encoding of the Miden `AccountId` using the network's
-    /// HRP (e.g. `mtst...`, `mdev...`, `mm...`). `None` for EVM
-    /// accounts (no bech32 in that addressing scheme) and for any
-    /// Miden `account_id` that fails to parse as a 15-byte id.
+    /// Bech32m encoding of the Miden `AccountId` using the HRP of the
+    /// network this server is configured against (e.g. `mtst...`,
+    /// `mdev...`, `mm...`). `None` for EVM accounts (no bech32 in that
+    /// addressing scheme) and for any Miden `account_id` that fails to
+    /// parse as a 15-byte id.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub account_id_bech32: Option<String>,
     pub auth_scheme: String,
@@ -142,7 +144,12 @@ pub async fn list_dashboard_accounts_paged(
                 ),
                 None => (None, DashboardAccountStateStatus::Unavailable),
             };
-            DashboardAccountSummary::from_parts(metadata, current_commitment, state_status)
+            DashboardAccountSummary::from_parts(
+                metadata,
+                current_commitment,
+                state_status,
+                state.dashboard.network_type(),
+            )
         })
         .collect();
 
@@ -203,7 +210,11 @@ pub async fn get_dashboard_account(
         })?;
 
     Ok(GetDashboardAccountResult {
-        account: DashboardAccountDetail::from_parts(&metadata, &account_state),
+        account: DashboardAccountDetail::from_parts(
+            &metadata,
+            &account_state,
+            state.dashboard.network_type(),
+        ),
     })
 }
 
@@ -212,10 +223,11 @@ impl DashboardAccountSummary {
         metadata: &AccountMetadata,
         current_commitment: Option<String>,
         state_status: DashboardAccountStateStatus,
+        network_type: NetworkType,
     ) -> Self {
         Self {
             account_id: metadata.account_id.clone(),
-            account_id_bech32: bech32_for_account(metadata),
+            account_id_bech32: bech32_for_account(metadata, network_type),
             auth_scheme: metadata.auth.scheme().to_string(),
             authorized_signer_count: normalized_authorized_signer_ids(&metadata.auth).len(),
             has_pending_candidate: metadata.has_pending_candidate,
@@ -231,12 +243,16 @@ impl DashboardAccountSummary {
 }
 
 impl DashboardAccountDetail {
-    fn from_parts(metadata: &AccountMetadata, account_state: &StateObject) -> Self {
+    fn from_parts(
+        metadata: &AccountMetadata,
+        account_state: &StateObject,
+        network_type: NetworkType,
+    ) -> Self {
         let authorized_signer_ids = normalized_authorized_signer_ids(&metadata.auth);
 
         Self {
             account_id: metadata.account_id.clone(),
-            account_id_bech32: bech32_for_account(metadata),
+            account_id_bech32: bech32_for_account(metadata, network_type),
             auth_scheme: metadata.auth.scheme().to_string(),
             authorized_signer_count: authorized_signer_ids.len(),
             authorized_signer_ids,
@@ -254,21 +270,24 @@ impl DashboardAccountDetail {
     }
 }
 
-/// Encode a Miden account_id (hex) as bech32m using the network HRP
-/// from the account's persisted `NetworkConfig`. Returns `None` for
-/// EVM accounts and for any hex that fails to parse as a Miden
-/// `AccountId` (data drift). The HRP set is fixed by the Miden
+/// Encode a Miden account_id (hex) as bech32m using the HRP of the
+/// network this server runs against (`GUARDIAN_NETWORK_TYPE`). The
+/// per-account `NetworkConfig` is only consulted to skip EVM accounts;
+/// its Miden `network_type` is untrusted here because clients omit it
+/// at registration and the server used to stamp a hardcoded `local`
+/// default, mislabeling accounts on testnet/devnet servers. Returns
+/// `None` for EVM accounts and for any hex that fails to parse as a
+/// Miden `AccountId` (data drift). The HRP set is fixed by the Miden
 /// protocol: `mm` for mainnet, `mtst` for testnet, `mdev` for devnet
 /// (Local is folded into Devnet — Miden has no separate Local HRP).
-fn bech32_for_account(metadata: &AccountMetadata) -> Option<String> {
-    use crate::metadata::NetworkConfig;
+fn bech32_for_account(metadata: &AccountMetadata, network_type: NetworkType) -> Option<String> {
+    use crate::metadata::MidenNetworkType;
     use miden_protocol::account::AccountId;
-    let network_type = match &metadata.network_config {
-        NetworkConfig::Miden { network_type } => *network_type,
-        NetworkConfig::Evm { .. } => return None,
-    };
+    if metadata.network_config.is_evm() {
+        return None;
+    }
     let account_id = AccountId::from_hex(&metadata.account_id).ok()?;
-    Some(account_id.to_bech32(network_type.to_miden_network_id()))
+    Some(account_id.to_bech32(MidenNetworkType::from(network_type).to_miden_network_id()))
 }
 
 fn normalized_authorized_signer_ids(auth: &Auth) -> Vec<String> {
@@ -320,24 +339,39 @@ mod tests {
     }
 
     #[test]
-    fn bech32_for_miden_account_encodes_with_network_hrp() {
-        let mut meta = miden_meta("0x7b7b7b7a7b7b7b017b7b7b7b7b7b7b", "2026-05-26T00:00:00Z");
-        meta.network_config = NetworkConfig::Miden {
-            network_type: MidenNetworkType::Testnet,
-        };
-        let bech32 = bech32_for_account(&meta).expect("bech32 encodes for valid miden id");
+    fn bech32_for_miden_account_encodes_with_server_network_hrp() {
+        let meta = miden_meta("0x7b7b7b7a7b7b7b017b7b7b7b7b7b7b", "2026-05-26T00:00:00Z");
+        let bech32 = bech32_for_account(&meta, NetworkType::MidenTestnet)
+            .expect("bech32 encodes for valid miden id");
         assert!(
             bech32.starts_with("mtst1"),
             "testnet HRP expected, got '{bech32}'",
         );
 
-        meta.network_config = NetworkConfig::Miden {
-            network_type: MidenNetworkType::Local,
-        };
-        let bech32_local = bech32_for_account(&meta).expect("local maps to devnet HRP");
+        let bech32_local = bech32_for_account(&meta, NetworkType::MidenLocal)
+            .expect("local maps to devnet HRP");
         assert!(
             bech32_local.starts_with("mdev1"),
             "local folds into devnet HRP, got '{bech32_local}'",
+        );
+    }
+
+    /// Regression: clients omit `network_config` at registration and the
+    /// server used to stamp a hardcoded `local` default into metadata, so
+    /// a testnet server rendered `mdev...` addresses. The HRP must come
+    /// from the server's configured network, never from the persisted
+    /// per-account value.
+    #[test]
+    fn bech32_ignores_stale_local_network_config_in_metadata() {
+        let mut meta = miden_meta("0x7b7b7b7a7b7b7b017b7b7b7b7b7b7b", "2026-05-26T00:00:00Z");
+        meta.network_config = NetworkConfig::Miden {
+            network_type: MidenNetworkType::Local,
+        };
+        let bech32 = bech32_for_account(&meta, NetworkType::MidenTestnet)
+            .expect("bech32 encodes for valid miden id");
+        assert!(
+            bech32.starts_with("mtst1"),
+            "server network HRP expected despite 'local' metadata, got '{bech32}'",
         );
     }
 
@@ -361,13 +395,13 @@ mod tests {
             paused_reason: None,
             released_at: None,
         };
-        assert!(bech32_for_account(&meta).is_none());
+        assert!(bech32_for_account(&meta, NetworkType::MidenTestnet).is_none());
     }
 
     #[test]
     fn bech32_for_unparseable_miden_account_returns_none() {
         let meta = miden_meta("not-hex", "2026-05-26T00:00:00Z");
-        assert!(bech32_for_account(&meta).is_none());
+        assert!(bech32_for_account(&meta, NetworkType::MidenTestnet).is_none());
     }
 
     /// Bug #6 regression: walk multi-page cursor traversal end-to-end

--- a/crates/server/src/services/dashboard_accounts.rs
+++ b/crates/server/src/services/dashboard_accounts.rs
@@ -348,8 +348,8 @@ mod tests {
             "testnet HRP expected, got '{bech32}'",
         );
 
-        let bech32_local = bech32_for_account(&meta, NetworkType::MidenLocal)
-            .expect("local maps to devnet HRP");
+        let bech32_local =
+            bech32_for_account(&meta, NetworkType::MidenLocal).expect("local maps to devnet HRP");
         assert!(
             bech32_local.starts_with("mdev1"),
             "local folds into devnet HRP, got '{bech32_local}'",

--- a/docs/openapi-dashboard.json
+++ b/docs/openapi-dashboard.json
@@ -1612,7 +1612,7 @@
               "string",
               "null"
             ],
-            "description": "Bech32m encoding of the Miden `AccountId` using the network's\nHRP (e.g. `mtst...`, `mdev...`, `mm...`). `None` for EVM\naccounts (no bech32 in that addressing scheme) and for any\nMiden `account_id` that fails to parse as a 15-byte id."
+            "description": "Bech32m encoding of the Miden `AccountId` using the HRP of the\nnetwork this server is configured against (e.g. `mtst...`,\n`mdev...`, `mm...`). `None` for EVM accounts (no bech32 in that\naddressing scheme) and for any Miden `account_id` that fails to\nparse as a 15-byte id."
           },
           "auth_scheme": {
             "type": "string"
@@ -2502,7 +2502,7 @@
                     "string",
                     "null"
                   ],
-                  "description": "Bech32m encoding of the Miden `AccountId` using the network's\nHRP (e.g. `mtst...`, `mdev...`, `mm...`). `None` for EVM\naccounts (no bech32 in that addressing scheme) and for any\nMiden `account_id` that fails to parse as a 15-byte id."
+                  "description": "Bech32m encoding of the Miden `AccountId` using the HRP of the\nnetwork this server is configured against (e.g. `mtst...`,\n`mdev...`, `mm...`). `None` for EVM accounts (no bech32 in that\naddressing scheme) and for any Miden `account_id` that fails to\nparse as a 15-byte id."
                 },
                 "auth_scheme": {
                   "type": "string"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3574,7 +3574,7 @@
               "string",
               "null"
             ],
-            "description": "Bech32m encoding of the Miden `AccountId` using the network's\nHRP (e.g. `mtst...`, `mdev...`, `mm...`). `None` for EVM\naccounts (no bech32 in that addressing scheme) and for any\nMiden `account_id` that fails to parse as a 15-byte id."
+            "description": "Bech32m encoding of the Miden `AccountId` using the HRP of the\nnetwork this server is configured against (e.g. `mtst...`,\n`mdev...`, `mm...`). `None` for EVM accounts (no bech32 in that\naddressing scheme) and for any Miden `account_id` that fails to\nparse as a 15-byte id."
           },
           "auth_scheme": {
             "type": "string"
@@ -4940,7 +4940,7 @@
                     "string",
                     "null"
                   ],
-                  "description": "Bech32m encoding of the Miden `AccountId` using the network's\nHRP (e.g. `mtst...`, `mdev...`, `mm...`). `None` for EVM\naccounts (no bech32 in that addressing scheme) and for any\nMiden `account_id` that fails to parse as a 15-byte id."
+                  "description": "Bech32m encoding of the Miden `AccountId` using the HRP of the\nnetwork this server is configured against (e.g. `mtst...`,\n`mdev...`, `mm...`). `None` for EVM accounts (no bech32 in that\naddressing scheme) and for any Miden `account_id` that fails to\nparse as a 15-byte id."
                 },
                 "auth_scheme": {
                   "type": "string"


### PR DESCRIPTION
This PR fixes the logic for calculating Bech32 addresses by using the correct network configuration defined at server startup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Dashboard account IDs now use the Bech32m network format configured for the server, ensuring consistent display even when account metadata contains outdated network information.
  - Local server configurations correctly use the appropriate development network format.
  - EVM accounts and invalid Miden account IDs continue to display without Bech32m values.

- **Documentation**
  - Updated API documentation to clarify how the `account_id_bech32` format is determined and when it may be unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->