### PR TITLE
chore: Fix dockerfile dep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,10 @@
 #   docker build --platform linux/amd64 ...
 FROM rust:1.93.0-bookworm as base-builder
 
-# Install protobuf compiler (pinned to specific version)
+# Install protobuf compiler (pinned to upstream 3.21.12; the Debian
+# packaging revision floats so point-release rebuilds don't break the build)
 RUN apt-get update && apt-get install -y \
-    protobuf-compiler=3.21.12-3 \
+    "protobuf-compiler=3.21.12-*" \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
Fix for recent failure: https://github.com/OpenZeppelin/guardian/actions/runs/29820867962/job/88602929206

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the protobuf compiler package pinning to allow compatible Debian packaging revisions.
  * Added comments clarifying package version handling during rebuilds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->