### PR TITLE
fix: add candidate_landed to TS Guardian error-code vocabulary

### DIFF
--- a/packages/guardian-client/src/error-codes.ts
+++ b/packages/guardian-client/src/error-codes.ts
@@ -2,10 +2,10 @@
  * Typed vocabulary of Guardian's stable, machine-readable error codes
  * (issue #318). Mirrors `GuardianError::code()` in
  * `crates/server/src/error.rs` — a drift-guard test asserts the two stay in
- * sync. The three codes the server emits in SCREAMING_SNAKE wire form
+ * sync. The four codes the server emits in SCREAMING_SNAKE wire form
  * (`GUARDIAN_ACCOUNT_PAUSED`, `GUARDIAN_ACCOUNT_RELEASED`,
- * `GUARDIAN_INSUFFICIENT_OPERATOR_PERMISSION`) are normalized to snake_case
- * here so the union has one consistent shape; use
+ * `GUARDIAN_INSUFFICIENT_OPERATOR_PERMISSION`, `GUARDIAN_CANDIDATE_LANDED`)
+ * are normalized to snake_case here so the union has one consistent shape; use
  * {@link normalizeGuardianErrorCode} at the wire boundary.
  */
 export const GUARDIAN_ERROR_CODES = [
@@ -16,6 +16,7 @@ export const GUARDIAN_ERROR_CODES = [
   'account_released',
   'authentication_failed',
   'authorization_failed',
+  'candidate_landed',
   'commitment_mismatch',
   'configuration_error',
   'conflict_pending_delta',
@@ -67,6 +68,7 @@ const WIRE_ALIASES: Readonly<Record<string, GuardianErrorCode>> = {
   GUARDIAN_ACCOUNT_PAUSED: 'account_paused',
   GUARDIAN_ACCOUNT_RELEASED: 'account_released',
   GUARDIAN_INSUFFICIENT_OPERATOR_PERMISSION: 'insufficient_operator_permission',
+  GUARDIAN_CANDIDATE_LANDED: 'candidate_landed',
 };
 
 /** Type guard narrowing an arbitrary string to {@link GuardianErrorCode}. */

--- a/packages/guardian-client/src/http.test.ts
+++ b/packages/guardian-client/src/http.test.ts
@@ -512,7 +512,8 @@ describe('GuardianHttpClient', () => {
         .catch((e) => e);
       expect(error).toBeInstanceOf(GuardianHttpError);
       expect(error.status).toBe(409);
-      expect(error.code).toBe('GUARDIAN_CANDIDATE_LANDED');
+      expect(error.code).toBe('candidate_landed');
+      expect(error.rawCode).toBe('GUARDIAN_CANDIDATE_LANDED');
     });
 
     it('surfaces 404 delta_not_found when no candidate exists at the nonce', async () => {


### PR DESCRIPTION
## What

Adds the `candidate_landed` code to the TypeScript Guardian error-code vocabulary so it mirrors the server again.

## Why

The abandon-candidate endpoint (#327) introduced `GuardianError::CandidateLanded` (stable wire code `GUARDIAN_CANDIDATE_LANDED`) but merged **after** the compiler-checked TS error-code union (#318 / #339) and never updated the mirror. As a result:

- The **drift-guard test** (`error-codes.test.ts`) has been red on `main` — the server code normalizes to `UNKNOWN:GUARDIAN_CANDIDATE_LANDED`.
- A consumer catching a 409 from `abandonCandidate` got `error.code === null` and could not branch on the typed union, defeating the purpose of #318.

## Changes

- Add `'candidate_landed'` to `GUARDIAN_ERROR_CODES`.
- Map `GUARDIAN_CANDIDATE_LANDED → 'candidate_landed'` in `WIRE_ALIASES` (server emits it in SCREAMING_SNAKE like the other `GUARDIAN_*` codes).
- Correct the `abandonCandidate` HTTP test to assert normalized `.code` (`candidate_landed`) and verbatim `.rawCode` (`GUARDIAN_CANDIDATE_LANDED`), matching the documented `{ code, message, meta }` envelope contract.

## Test

`packages/guardian-client`: 64/64 tests pass; `tsc` build clean.

This is a prerequisite for the upcoming v0.16.0 release (drift guard must be green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for recognizing candidate-landed errors from the service.
  * Error responses now expose a normalized `candidate_landed` code while retaining the original service error code for diagnostics.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->