### PR TITLE
feat: Remove silent devnet network defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,14 +81,19 @@ For env-driven benchmark network/canonicalization settings, apply the runtime co
 #### Running with Cargo
 
 ```bash
-cargo run --bin server
+GUARDIAN_NETWORK_TYPE=MidenTestnet cargo run --bin server
 ```
+
+`GUARDIAN_NETWORK_TYPE` (`MidenLocal`, `MidenTestnet`, or `MidenDevnet`) is
+required — the server refuses to start without it. A root `.env` file works
+too; see [`docs/LOCAL_DEV.md`](docs/LOCAL_DEV.md#environment-file).
 
 EVM proposal support is feature-gated. Default builds do not register EVM
 routes. EVM-enabled servers use the domain-separated `/evm/auth/*`,
 `/evm/accounts`, and `/evm/proposals*` routes.
 
 ```bash
+GUARDIAN_NETWORK_TYPE=MidenTestnet \
 GUARDIAN_EVM_RPC_URLS=31337=http://127.0.0.1:8545 \
 GUARDIAN_EVM_ENTRYPOINT_ADDRESS=0x... \
 cargo run -p guardian-server --features evm --bin server
@@ -96,8 +101,10 @@ cargo run -p guardian-server --features evm --bin server
 
 #### Running with Docker Compose
 
-The default compose file sets the container paths it needs, so a root `.env`
-is not required for this path. Start the server:
+The default compose file sets the container paths it needs and pins
+`GUARDIAN_NETWORK_TYPE` to `MidenTestnet` (override via `.env` or the shell
+environment), so a root `.env` is not required for this path. Start the
+server:
 
 ```bash
 docker compose up --build -d

--- a/README.md
+++ b/README.md
@@ -101,12 +101,13 @@ cargo run -p guardian-server --features evm --bin server
 
 #### Running with Docker Compose
 
-The default compose file sets the container paths it needs and pins
-`GUARDIAN_NETWORK_TYPE` to `MidenTestnet` (override via `.env` or the shell
-environment), so a root `.env` is not required for this path. Start the
-server:
+The default compose file sets the container paths it needs, but you must
+choose a network explicitly: `GUARDIAN_NETWORK_TYPE` has no default and the
+server refuses to start without it. Set it in a root `.env` or export it in
+your shell before starting:
 
 ```bash
+echo "GUARDIAN_NETWORK_TYPE=MidenTestnet" > .env
 docker compose up --build -d
 ```
 

--- a/crates/server/README.md
+++ b/crates/server/README.md
@@ -69,6 +69,7 @@ The JSON payload is a plain array of serialized Falcon public key hex strings:
 Local example:
 
 ```bash
+GUARDIAN_NETWORK_TYPE=MidenLocal \
 GUARDIAN_OPERATOR_PUBLIC_KEYS_FILE=/tmp/guardian-operator-public-keys.json \
 cargo run -p guardian-server --bin server
 ```
@@ -76,6 +77,7 @@ cargo run -p guardian-server --bin server
 Deployed example:
 
 ```bash
+GUARDIAN_NETWORK_TYPE=MidenTestnet \
 GUARDIAN_OPERATOR_PUBLIC_KEYS_SECRET_ID=arn:aws:secretsmanager:us-east-1:123456789012:secret:guardian/operators \
 cargo run -p guardian-server --bin server
 ```
@@ -98,6 +100,7 @@ with the `evm` feature for local EVM proposal coordination through
 `/evm/auth/*`, `/evm/accounts`, and `/evm/proposals*`:
 
 ```bash
+GUARDIAN_NETWORK_TYPE=MidenTestnet \
 GUARDIAN_EVM_RPC_URLS=31337=http://127.0.0.1:8545 \
 GUARDIAN_EVM_ENTRYPOINT_ADDRESS=0x433709009b8330fda32311df1c2afa402ed8d009 \
 cargo run -p guardian-server --features evm --bin server

--- a/crates/server/bench/README.md
+++ b/crates/server/bench/README.md
@@ -126,7 +126,10 @@ If you want benchmark scripts to drive network/canonicalization through environm
 to:
 
 ```rust
-.network(NetworkType::from_env("GUARDIAN_NETWORK_TYPE"))
+.network(
+    NetworkType::from_env("GUARDIAN_NETWORK_TYPE")
+        .unwrap_or_else(|error| panic!("Failed to resolve network type: {error}")),
+)
 .with_canonicalization({
     let canonicalization_enabled = std::env::var("GUARDIAN_CANONICALIZATION_ENABLED")
         .ok()

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -31,7 +31,8 @@ async fn main() {
         .expect("Failed to initialize CORS config")
         .layer();
 
-    let network_type = NetworkType::from_env_or("GUARDIAN_NETWORK_TYPE", NetworkType::MidenDevnet);
+    let network_type =
+        NetworkType::from_env("GUARDIAN_NETWORK_TYPE").expect("Failed to resolve network type");
 
     ServerBuilder::new()
         .with_logging(LoggingConfig::default())

--- a/crates/server/src/network/mod.rs
+++ b/crates/server/src/network/mod.rs
@@ -116,15 +116,21 @@ pub enum NetworkType {
 }
 
 impl NetworkType {
-    pub fn from_env(var_name: &str) -> Self {
-        let value = std::env::var(var_name).unwrap_or_else(|_| "MidenDevnet".to_string());
-        Self::from_name(&value).unwrap_or(Self::MidenDevnet)
-    }
+    const ACCEPTED_VALUES: &str =
+        "MidenLocal (local), MidenTestnet (testnet), MidenDevnet (devnet); case-insensitive";
 
-    pub fn from_env_or(var_name: &str, default: Self) -> Self {
+    pub fn from_env(var_name: &str) -> Result<Self, String> {
         match std::env::var(var_name) {
-            Ok(value) => Self::from_name(&value).unwrap_or(default),
-            Err(_) => default,
+            Ok(value) => Self::from_name(&value).ok_or_else(|| {
+                format!(
+                    "{var_name} has unrecognized value \"{value}\"; accepted values: {}",
+                    Self::ACCEPTED_VALUES
+                )
+            }),
+            Err(_) => Err(format!(
+                "{var_name} is not set; accepted values: {}",
+                Self::ACCEPTED_VALUES
+            )),
         }
     }
 
@@ -161,34 +167,49 @@ mod tests {
     use super::NetworkType;
 
     #[test]
-    fn from_env_or_returns_default_when_var_missing() {
+    fn from_env_errors_when_var_missing() {
         let var_name = "GUARDIAN_NETWORK_TYPE_TEST_MISSING";
         unsafe { std::env::remove_var(var_name) };
 
-        let network = NetworkType::from_env_or(var_name, NetworkType::MidenTestnet);
+        let error = NetworkType::from_env(var_name).unwrap_err();
 
-        assert_eq!(network, NetworkType::MidenTestnet);
+        assert!(error.contains(var_name));
+        assert!(error.contains("MidenLocal"));
+        assert!(error.contains("MidenTestnet"));
+        assert!(error.contains("MidenDevnet"));
     }
 
     #[test]
-    fn from_env_or_returns_parsed_value_when_var_present() {
-        let var_name = "GUARDIAN_NETWORK_TYPE_TEST_PRESENT";
-        unsafe { std::env::set_var(var_name, "devnet") };
+    fn from_env_errors_when_value_unrecognized() {
+        let var_name = "GUARDIAN_NETWORK_TYPE_TEST_INVALID";
+        unsafe { std::env::set_var(var_name, "tesnet") };
 
-        let network = NetworkType::from_env_or(var_name, NetworkType::MidenTestnet);
+        let error = NetworkType::from_env(var_name).unwrap_err();
 
-        assert_eq!(network, NetworkType::MidenDevnet);
+        assert!(error.contains(var_name));
+        assert!(error.contains("tesnet"));
+        assert!(error.contains("MidenTestnet"));
         unsafe { std::env::remove_var(var_name) };
     }
 
     #[test]
-    fn from_env_or_falls_back_to_default_when_value_invalid() {
-        let var_name = "GUARDIAN_NETWORK_TYPE_TEST_INVALID";
-        unsafe { std::env::set_var(var_name, "not-a-network") };
+    fn from_env_parses_every_accepted_spelling() {
+        let cases = [
+            ("MidenLocal", NetworkType::MidenLocal),
+            ("local", NetworkType::MidenLocal),
+            ("LOCAL", NetworkType::MidenLocal),
+            ("MidenTestnet", NetworkType::MidenTestnet),
+            ("testnet", NetworkType::MidenTestnet),
+            ("MidenDevnet", NetworkType::MidenDevnet),
+            ("devnet", NetworkType::MidenDevnet),
+            ("DEVNET", NetworkType::MidenDevnet),
+        ];
 
-        let network = NetworkType::from_env_or(var_name, NetworkType::MidenTestnet);
-
-        assert_eq!(network, NetworkType::MidenTestnet);
+        let var_name = "GUARDIAN_NETWORK_TYPE_TEST_PRESENT";
+        for (value, expected) in cases {
+            unsafe { std::env::set_var(var_name, value) };
+            assert_eq!(NetworkType::from_env(var_name).unwrap(), expected);
+        }
         unsafe { std::env::remove_var(var_name) };
     }
 }

--- a/crates/server/src/network/mod.rs
+++ b/crates/server/src/network/mod.rs
@@ -127,8 +127,12 @@ impl NetworkType {
                     Self::ACCEPTED_VALUES
                 )
             }),
-            Err(_) => Err(format!(
+            Err(std::env::VarError::NotPresent) => Err(format!(
                 "{var_name} is not set; accepted values: {}",
+                Self::ACCEPTED_VALUES
+            )),
+            Err(std::env::VarError::NotUnicode(_)) => Err(format!(
+                "{var_name} contains non-Unicode data; accepted values: {}",
                 Self::ACCEPTED_VALUES
             )),
         }
@@ -164,10 +168,13 @@ impl std::fmt::Display for NetworkType {
 
 #[cfg(test)]
 mod tests {
+    use crate::testing::env_lock::ENV_LOCK;
+
     use super::NetworkType;
 
     #[test]
     fn from_env_errors_when_var_missing() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|poison| poison.into_inner());
         let var_name = "GUARDIAN_NETWORK_TYPE_TEST_MISSING";
         unsafe { std::env::remove_var(var_name) };
 
@@ -181,6 +188,7 @@ mod tests {
 
     #[test]
     fn from_env_errors_when_value_unrecognized() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|poison| poison.into_inner());
         let var_name = "GUARDIAN_NETWORK_TYPE_TEST_INVALID";
         unsafe { std::env::set_var(var_name, "tesnet") };
 
@@ -192,8 +200,25 @@ mod tests {
         unsafe { std::env::remove_var(var_name) };
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn from_env_errors_when_value_is_not_unicode() {
+        use std::{ffi::OsString, os::unix::ffi::OsStringExt};
+
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|poison| poison.into_inner());
+        let var_name = "GUARDIAN_NETWORK_TYPE_TEST_NOT_UNICODE";
+        unsafe { std::env::set_var(var_name, OsString::from_vec(vec![0xff])) };
+
+        let error = NetworkType::from_env(var_name).unwrap_err();
+
+        assert!(error.contains(var_name));
+        assert!(error.contains("non-Unicode"));
+        unsafe { std::env::remove_var(var_name) };
+    }
+
     #[test]
     fn from_env_parses_every_accepted_spelling() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|poison| poison.into_inner());
         let cases = [
             ("MidenLocal", NetworkType::MidenLocal),
             ("local", NetworkType::MidenLocal),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - GUARDIAN_STORAGE_PATH=/var/guardian/storage
       - GUARDIAN_METADATA_PATH=/var/guardian/metadata
       - GUARDIAN_KEYSTORE_PATH=/var/guardian/keystore
+      - GUARDIAN_NETWORK_TYPE=${GUARDIAN_NETWORK_TYPE:-MidenTestnet}
 
 volumes:
   guardian-storage:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - GUARDIAN_STORAGE_PATH=/var/guardian/storage
       - GUARDIAN_METADATA_PATH=/var/guardian/metadata
       - GUARDIAN_KEYSTORE_PATH=/var/guardian/keystore
-      - GUARDIAN_NETWORK_TYPE=${GUARDIAN_NETWORK_TYPE:-MidenTestnet}
+      - GUARDIAN_NETWORK_TYPE
 
 volumes:
   guardian-storage:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -82,7 +82,7 @@ DATABASE_URL=postgres://guardian:guardian@localhost:5432/guardian
 |---|---|---|
 | `GUARDIAN_ENV` | _unset_ | Selects the **default** ACK secret source: `prod` → AWS Secrets Manager; anything else (or unset) → ephemeral filesystem keys, regenerated each restart. Override explicitly with `GUARDIAN_ACK_SECRET_PROVIDER` (below) — e.g. `file` for a stable identity without AWS. |
 | `AWS_REGION` | _unset_ | **Required** when `GUARDIAN_ENV=prod`. Region for Secrets Manager calls. |
-| `GUARDIAN_NETWORK_TYPE` | `MidenDevnet` | Miden network identifier (`MidenDevnet`, `MidenTestnet`, etc.). Required only when you need a non-default network. Pins which Miden RPC and on-chain consensus the server speaks to. |
+| `GUARDIAN_NETWORK_TYPE` | _none — **required**_ | Miden network identifier: `MidenLocal` (`local`), `MidenTestnet` (`testnet`), `MidenDevnet` (`devnet`); case-insensitive. Pins which Miden RPC and on-chain consensus the server speaks to. The server refuses to start when it is unset or unrecognized — there is no fallback network. |
 
 ACK secret IDs are configurable. The server reads two env vars at startup
 and falls back to fixed defaults when they're unset

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -269,6 +269,7 @@ cat > /tmp/operators.json <<'EOF'
    "permissions": ["dashboard:read", "accounts:pause"] }]
 EOF
 
+GUARDIAN_NETWORK_TYPE=MidenLocal \
 GUARDIAN_OPERATOR_PUBLIC_KEYS_FILE=/tmp/operators.json \
 GUARDIAN_STORAGE_PATH=.guardian/storage \
 GUARDIAN_METADATA_PATH=.guardian/metadata \

--- a/docs/LOCAL_DEV.md
+++ b/docs/LOCAL_DEV.md
@@ -33,10 +33,11 @@ Three decisions when running Guardian locally:
 ## Environment file
 
 The server calls `dotenvy::dotenv()` on startup, so `cargo run --bin server`
-automatically reads a root `.env` file when one exists. A `.env` file is not
-strictly required for the default filesystem server, but it is recommended for
-local `cargo run` because the built-in filesystem defaults live under
-`/var/guardian`, which may not exist or be writable on a developer machine.
+automatically reads a root `.env` file when one exists. In practice a `.env`
+file (or exported variables) is required: `GUARDIAN_NETWORK_TYPE` has no
+default and the server refuses to start without it, and the built-in
+filesystem paths live under `/var/guardian`, which may not exist or be
+writable on a developer machine.
 
 Minimal local `.env`:
 
@@ -74,7 +75,7 @@ Useful env:
 | `GUARDIAN_METADATA_PATH` | Local path for accounts, auth, network. Defaults to `/var/guardian/metadata`. |
 | `GUARDIAN_KEYSTORE_PATH` | ACK key files, auto-generated on first run. Defaults to `/var/guardian/keystore`. |
 | `RUST_LOG` (`info`) | `info`, `debug`, or e.g. `server::jobs::canonicalization=debug`. |
-| `GUARDIAN_NETWORK_TYPE` (`MidenDevnet`) | Miden network name. |
+| `GUARDIAN_NETWORK_TYPE` (**required**) | Miden network name: `MidenLocal`, `MidenTestnet`, or `MidenDevnet`. The server refuses to start when it is unset or unrecognized. |
 
 At startup the server emits a warning that audit events will **not** be
 persisted — that's expected for filesystem mode

--- a/docs/MULTISIG_SDK.md
+++ b/docs/MULTISIG_SDK.md
@@ -55,6 +55,8 @@ const client = new MultisigClient(midenClient, {
   guardianEndpoint: 'http://localhost:3000',
   midenRpcEndpoint: 'https://rpc.devnet.miden.io',
 });
+// Both endpoints are required; construction throws when either is omitted.
+// midenRpcEndpoint must point at the same network as the injected MidenClient.
 
 // 2. Get GUARDIAN server public key
 const guardianCommitment = await client.guardianClient.getPubkey();

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -9,9 +9,11 @@ read [`docs/CONCEPTS.md`](./CONCEPTS.md). For production readiness, start
 with [`docs/PRODUCTION.md`](./PRODUCTION.md).
 
 No `.env` file is required for this Docker Compose quickstart. The compose
-file sets the container paths it needs. If you run the server directly with
-`cargo run`, set up a local `.env` first; see
-[`LOCAL_DEV.md`](./LOCAL_DEV.md#environment-file).
+file sets the container paths it needs and pins `GUARDIAN_NETWORK_TYPE` to
+`MidenTestnet` (override it via `.env` or the shell environment). If you run
+the server directly with `cargo run`, set up a local `.env` first —
+`GUARDIAN_NETWORK_TYPE` is required and the server refuses to start without
+it; see [`LOCAL_DEV.md`](./LOCAL_DEV.md#environment-file).
 
 ## Run
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -8,16 +8,18 @@ read [`docs/LOCAL_DEV.md`](./LOCAL_DEV.md). For the *why* before the *how*,
 read [`docs/CONCEPTS.md`](./CONCEPTS.md). For production readiness, start
 with [`docs/PRODUCTION.md`](./PRODUCTION.md).
 
-No `.env` file is required for this Docker Compose quickstart. The compose
-file sets the container paths it needs and pins `GUARDIAN_NETWORK_TYPE` to
-`MidenTestnet` (override it via `.env` or the shell environment). If you run
-the server directly with `cargo run`, set up a local `.env` first —
-`GUARDIAN_NETWORK_TYPE` is required and the server refuses to start without
-it; see [`LOCAL_DEV.md`](./LOCAL_DEV.md#environment-file).
+The compose file sets the container paths it needs, but you must choose a
+network explicitly — `GUARDIAN_NETWORK_TYPE` has no default and the server
+refuses to start without it (there is no fallback network). Set it in a
+local `.env` file or export it in your shell; accepted values are
+`MidenLocal`, `MidenTestnet`, and `MidenDevnet`. The same requirement
+applies when you run the server directly with `cargo run`; see
+[`LOCAL_DEV.md`](./LOCAL_DEV.md#environment-file).
 
 ## Run
 
 ```bash
+echo "GUARDIAN_NETWORK_TYPE=MidenTestnet" > .env
 docker compose up --build -d
 ```
 

--- a/docs/SERVER_AWS_DEPLOY.md
+++ b/docs/SERVER_AWS_DEPLOY.md
@@ -88,7 +88,8 @@ set -a && source .env && set +a
 # Optional: build/deploy ARM64 instead of X86_64
 # export CPU_ARCHITECTURE=ARM64
 
-# Optional: pin the server to a specific Miden network
+# Miden network the server runs against. The server requires this at startup;
+# the deploy script passes MidenTestnet unless you override it here.
 export GUARDIAN_NETWORK_TYPE=MidenDevnet
 
 # Optional: allow dashboard operators and let Terraform create the secret

--- a/docs/SERVER_AWS_DEPLOY.md
+++ b/docs/SERVER_AWS_DEPLOY.md
@@ -90,7 +90,7 @@ set -a && source .env && set +a
 
 # Miden network the server runs against. The server requires this at startup;
 # the deploy script passes MidenTestnet unless you override it here.
-export GUARDIAN_NETWORK_TYPE=MidenDevnet
+export GUARDIAN_NETWORK_TYPE=MidenTestnet
 
 # Optional: allow dashboard operators and let Terraform create the secret
 # export GUARDIAN_OPERATOR_PUBLIC_KEYS_JSON='["0x<alice-falcon-public-key>","0x<bob-falcon-public-key>"]'

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -13,11 +13,12 @@ For local-dev setup see [`docs/LOCAL_DEV.md`](./LOCAL_DEV.md).
 
 Most startup failures are environment misconfiguration. Check in order:
 
-1. **`GUARDIAN_NETWORK_TYPE` unset or unrecognized.** The server exits
+1. **`GUARDIAN_NETWORK_TYPE` unset, non-Unicode, or unrecognized.** The server exits
    before binding any port with
    `Failed to resolve network type: GUARDIAN_NETWORK_TYPE is not set; accepted values: ...`
-   (or `has unrecognized value "..."` for typos like `tesnet`). There is
-   no fallback network. Set it to `MidenLocal`, `MidenTestnet`, or
+   (or `contains non-Unicode data` / `has unrecognized value "..."` for
+   malformed values and typos like `tesnet`). There is no fallback network.
+   Replace the variable with `MidenLocal`, `MidenTestnet`, or
    `MidenDevnet` (short forms `local`/`testnet`/`devnet` work,
    case-insensitive).
 2. **`DATABASE_URL` missing under `--features postgres`.** The builder

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -13,10 +13,17 @@ For local-dev setup see [`docs/LOCAL_DEV.md`](./LOCAL_DEV.md).
 
 Most startup failures are environment misconfiguration. Check in order:
 
-1. **`DATABASE_URL` missing under `--features postgres`.** The builder
+1. **`GUARDIAN_NETWORK_TYPE` unset or unrecognized.** The server exits
+   before binding any port with
+   `Failed to resolve network type: GUARDIAN_NETWORK_TYPE is not set; accepted values: ...`
+   (or `has unrecognized value "..."` for typos like `tesnet`). There is
+   no fallback network. Set it to `MidenLocal`, `MidenTestnet`, or
+   `MidenDevnet` (short forms `local`/`testnet`/`devnet` work,
+   case-insensitive).
+2. **`DATABASE_URL` missing under `--features postgres`.** The builder
    panics with `"DATABASE_URL environment variable is required"`. Either
    set it or rebuild without the `postgres` feature.
-2. **Filesystem paths not writable.** Filesystem builds use
+3. **Filesystem paths not writable.** Filesystem builds use
    `GUARDIAN_STORAGE_PATH`, `GUARDIAN_METADATA_PATH`, and
    `GUARDIAN_KEYSTORE_PATH` when set, defaulting to
    `/var/guardian/storage`, `/var/guardian/metadata`, and
@@ -26,18 +33,18 @@ Most startup failures are environment misconfiguration. Check in order:
    Either set the env vars to a writable location or `mkdir -p`
    `/var/guardian/{storage,metadata,keystore}` with the right
    permissions.
-3. **Postgres migrations fail.** The Postgres path runs migrations at
+4. **Postgres migrations fail.** The Postgres path runs migrations at
    startup. If the DB user lacks `CREATE` permissions, startup fails.
    Grant `CREATE` on the schema or run migrations as a privileged user.
-4. **ACK secrets missing in prod.**
+5. **ACK secrets missing in prod.**
    `scripts/aws-deploy.sh deploy` refuses to apply if either ACK secret
    is missing. Run `DEPLOY_STAGE=prod ./scripts/aws-deploy.sh bootstrap-ack-keys`
    first (see [Secrets runbook](./runbooks/secrets.md#bootstrap-first-prod-deploy)).
-5. **Operator allowlist source not set.** If you intend to use the
+6. **Operator allowlist source not set.** If you intend to use the
    dashboard, set `GUARDIAN_OPERATOR_PUBLIC_KEYS_SECRET_ID` (prod) or
    `GUARDIAN_OPERATOR_PUBLIC_KEYS_FILE` (local). Without either, the
    dashboard is unreachable.
-6. **Database TLS misconfigured.** With a verifying `sslmode`, startup fails
+7. **Database TLS misconfigured.** With a verifying `sslmode`, startup fails
    closed before migrations run. Map the error:
    - error naming `sslmode` (`allow`/`prefer` or an unknown value) → choose an
      explicit mode: `disable`, `require`, `verify-ca`, or `verify-full`.

--- a/docs/guides/aws-signers/.env.example
+++ b/docs/guides/aws-signers/.env.example
@@ -36,8 +36,8 @@ GUARDIAN_ACK_ECDSA_KMS_KEY_ID=alias/guardian-ack-ecdsa
 
 # --- Optional server runtime config (uncomment as needed) ---
 
-# Miden network the server targets (server default: MidenDevnet).
-# GUARDIAN_NETWORK_TYPE=MidenTestnet
+# Miden network the server targets (required; the server refuses to start without it).
+GUARDIAN_NETWORK_TYPE=MidenTestnet
 
 # Comma-separated origins allowed by credentialed CORS.
 # GUARDIAN_CORS_ALLOWED_ORIGINS=https://accounts.openzeppelin.com

--- a/docs/guides/horizontal-scaling/docker-compose.yml
+++ b/docs/guides/horizontal-scaling/docker-compose.yml
@@ -30,7 +30,7 @@ x-guardian-server: &guardian-server
       condition: service_healthy
   environment:
     RUST_LOG: info
-    GUARDIAN_NETWORK_TYPE: ${GUARDIAN_NETWORK_TYPE:-MidenDevnet}
+    GUARDIAN_NETWORK_TYPE: ${GUARDIAN_NETWORK_TYPE:?set GUARDIAN_NETWORK_TYPE in .env}
     DATABASE_URL: postgres://guardian:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}@postgres:5432/guardian
     GUARDIAN_KEYSTORE_PATH: /var/guardian/keystore
     GUARDIAN_OPERATOR_PUBLIC_KEYS_FILE: /etc/guardian/operators.json

--- a/docs/guides/miden-dashboard/docker-compose.yml
+++ b/docs/guides/miden-dashboard/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - ./operators.json:/etc/guardian/operators.json:ro
     environment:
       - RUST_LOG=info
-      - GUARDIAN_NETWORK_TYPE=${GUARDIAN_NETWORK_TYPE:-MidenTestnet}
+      - GUARDIAN_NETWORK_TYPE=${GUARDIAN_NETWORK_TYPE:?set GUARDIAN_NETWORK_TYPE in .env}
       - DATABASE_URL=postgres://guardian:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}@postgres:5432/guardian
       - GUARDIAN_KEYSTORE_PATH=/var/guardian/keystore
       - GUARDIAN_OPERATOR_PUBLIC_KEYS_FILE=/etc/guardian/operators.json

--- a/docs/guides/observability/.env.example
+++ b/docs/guides/observability/.env.example
@@ -8,9 +8,9 @@
 # Walkthrough: ./README.md
 # Full server config reference: ../../CONFIGURATION.md
 
-# Miden network the server targets (server default: MidenDevnet). The server
+# Miden network the server targets (required; the server refuses to start without it). The server
 # connects to this network's RPC at startup, so it needs outbound internet.
-# GUARDIAN_NETWORK_TYPE=MidenTestnet
+GUARDIAN_NETWORK_TYPE=MidenTestnet
 
 # Server log level.
 # RUST_LOG=info

--- a/docs/guides/postgres-tls/.env.example
+++ b/docs/guides/postgres-tls/.env.example
@@ -28,5 +28,5 @@ POSTGRES_PASSWORD=change-me
 # GUARDIAN_IMAGE=guardian:dbtls-local
 # GUARDIAN_PULL_POLICY=missing
 
-# Optional: Miden network the server targets (server default: MidenDevnet).
-# GUARDIAN_NETWORK_TYPE=MidenTestnet
+# Miden network the server targets (required; the server refuses to start without it).
+GUARDIAN_NETWORK_TYPE=MidenTestnet

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,4 +7,7 @@ Small projects that showcase different ways to interact with Guardian:
 - [`rust/`](./rust/) – Low-level Rust example with binaries for both local-node and mockchain flows.
 - [`smoke-web/`](./smoke-web/) – Browser smoke harness for multisig workflows and wallet integrations.
 
-All examples expect a running GUARDIAN server (`cargo run -p guardian-server --bin server`). Some also require a Miden node on `http://localhost:57291`. See each subdirectory README for specific instructions.
+All examples expect a running GUARDIAN server
+(`GUARDIAN_NETWORK_TYPE=MidenLocal cargo run -p guardian-server --bin server`).
+Some also require a Miden node on `http://localhost:57291`. See each
+subdirectory README for specific instructions.

--- a/examples/operator-smoke-web/README.md
+++ b/examples/operator-smoke-web/README.md
@@ -26,6 +26,7 @@ Create a local operator public keys file and start Guardian with that path:
 mkdir -p /tmp/guardian-operator-smoke
 printf '[]\n' > /tmp/guardian-operator-smoke/operator-public-keys.json
 
+GUARDIAN_NETWORK_TYPE=MidenLocal \
 GUARDIAN_OPERATOR_PUBLIC_KEYS_FILE=/tmp/guardian-operator-smoke/operator-public-keys.json \
 cargo run -p guardian-server --bin server
 ```

--- a/packages/miden-multisig-client/README.md
+++ b/packages/miden-multisig-client/README.md
@@ -32,7 +32,9 @@ const midenClient = await MidenClient.createDevnet();
 const secretKey = AuthSecretKey.rpoFalconWithRNG(undefined);
 const signer = new FalconSigner(secretKey);
 
-// Create MultisigClient
+// Create MultisigClient. Both endpoints are required; construction throws
+// when either is omitted. midenRpcEndpoint must point at the same network as
+// the injected MidenClient.
 const client = new MultisigClient(midenClient, {
   guardianEndpoint: 'http://localhost:3000',
   midenRpcEndpoint: 'https://rpc.devnet.miden.io',

--- a/packages/miden-multisig-client/src/account/builder.test.ts
+++ b/packages/miden-multisig-client/src/account/builder.test.ts
@@ -105,11 +105,15 @@ describe('createMultisigAccount', () => {
       },
     };
 
-    await createMultisigAccount(webClient as never, {
-      threshold: 1,
-      signerCommitments: ['0x' + '1'.repeat(64)],
-      guardianCommitment: '0x' + '2'.repeat(64),
-    });
+    await createMultisigAccount(
+      webClient as never,
+      {
+        threshold: 1,
+        signerCommitments: ['0x' + '1'.repeat(64)],
+        guardianCommitment: '0x' + '2'.repeat(64),
+      },
+      'http://localhost:57291',
+    );
 
     expect(authBuilder.linkModule).toHaveBeenNthCalledWith(
       1,
@@ -139,12 +143,16 @@ describe('createMultisigAccount', () => {
       },
     };
 
-    await createMultisigAccount(webClient as never, {
-      threshold: 1,
-      signerCommitments: ['0x' + '1'.repeat(64)],
-      guardianCommitment: '0x' + '2'.repeat(64),
-      signatureScheme: 'ecdsa',
-    });
+    await createMultisigAccount(
+      webClient as never,
+      {
+        threshold: 1,
+        signerCommitments: ['0x' + '1'.repeat(64)],
+        guardianCommitment: '0x' + '2'.repeat(64),
+        signatureScheme: 'ecdsa',
+      },
+      'http://localhost:57291',
+    );
 
     expect(authBuilder.linkModule).toHaveBeenNthCalledWith(
       1,

--- a/packages/miden-multisig-client/src/account/builder.ts
+++ b/packages/miden-multisig-client/src/account/builder.ts
@@ -30,12 +30,13 @@ import { normalizeSignerCommitment } from '../utils/signature.js';
  *
  * @param midenClient - Initialized MidenClient
  * @param config - Multisig configuration
+ * @param midenRpcEndpoint - RPC endpoint for the MidenClient's network
  * @returns The created account and seed
  */
 export async function createMultisigAccount(
   midenClient: MidenClient,
   config: MultisigConfig,
-  midenRpcEndpoint?: string,
+  midenRpcEndpoint: string,
 ): Promise<CreateAccountResult> {
   validateMultisigConfig(config);
   const signatureScheme = config.signatureScheme ?? 'falcon';

--- a/packages/miden-multisig-client/src/client.test.ts
+++ b/packages/miden-multisig-client/src/client.test.ts
@@ -106,7 +106,7 @@ describe('MultisigClient', () => {
       );
     });
 
-    it.each([undefined, '', '   '])(
+    it.each([undefined, null, 42, '', '   '])(
       'throws before any network or store access when midenRpcEndpoint is %j',
       (endpoint) => {
         expect(
@@ -122,7 +122,7 @@ describe('MultisigClient', () => {
       },
     );
 
-    it.each([undefined, '', '   '])(
+    it.each([undefined, null, 42, '', '   '])(
       'throws before any network or store access when guardianEndpoint is %j',
       (endpoint) => {
         expect(

--- a/packages/miden-multisig-client/src/client.test.ts
+++ b/packages/miden-multisig-client/src/client.test.ts
@@ -55,6 +55,10 @@ vi.mock('./account/index.js', () => ({
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 
+const GUARDIAN_URL = 'http://localhost:3000';
+const MIDEN_RPC = 'http://localhost:57291';
+const CLIENT_CONFIG = { guardianEndpoint: GUARDIAN_URL, midenRpcEndpoint: MIDEN_RPC };
+
 describe('MultisigClient', () => {
   let webClient: any;
   let mockSigner: Signer;
@@ -83,27 +87,75 @@ describe('MultisigClient', () => {
   });
 
   describe('constructor', () => {
-    it('should create client with default GUARDIAN endpoint', () => {
-      const client = new MultisigClient(webClient);
+    it('should create client when both endpoints are supplied', () => {
+      const client = new MultisigClient(webClient, CLIENT_CONFIG);
       expect(client).toBeInstanceOf(MultisigClient);
     });
 
     it('should create client with custom GUARDIAN endpoint', () => {
-      const client = new MultisigClient(webClient, { guardianEndpoint: 'http://custom:8080' });
+      const client = new MultisigClient(webClient, {
+        guardianEndpoint: 'http://custom:8080',
+        midenRpcEndpoint: MIDEN_RPC,
+      });
       expect(client).toBeInstanceOf(MultisigClient);
+    });
+
+    it('throws when the config object is omitted', () => {
+      expect(() => new (MultisigClient as any)(webClient)).toThrow(
+        'missing required configuration: midenRpcEndpoint',
+      );
+    });
+
+    it.each([undefined, '', '   '])(
+      'throws before any network or store access when midenRpcEndpoint is %j',
+      (endpoint) => {
+        expect(
+          () =>
+            new MultisigClient(webClient, {
+              guardianEndpoint: GUARDIAN_URL,
+              midenRpcEndpoint: endpoint as any,
+            }),
+        ).toThrow('missing required configuration: midenRpcEndpoint');
+        expect(mockFetch).not.toHaveBeenCalled();
+        expect(webClient.accounts.get).not.toHaveBeenCalled();
+        expect(webClient.accounts.insert).not.toHaveBeenCalled();
+      },
+    );
+
+    it.each([undefined, '', '   '])(
+      'throws before any network or store access when guardianEndpoint is %j',
+      (endpoint) => {
+        expect(
+          () =>
+            new MultisigClient(webClient, {
+              guardianEndpoint: endpoint as any,
+              midenRpcEndpoint: MIDEN_RPC,
+            }),
+        ).toThrow('missing required configuration: guardianEndpoint');
+        expect(mockFetch).not.toHaveBeenCalled();
+        expect(webClient.accounts.get).not.toHaveBeenCalled();
+        expect(webClient.accounts.insert).not.toHaveBeenCalled();
+      },
+    );
+
+    it('rejects a blank endpoint passed to setGuardianEndpoint', () => {
+      const client = new MultisigClient(webClient, CLIENT_CONFIG);
+      expect(() => client.setGuardianEndpoint('   ')).toThrow(
+        'missing required configuration: guardianEndpoint',
+      );
     });
   });
 
   describe('guardianClient getter', () => {
     it('should expose GUARDIAN client for getting pubkey', () => {
-      const client = new MultisigClient(webClient);
+      const client = new MultisigClient(webClient, CLIENT_CONFIG);
       expect(client.guardianClient).toBeDefined();
     });
   });
 
   describe('create', () => {
     it('should create multisig and return Multisig instance', async () => {
-      const client = new MultisigClient(webClient);
+      const client = new MultisigClient(webClient, CLIENT_CONFIG);
 
       const config = {
         threshold: 2,
@@ -120,7 +172,7 @@ describe('MultisigClient', () => {
     });
 
     it('should set signer on GUARDIAN client', async () => {
-      const client = new MultisigClient(webClient);
+      const client = new MultisigClient(webClient, CLIENT_CONFIG);
 
       const config = {
         threshold: 1,
@@ -133,7 +185,7 @@ describe('MultisigClient', () => {
     });
 
     it('binds the signer auth key to the created account when supported', async () => {
-      const client = new MultisigClient(webClient);
+      const client = new MultisigClient(webClient, CLIENT_CONFIG);
       const bindAccountKey = vi.fn().mockResolvedValue(undefined);
       const bindingSigner = {
         ...mockSigner,
@@ -152,7 +204,7 @@ describe('MultisigClient', () => {
 
   describe('load', () => {
     it('should load existing multisig account and detect config', async () => {
-      const client = new MultisigClient(webClient);
+      const client = new MultisigClient(webClient, CLIENT_CONFIG);
 
       // Mock getState response
       mockFetch.mockResolvedValueOnce({
@@ -181,7 +233,7 @@ describe('MultisigClient', () => {
     });
 
     it('should throw if account not found on GUARDIAN', async () => {
-      const client = new MultisigClient(webClient);
+      const client = new MultisigClient(webClient, CLIENT_CONFIG);
 
       mockFetch.mockResolvedValueOnce({
         ok: false,
@@ -196,7 +248,7 @@ describe('MultisigClient', () => {
     });
 
     it('should allow registerOnGuardian after load without explicit initial state', async () => {
-      const client = new MultisigClient(webClient);
+      const client = new MultisigClient(webClient, CLIENT_CONFIG);
 
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -227,7 +279,7 @@ describe('MultisigClient', () => {
     });
 
     it('binds the signer auth key after loading an account when supported', async () => {
-      const client = new MultisigClient(webClient);
+      const client = new MultisigClient(webClient, CLIENT_CONFIG);
       const bindAccountKey = vi.fn().mockResolvedValue(undefined);
       const bindingSigner = {
         ...mockSigner,
@@ -289,7 +341,7 @@ describe('MultisigClient', () => {
     }
 
     it('returns one (accountId, state) pair when lookup matches a single account', async () => {
-      const client = new MultisigClient(webClient);
+      const client = new MultisigClient(webClient, CLIENT_CONFIG);
       const signer = makeLookupCapableSigner();
       const accountId = '0x7bfb0f38b0fafa103f86a805594170';
 
@@ -311,7 +363,7 @@ describe('MultisigClient', () => {
     });
 
     it('returns multiple (accountId, state) pairs when one commitment authorizes several accounts', async () => {
-      const client = new MultisigClient(webClient);
+      const client = new MultisigClient(webClient, CLIENT_CONFIG);
       const signer = makeLookupCapableSigner();
       const accountA = '0xaaa1';
       const accountB = '0xbbb2';
@@ -328,7 +380,7 @@ describe('MultisigClient', () => {
     });
 
     it('returns empty array when no account authorizes the commitment', async () => {
-      const client = new MultisigClient(webClient);
+      const client = new MultisigClient(webClient, CLIENT_CONFIG);
       const signer = makeLookupCapableSigner();
 
       mockServerLookupResponse([]);
@@ -341,7 +393,7 @@ describe('MultisigClient', () => {
     });
 
     it('throws a clear error when the signer does not implement signLookupMessage', async () => {
-      const client = new MultisigClient(webClient);
+      const client = new MultisigClient(webClient, CLIENT_CONFIG);
       // mockSigner from the outer beforeEach lacks signLookupMessage.
       await expect(client.recoverByKey(mockSigner)).rejects.toThrow(/signLookupMessage/);
       expect(mockFetch).not.toHaveBeenCalled();

--- a/packages/miden-multisig-client/src/client.ts
+++ b/packages/miden-multisig-client/src/client.ts
@@ -11,7 +11,7 @@ import type { StateObject } from '@openzeppelin/guardian-client';
 import { Multisig } from './multisig.js';
 import { createMultisigAccount } from './account/index.js';
 import { AccountInspector } from './inspector.js';
-import { getRawMidenClient, resolveMidenRpcEndpoint } from './raw-client.js';
+import { getRawMidenClient, requireConfigValue, requireMidenRpcEndpoint } from './raw-client.js';
 import type { MultisigConfig, Signer } from './types.js';
 
 interface AccountKeyBindingSigner {
@@ -33,10 +33,14 @@ async function bindSignerAccountKey(
  * Configuration for MultisigClient.
  */
 export interface MultisigClientConfig {
-  /** GUARDIAN server endpoint */
-  guardianEndpoint?: string;
-  /** Miden node RPC endpoint used for state commitment verification */
-  midenRpcEndpoint?: string;
+  /** GUARDIAN server endpoint. Required — there is no default. */
+  guardianEndpoint: string;
+  /**
+   * Miden node RPC endpoint used for proposal execution and state
+   * commitment verification. Required — must point at the same network as
+   * the injected `MidenClient`; there is no default.
+   */
+  midenRpcEndpoint: string;
 }
 
 /**
@@ -81,19 +85,23 @@ export class MultisigClient {
   private readonly midenRpcEndpoint: string;
   private _guardianClient: GuardianHttpClient;
 
-  constructor(midenClient: MidenClient, config: MultisigClientConfig = {}) {
+  constructor(midenClient: MidenClient, config: MultisigClientConfig) {
     this.midenClient = midenClient;
-    this.midenRpcEndpoint = resolveMidenRpcEndpoint(config.midenRpcEndpoint);
-    this._guardianClient = new GuardianHttpClient(config.guardianEndpoint ?? 'http://localhost:3000');
+    this.midenRpcEndpoint = requireMidenRpcEndpoint(config?.midenRpcEndpoint);
+    this._guardianClient = new GuardianHttpClient(
+      requireConfigValue('guardianEndpoint', config?.guardianEndpoint),
+    );
   }
 
   /**
    * Change the GUARDIAN endpoint.
-   * 
+   *
    * @param endpoint - The new GUARDIAN server endpoint URL
    */
   setGuardianEndpoint(endpoint: string): void {
-    this._guardianClient = new GuardianHttpClient(endpoint);
+    this._guardianClient = new GuardianHttpClient(
+      requireConfigValue('guardianEndpoint', endpoint),
+    );
   }
 
   /**

--- a/packages/miden-multisig-client/src/index.ts
+++ b/packages/miden-multisig-client/src/index.ts
@@ -20,7 +20,8 @@
  * // Create a signer
  * const signer = new FalconSigner(secretKey);
  *
- * // Create multisig client
+ * // Create multisig client. Both endpoints are required; midenRpcEndpoint
+ * // must point at the same network as the injected MidenClient.
  * const client = new MultisigClient(midenClient, {
  *   guardianEndpoint: 'http://localhost:3000',
  *   midenRpcEndpoint: 'https://rpc.devnet.miden.io',

--- a/packages/miden-multisig-client/src/multisig.test.ts
+++ b/packages/miden-multisig-client/src/multisig.test.ts
@@ -119,6 +119,8 @@ vi.mock('./inspector.js', () => ({
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 
+const MIDEN_RPC_ENDPOINT = 'https://rpc.devnet.miden.io';
+
 function mockedAccount(commitmentHex: string, nonce = 0): any {
   return {
     commitment: () => ({
@@ -138,6 +140,22 @@ describe('Multisig', () => {
   let mockSigner: Signer;
   let mockAccount: any;
   let mockWebClient: any;
+
+  function createTestMultisig(
+    config: ConstructorParameters<typeof Multisig>[1],
+    signer: Signer = mockSigner,
+    accountId?: string
+  ): Multisig {
+    return new Multisig(
+      mockAccount,
+      config,
+      guardian,
+      signer,
+      mockWebClient,
+      accountId,
+      MIDEN_RPC_ENDPOINT
+    );
+  }
 
   beforeEach(() => {
     mockFetch.mockReset();
@@ -213,7 +231,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       expect(multisig.threshold).toBe(2);
       expect(multisig.signerCommitments).toEqual(config.signerCommitments);
@@ -229,10 +247,30 @@ describe('Multisig', () => {
       };
 
       const accountId = '0x' + 'd'.repeat(30);
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient, accountId);
+      const multisig = createTestMultisig(config, mockSigner, accountId);
 
       expect(multisig.account).toBe(mockAccount);
       expect(multisig.accountId).toBe(accountId);
+    });
+
+    it('should reject a missing Miden RPC endpoint immediately', () => {
+      const config = {
+        threshold: 2,
+        signerCommitments: ['0x' + 'a'.repeat(64), '0x' + 'b'.repeat(64)],
+        guardianCommitment: '0x' + 'c'.repeat(64),
+      };
+
+      expect(
+        () => new Multisig(
+          mockAccount,
+          config,
+          guardian,
+          mockSigner,
+          mockWebClient,
+          undefined,
+          undefined as unknown as string
+        )
+      ).toThrow('missing required configuration: midenRpcEndpoint');
     });
   });
 
@@ -244,7 +282,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
       expect(multisig.accountId).toBe('0x' + 'a'.repeat(30));
     });
 
@@ -256,7 +294,7 @@ describe('Multisig', () => {
       };
 
       const accountId = '0x' + 'e'.repeat(30);
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient, accountId);
+      const multisig = createTestMultisig(config, mockSigner, accountId);
       expect(multisig.accountId).toBe(accountId);
     });
   });
@@ -269,7 +307,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
       expect(multisig.signerCommitment).toBe(mockSigner.commitment);
     });
   });
@@ -282,7 +320,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -662,7 +700,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -690,7 +728,7 @@ describe('Multisig', () => {
       };
 
       guardian.setSigner(ecdsaSigner);
-      const multisig = new Multisig(mockAccount, config, guardian, ecdsaSigner, mockWebClient);
+      const multisig = createTestMultisig(config, ecdsaSigner);
 
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -726,6 +764,7 @@ describe('Multisig', () => {
         mockSigner,
         mockWebClient,
         '0x' + 'e'.repeat(30),
+        MIDEN_RPC_ENDPOINT,
       );
 
       mockFetch.mockResolvedValueOnce({
@@ -746,7 +785,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -768,7 +807,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       const mockProposals = [
         {
@@ -819,7 +858,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       const mockProposals = [
         {
@@ -868,7 +907,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -917,7 +956,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       const mockProposals = [
         {
@@ -964,7 +1003,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       const mockProposals = [
         {
@@ -1018,7 +1057,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
       expect(multisig.listProposals()).toEqual([]);
     });
   });
@@ -1031,7 +1070,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       const mockDelta = {
         account_id: '0x' + 'a'.repeat(30),
@@ -1075,7 +1114,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       const mockDelta = {
         account_id: '0x' + 'a'.repeat(30),
@@ -1120,7 +1159,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       const mockDelta = {
         account_id: '0x' + 'a'.repeat(30),
@@ -1179,7 +1218,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       const mockDelta = {
         account_id: '0x' + 'a'.repeat(30),
@@ -1269,7 +1308,7 @@ describe('Multisig', () => {
         }),
       });
 
-      const multisig = new Multisig(mockAccount, config, guardian, ecdsaSigner, mockWebClient);
+      const multisig = createTestMultisig(config, ecdsaSigner);
       await multisig.createChangeThresholdProposal(2, 1);
 
       expect(buildUpdateSignersTransactionRequest).toHaveBeenCalledWith(
@@ -1293,7 +1332,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
       const newGuardianPubkey = '0x' + '1'.repeat(64);
 
       mockFetch.mockResolvedValueOnce({
@@ -1342,7 +1381,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -1372,7 +1411,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, ecdsaSigner, mockWebClient);
+      const multisig = createTestMultisig(config, ecdsaSigner);
       const newGuardianCommitment = '0x' + '1'.repeat(64);
 
       mockFetch.mockResolvedValueOnce({
@@ -1427,7 +1466,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       const mockDelta = {
         account_id: '0x' + 'a'.repeat(30),
@@ -1495,7 +1534,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, ecdsaSigner, mockWebClient);
+      const multisig = createTestMultisig(config, ecdsaSigner);
 
       const mockDelta = {
         account_id: '0x' + 'a'.repeat(30),
@@ -1546,7 +1585,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       // First create a proposal
       const mockDelta = {
@@ -1624,7 +1663,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       const mockDelta = {
         account_id: '0x' + 'a'.repeat(30),
@@ -1675,7 +1714,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
       const proposalId = '0x' + 'd'.repeat(64);
 
       mockFetch.mockResolvedValueOnce({
@@ -1722,7 +1761,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       vi.mocked(executeForSummary).mockResolvedValueOnce({
         toCommitment: () => ({
@@ -1758,7 +1797,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       vi.mocked(executeForSummary).mockResolvedValueOnce({
         toCommitment: () => ({
@@ -1809,7 +1848,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       const mockProposals = [
         {
@@ -1862,7 +1901,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
       const publicKey = '0x' + 'd'.repeat(66);
 
       mockFetch.mockResolvedValueOnce({
@@ -1920,7 +1959,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       mockFetch.mockResolvedValueOnce({
         ok: false,
@@ -1943,7 +1982,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       const exported = {
         accountId: multisig.accountId,
@@ -1976,7 +2015,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
       const publicKey = '0x' + 'd'.repeat(66);
 
       const proposal = await multisig.importProposal(
@@ -2023,7 +2062,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       await expect(
         multisig.importProposal(
@@ -2057,7 +2096,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       const exported = {
         accountId: multisig.accountId,
@@ -2102,7 +2141,7 @@ describe('Multisig', () => {
         publicKey: '0x' + '2'.repeat(66),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, ecdsaSigner, mockWebClient);
+      const multisig = createTestMultisig(config, ecdsaSigner);
       const cachedProposalId = '0x' + 'c'.repeat(64);
       const requestedProposalId = '0x' + 'C'.repeat(64);
       const cosignerPubkey = '0x' + '3'.repeat(66);
@@ -2225,7 +2264,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
       const proposalId = '0x' + 'c'.repeat(64);
       const newGuardianPubkey = '0x' + '1'.repeat(64);
       const finalRequest = { kind: 'final-switch-guardian-request' };
@@ -2280,7 +2319,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       await expect(
         multisig.createTransactionProposalRequest('0x' + 'nonexistent'.repeat(5))
@@ -2294,7 +2333,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       const mockProposals = [
         {
@@ -2345,7 +2384,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
       const proposalId = '0x' + 'c'.repeat(64);
 
       vi.mocked(executeForSummary).mockResolvedValueOnce({
@@ -2388,7 +2427,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
       const proposalId = '0x' + 'c'.repeat(64);
 
       (multisig as any).proposals.set(proposalId, {
@@ -2430,7 +2469,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
       const proposalId = '0x' + 'c'.repeat(64);
 
       (multisig as any).proposals.set(proposalId, {
@@ -2502,7 +2541,7 @@ describe('Multisig', () => {
           guardianCommitment: '0x' + 'c'.repeat(64),
         };
 
-        const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+        const multisig = createTestMultisig(config);
         const proposalId = '0x' + 'c'.repeat(64);
         const finalRequest = { kind: 'fresh-message-word-request' };
 
@@ -2601,7 +2640,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
       const proposalId = '0x' + 'c'.repeat(64);
 
       (multisig as any).proposals.set(proposalId, {
@@ -2644,7 +2683,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       await expect(
         multisig.executeProposal('0x' + 'nonexistent'.repeat(5))
@@ -2658,7 +2697,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       // Sync with pending proposal (only 1 signature)
       const mockProposals = [
@@ -2711,7 +2750,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       const readyDelta = {
         account_id: '0x' + 'a'.repeat(30),
@@ -2784,7 +2823,7 @@ describe('Multisig', () => {
         publicKey: '0x' + '2'.repeat(66),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, ecdsaSigner, mockWebClient);
+      const multisig = createTestMultisig(config, ecdsaSigner);
       const proposalId = '0x' + 'c'.repeat(64);
       const cosignerPubkey = '0x' + '3'.repeat(66);
       const ackPubkey = '0x' + '4'.repeat(66);
@@ -2900,7 +2939,7 @@ describe('Multisig', () => {
         publicKey: '0x' + '2'.repeat(66),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, ecdsaSigner, mockWebClient);
+      const multisig = createTestMultisig(config, ecdsaSigner);
       const proposalId = '0x' + 'c'.repeat(64);
       const cosignerPubkey = '0x' + '3'.repeat(66);
       const ackPubkey = '0x' + '4'.repeat(66);
@@ -3003,7 +3042,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
       const proposalId = '0x' + 'c'.repeat(64);
       const newGuardianPubkey = '0x' + '1'.repeat(64);
 
@@ -3086,7 +3125,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
       const proposalId = '0x' + 'c'.repeat(64);
       const newGuardianPubkey = '0x' + '1'.repeat(64);
 
@@ -3137,7 +3176,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
       const proposalId = '0x' + 'c'.repeat(64);
 
       (multisig as any).proposals.set(proposalId, {
@@ -3179,7 +3218,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
       const proposalId = '0x' + 'c'.repeat(64);
 
       (multisig as any).proposals.set(proposalId, {
@@ -3231,7 +3270,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
       const proposalId = '0x' + 'c'.repeat(64);
 
       (multisig as any).proposals.set(proposalId, {
@@ -3308,7 +3347,7 @@ describe('Multisig', () => {
         signerCommitments: ['0x' + 'a'.repeat(64)],
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       const builtinDelta = {
         ...customDelta('change_threshold', [falconSig('0x' + 'a'.repeat(64))]),
@@ -3336,7 +3375,7 @@ describe('Multisig', () => {
         signerCommitments: ['0x' + 'a'.repeat(64), '0x' + 'b'.repeat(64)],
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -3354,7 +3393,7 @@ describe('Multisig', () => {
         signerCommitments: ['0x' + 'a'.repeat(64)],
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       // Signed commitment comes from TransactionSummary.deserialize -> 'c' * 64.
       // Make the binding request derive a different commitment so the check fails.
@@ -3381,7 +3420,7 @@ describe('Multisig', () => {
         signerCommitments: ['0x' + 'a'.repeat(64)],
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       const ready = customDelta('b2agg', [falconSig('0x' + 'a'.repeat(64))]);
 
@@ -3410,7 +3449,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       // Create a proposal with metadata
       const mockDelta = {
@@ -3472,7 +3511,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       // Sync proposals - no local proposals exist
       const mockProposals = [
@@ -3519,7 +3558,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       const mockDelta = {
         account_id: '0x' + 'a'.repeat(30),
@@ -3567,7 +3606,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       const mockDelta = {
         account_id: '0x' + 'a'.repeat(30),
@@ -3617,7 +3656,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       const mockDelta = {
         account_id: '0x' + 'a'.repeat(30),
@@ -3668,7 +3707,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       // First sync with 1 signature (pending)
       const mockProposalsPending = [
@@ -3760,7 +3799,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'd'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
       expect(multisig.threshold).toBe(3);
     });
 
@@ -3772,7 +3811,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'd'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
       expect(multisig.signerCommitments).toEqual(signerCommitments);
     });
 
@@ -3784,7 +3823,7 @@ describe('Multisig', () => {
         guardianCommitment,
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
       expect(multisig.guardianCommitment).toBe(guardianCommitment);
     });
 
@@ -3795,7 +3834,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'd'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
       expect(multisig.account).toBe(mockAccount);
     });
   });
@@ -3808,7 +3847,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       // Simulates a GUARDIAN response with canonical snake_case metadata
       const rustProposals = [
@@ -3858,7 +3897,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       // P2ID proposal with canonical snake_case fields
       const p2idProposals = [
@@ -3915,7 +3954,7 @@ describe('Multisig', () => {
         guardianCommitment: '0x' + 'c'.repeat(64),
       };
 
-      const multisig = new Multisig(mockAccount, config, guardian, mockSigner, mockWebClient);
+      const multisig = createTestMultisig(config);
 
       const switchGuardianProposals = [
         {

--- a/packages/miden-multisig-client/src/multisig.ts
+++ b/packages/miden-multisig-client/src/multisig.ts
@@ -73,7 +73,11 @@ import { AccountInspector } from './inspector.js';
 import { ProposalFactory } from './proposal/factory.js';
 import { ProposalMetadataCodec } from './proposal/metadata.js';
 import { ProposalSignatures } from './proposal/signatures.js';
-import { getRawMidenClient, getTransactionProver, requireMidenRpcEndpoint } from './raw-client.js';
+import {
+  getRawMidenClient,
+  getTransactionProver,
+  requireMidenRpcEndpoint,
+} from './raw-client.js';
 
 /**
  * Result of fetching account state from GUARDIAN.
@@ -138,7 +142,7 @@ export class Multisig {
   private readonly rawClientPromise: Promise<WasmWebClient>;
   private readonly transactionProver: TransactionProver | null;
   private readonly _accountId: string;
-  private readonly midenRpcEndpoint?: string;
+  private readonly midenRpcEndpoint: string;
   private proposals: Map<string, Proposal> = new Map();
 
   constructor(
@@ -147,8 +151,8 @@ export class Multisig {
     guardian: GuardianHttpClient,
     signer: Signer,
     midenClient: MidenClient,
-    accountId?: string,
-    midenRpcEndpoint?: string
+    accountId: string | undefined,
+    midenRpcEndpoint: string
   ) {
     this.account = account;
     this.threshold = config.threshold;
@@ -162,13 +166,13 @@ export class Multisig {
     this.signer = signer;
     this.midenClient = midenClient;
     this._accountId = accountId ?? (account ? accountIdToHex(account) : '');
-    this.midenRpcEndpoint = midenRpcEndpoint;
-    this.rawClientPromise = getRawMidenClient(midenClient, midenRpcEndpoint);
+    this.midenRpcEndpoint = requireMidenRpcEndpoint(midenRpcEndpoint);
     this.transactionProver = getTransactionProver(midenClient);
+    this.rawClientPromise = getRawMidenClient(midenClient, this.midenRpcEndpoint);
   }
 
   private getMidenRpcEndpoint(): string {
-    return requireMidenRpcEndpoint(this.midenRpcEndpoint);
+    return this.midenRpcEndpoint;
   }
 
   private async getRawClient(): Promise<WasmWebClient> {

--- a/packages/miden-multisig-client/src/multisig.ts
+++ b/packages/miden-multisig-client/src/multisig.ts
@@ -73,7 +73,7 @@ import { AccountInspector } from './inspector.js';
 import { ProposalFactory } from './proposal/factory.js';
 import { ProposalMetadataCodec } from './proposal/metadata.js';
 import { ProposalSignatures } from './proposal/signatures.js';
-import { getRawMidenClient, getTransactionProver } from './raw-client.js';
+import { getRawMidenClient, getTransactionProver, requireMidenRpcEndpoint } from './raw-client.js';
 
 /**
  * Result of fetching account state from GUARDIAN.
@@ -168,10 +168,7 @@ export class Multisig {
   }
 
   private getMidenRpcEndpoint(): string {
-    if (!this.midenRpcEndpoint) {
-      throw new Error('Missing Miden RPC endpoint in MultisigClient configuration');
-    }
-    return this.midenRpcEndpoint;
+    return requireMidenRpcEndpoint(this.midenRpcEndpoint);
   }
 
   private async getRawClient(): Promise<WasmWebClient> {

--- a/packages/miden-multisig-client/src/raw-client.test.ts
+++ b/packages/miden-multisig-client/src/raw-client.test.ts
@@ -14,7 +14,6 @@ import {
   compileTxScript,
   getRawMidenClient,
   getTransactionProver,
-  resolveMidenRpcEndpoint,
 } from './raw-client.js';
 
 describe('raw-client', () => {
@@ -22,8 +21,31 @@ describe('raw-client', () => {
     mockCreateClient.mockReset();
   });
 
-  it('defaults RPC endpoint resolution to devnet', () => {
-    expect(resolveMidenRpcEndpoint()).toBe('https://rpc.devnet.miden.io');
+  it('rejects shadow client creation without an RPC endpoint', async () => {
+    const client = {
+      accounts: {},
+      sync: vi.fn(),
+      defaultProver: null,
+      storeIdentifier: vi.fn(() => 'browser-db'),
+    };
+
+    await expect(getRawMidenClient(client as any)).rejects.toThrow(
+      'missing required configuration: midenRpcEndpoint',
+    );
+    await expect(getRawMidenClient(client as any, '   ')).rejects.toThrow(
+      'missing required configuration: midenRpcEndpoint',
+    );
+    expect(mockCreateClient).not.toHaveBeenCalled();
+  });
+
+  it('returns an injected raw web client without needing an endpoint', async () => {
+    const rawClient = {
+      executeTransaction: vi.fn(),
+      proveTransaction: vi.fn(),
+    };
+
+    await expect(getRawMidenClient(rawClient as any)).resolves.toBe(rawClient);
+    expect(mockCreateClient).not.toHaveBeenCalled();
   });
 
   it('returns the default prover from a public MidenClient', () => {

--- a/packages/miden-multisig-client/src/raw-client.test.ts
+++ b/packages/miden-multisig-client/src/raw-client.test.ts
@@ -14,11 +14,27 @@ import {
   compileTxScript,
   getRawMidenClient,
   getTransactionProver,
+  requireConfigValue,
 } from './raw-client.js';
 
 describe('raw-client', () => {
   beforeEach(() => {
     mockCreateClient.mockReset();
+  });
+
+  it.each([undefined, null, 42, {}, []])(
+    'rejects non-string configuration value %j consistently',
+    (value) => {
+      expect(() => requireConfigValue('guardianEndpoint', value)).toThrow(
+        'missing required configuration: guardianEndpoint',
+      );
+    },
+  );
+
+  it('trims surrounding whitespace from configuration values', () => {
+    expect(requireConfigValue('guardianEndpoint', '  http://localhost:3000\n')).toBe(
+      'http://localhost:3000',
+    );
   });
 
   it('rejects shadow client creation without an RPC endpoint', async () => {

--- a/packages/miden-multisig-client/src/raw-client.ts
+++ b/packages/miden-multisig-client/src/raw-client.ts
@@ -5,8 +5,6 @@ import {
   WasmWebClient,
 } from '@miden-sdk/miden-sdk';
 
-export const DEFAULT_MIDEN_RPC_URL = 'https://rpc.devnet.miden.io';
-
 export type RawClientSource = MidenClient | WasmWebClient;
 export interface ScriptLibrarySource {
   namespace: string;
@@ -16,8 +14,15 @@ export interface ScriptLibrarySource {
 
 const rawClientCache = new WeakMap<MidenClient, Promise<WasmWebClient>>();
 
-export function resolveMidenRpcEndpoint(endpoint?: string): string {
-  return endpoint ?? DEFAULT_MIDEN_RPC_URL;
+export function requireConfigValue(field: string, value?: string): string {
+  if (value === undefined || value.trim() === '') {
+    throw new Error(`missing required configuration: ${field}`);
+  }
+  return value;
+}
+
+export function requireMidenRpcEndpoint(endpoint?: string): string {
+  return requireConfigValue('midenRpcEndpoint', endpoint);
 }
 
 function isPublicMidenClient(client: RawClientSource): client is MidenClient {
@@ -37,8 +42,9 @@ export async function getRawMidenClient(
     return cached;
   }
 
+  const endpoint = requireMidenRpcEndpoint(rpcUrl);
   const rawClient = WasmWebClient.createClient(
-    resolveMidenRpcEndpoint(rpcUrl),
+    endpoint,
     undefined,
     undefined,
     await client.storeIdentifier(),

--- a/packages/miden-multisig-client/src/raw-client.ts
+++ b/packages/miden-multisig-client/src/raw-client.ts
@@ -14,11 +14,15 @@ export interface ScriptLibrarySource {
 
 const rawClientCache = new WeakMap<MidenClient, Promise<WasmWebClient>>();
 
-export function requireConfigValue(field: string, value?: string): string {
-  if (value === undefined || value.trim() === '') {
+export function requireConfigValue(field: string, value?: unknown): string {
+  if (typeof value !== 'string') {
     throw new Error(`missing required configuration: ${field}`);
   }
-  return value;
+  const normalizedValue = value.trim();
+  if (normalizedValue === '') {
+    throw new Error(`missing required configuration: ${field}`);
+  }
+  return normalizedValue;
 }
 
 export function requireMidenRpcEndpoint(endpoint?: string): string {

--- a/packages/miden-multisig-client/src/transaction/consumeNotes.ts
+++ b/packages/miden-multisig-client/src/transaction/consumeNotes.ts
@@ -15,7 +15,7 @@ import { LegacyConsumeNotesNoteMissingError } from '../multisig/consumeNotesErro
 import { getRawMidenClient } from '../raw-client.js';
 import { normalizeHexWord } from '../utils/encoding.js';
 import { randomWord } from '../utils/random.js';
-import type { SignatureOptions } from './options.js';
+import type { MidenClientSignatureOptions, SignatureOptions } from './options.js';
 
 /**
  * Build a consume-notes request from loaded `Note` objects (no local-store
@@ -57,6 +57,16 @@ export function buildConsumeNotesTransactionRequestFromNotes(
  * Legacy/creation adapter: fetches notes from the local store and delegates
  * to the from-notes variant. v2 verification MUST NOT call this.
  */
+export function buildConsumeNotesTransactionRequest(
+  client: MidenClient,
+  noteIds: string[],
+  options: MidenClientSignatureOptions,
+): Promise<{ request: TransactionRequest; salt: Word }>;
+export function buildConsumeNotesTransactionRequest(
+  client: WasmWebClient,
+  noteIds: string[],
+  options?: SignatureOptions,
+): Promise<{ request: TransactionRequest; salt: Word }>;
 export async function buildConsumeNotesTransactionRequest(
   client: MidenClient | WasmWebClient,
   noteIds: string[],

--- a/packages/miden-multisig-client/src/transaction/options.ts
+++ b/packages/miden-multisig-client/src/transaction/options.ts
@@ -7,3 +7,7 @@ export interface SignatureOptions {
   signatureScheme?: SignatureScheme;
   midenRpcEndpoint?: string;
 }
+
+export interface MidenClientSignatureOptions extends SignatureOptions {
+  midenRpcEndpoint: string;
+}

--- a/packages/miden-multisig-client/src/transaction/summary.ts
+++ b/packages/miden-multisig-client/src/transaction/summary.ts
@@ -7,6 +7,18 @@ import type {
 import { AccountId } from '@miden-sdk/miden-sdk';
 import { getRawMidenClient } from '../raw-client.js';
 
+export function executeForSummary(
+  client: MidenClient,
+  accountId: string,
+  txRequest: TransactionRequest,
+  midenRpcEndpoint: string,
+): Promise<TransactionSummary>;
+export function executeForSummary(
+  client: WasmWebClient,
+  accountId: string,
+  txRequest: TransactionRequest,
+  midenRpcEndpoint?: string,
+): Promise<TransactionSummary>;
 export async function executeForSummary(
   client: MidenClient | WasmWebClient,
   accountId: string,

--- a/packages/miden-multisig-client/src/transaction/updateGuardian.ts
+++ b/packages/miden-multisig-client/src/transaction/updateGuardian.ts
@@ -13,7 +13,7 @@ import { GUARDIAN_ECDSA_MASM, GUARDIAN_MASM } from '../account/masm/auth.js';
 import { compileTxScript } from '../raw-client.js';
 import { normalizeHexWord } from '../utils/encoding.js';
 import { randomWord } from '../utils/random.js';
-import type { SignatureOptions } from './options.js';
+import type { MidenClientSignatureOptions, SignatureOptions } from './options.js';
 import type { SignatureScheme } from '../types.js';
 
 async function buildUpdateGuardianScript(
@@ -42,6 +42,16 @@ end
   );
 }
 
+export function buildUpdateGuardianTransactionRequest(
+  client: MidenClient,
+  newGuardianPubkey: string,
+  options: MidenClientSignatureOptions,
+): Promise<{ request: TransactionRequest; salt: Word }>;
+export function buildUpdateGuardianTransactionRequest(
+  client: WasmWebClient,
+  newGuardianPubkey: string,
+  options?: SignatureOptions,
+): Promise<{ request: TransactionRequest; salt: Word }>;
 export async function buildUpdateGuardianTransactionRequest(
   client: MidenClient | WasmWebClient,
   newGuardianPubkey: string,

--- a/packages/miden-multisig-client/src/transaction/updateProcedureThreshold.ts
+++ b/packages/miden-multisig-client/src/transaction/updateProcedureThreshold.ts
@@ -18,7 +18,7 @@ import { getProcedureRoot, type ProcedureName } from '../procedures.js';
 import { compileTxScript } from '../raw-client.js';
 import { normalizeHexWord } from '../utils/encoding.js';
 import { randomWord } from '../utils/random.js';
-import type { SignatureOptions } from './options.js';
+import type { MidenClientSignatureOptions, SignatureOptions } from './options.js';
 import type { SignatureScheme } from '../types.js';
 
 function buildProcedureThresholdFelts(procedure: ProcedureName, threshold: number): Felt[] {
@@ -76,6 +76,18 @@ end
   );
 }
 
+export function buildUpdateProcedureThresholdTransactionRequest(
+  client: MidenClient,
+  procedure: ProcedureName,
+  threshold: number,
+  options: MidenClientSignatureOptions,
+): Promise<{ request: TransactionRequest; salt: Word; configHash: Word }>;
+export function buildUpdateProcedureThresholdTransactionRequest(
+  client: WasmWebClient,
+  procedure: ProcedureName,
+  threshold: number,
+  options?: SignatureOptions,
+): Promise<{ request: TransactionRequest; salt: Word; configHash: Word }>;
 export async function buildUpdateProcedureThresholdTransactionRequest(
   client: MidenClient | WasmWebClient,
   procedure: ProcedureName,

--- a/packages/miden-multisig-client/src/transaction/updateSigners.ts
+++ b/packages/miden-multisig-client/src/transaction/updateSigners.ts
@@ -18,7 +18,7 @@ import {
 import { compileTxScript } from '../raw-client.js';
 import { normalizeHexWord } from '../utils/encoding.js';
 import { randomWord } from '../utils/random.js';
-import type { SignatureOptions } from './options.js';
+import type { MidenClientSignatureOptions, SignatureOptions } from './options.js';
 import type { SignatureScheme } from '../types.js';
 
 function buildMultisigConfigFelts(threshold: number, signerCommitments: string[]): Felt[] {
@@ -73,6 +73,18 @@ end
   );
 }
 
+export function buildUpdateSignersTransactionRequest(
+  client: MidenClient,
+  threshold: number,
+  signerCommitments: string[],
+  options: MidenClientSignatureOptions,
+): Promise<{ request: TransactionRequest; salt: Word; configHash: Word }>;
+export function buildUpdateSignersTransactionRequest(
+  client: WasmWebClient,
+  threshold: number,
+  signerCommitments: string[],
+  options?: SignatureOptions,
+): Promise<{ request: TransactionRequest; salt: Word; configHash: Word }>;
 export async function buildUpdateSignersTransactionRequest(
   client: MidenClient | WasmWebClient,
   threshold: number,


### PR DESCRIPTION
Require explicit Miden RPC configuration in the TypeScript multisig SDK and GUARDIAN_NETWORK_TYPE at server startup. Fail fast on missing or invalid values, update public helper types, tests, examples, and documentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Server startup now requires a valid `GUARDIAN_NETWORK_TYPE`; supported values are handled case-insensitively.
  * Multisig SDK configuration now requires both Guardian and Miden RPC endpoints.
  * Transaction APIs provide clearer type guidance for required endpoint and signing options.

* **Bug Fixes**
  * Prevented silent fallback to default networks or RPC endpoints when configuration is missing or invalid.

* **Documentation**
  * Updated setup, deployment, Docker Compose, examples, and troubleshooting guidance to reflect required configuration and network-specific endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->