### PR TITLE
fix: Add  protoc dep to npm publish CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,6 +52,9 @@ jobs:
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
 
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
       - name: Install dependencies
         working-directory: packages/${{ matrix.package }}
         run: npm ci


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release process to install the required Protocol Buffers compiler before building, testing, and publishing packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->