### PR TITLE
chore: Remove attestation step from npm publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -95,10 +95,3 @@ jobs:
         run: npm publish --provenance --access public --dry-run
         env:
           NPM_CONFIG_PROVENANCE: true
-
-      - name: Generate attestation
-        if: steps.check-version.outputs.already_published == 'false' && !(github.event.inputs.dry-run == 'true')
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
-        with:
-          subject-path: packages/${{ matrix.package }}
-          subject-name: ${{ steps.check-version.outputs.name }}@${{ steps.check-version.outputs.version }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package publishing workflow to remove the separate build provenance attestation step.
  * Package publishing and dry-run behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->