### PR TITLE
chore(release): v0.16.0

### DIFF
--- a/.agents/skills/release-guardian-sdk-packages/references/release-surface.md
+++ b/.agents/skills/release-guardian-sdk-packages/references/release-surface.md
@@ -1,6 +1,6 @@
 # Guardian SDK Release Surface
 
-Current coordinated SDK release line: `0.15.x`
+Current coordinated SDK release line: `0.16.x`
 
 ## Publishable Rust Crates
 
@@ -30,6 +30,10 @@ Current coordinated SDK release line: `0.15.x`
    - manifest: `packages/miden-multisig-client/package.json`
    - lockfile: `packages/miden-multisig-client/package-lock.json`
    - internal release dependency: `@openzeppelin/guardian-client`
+4. `@openzeppelin/guardian-operator-client`
+   - manifest: `packages/guardian-operator-client/package.json`
+   - lockfile: `packages/guardian-operator-client/package-lock.json`
+   - no internal release dependencies
 
 ## Files Usually Touched In A Coordinated Release
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3131,7 +3131,7 @@ dependencies = [
 
 [[package]]
 name = "guardian-client"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "guardian-shared",
@@ -3211,7 +3211,7 @@ dependencies = [
 
 [[package]]
 name = "guardian-server"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "aes-gcm",
  "alloy",
@@ -3301,7 +3301,7 @@ dependencies = [
 
 [[package]]
 name = "guardian-shared"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "base64",
  "hex",
@@ -4509,7 +4509,7 @@ dependencies = [
 
 [[package]]
 name = "miden-confidential-contracts"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4766,7 +4766,7 @@ dependencies = [
 
 [[package]]
 name = "miden-multisig-client"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.15.1"
+version = "0.16.0"
 edition = "2024"
 rust-version = "1.93"
 authors = ["OpenZeppelin"]

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -11,7 +11,7 @@ description = "Client library for Guardian"
 include = ["src/**/*", "proto/**/*", "build.rs", "Cargo.toml", "LICENSE", "README.md"]
 
 [dependencies]
-guardian-shared = { version = "=0.15.1", path = "../shared" }
+guardian-shared = { version = "=0.16.0", path = "../shared" }
 miden-protocol = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/contracts/Cargo.toml
+++ b/crates/contracts/Cargo.toml
@@ -18,7 +18,7 @@ miden-testing = { workspace = true }
 
 anyhow = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "net", "macros", "fs"] }
-guardian-shared = { version = "=0.15.1", path = "../shared" }
+guardian-shared = { version = "=0.16.0", path = "../shared" }
 
 [dev-dependencies]
 miden-client = { workspace = true, features = ["testing", "tonic"] }

--- a/crates/miden-multisig-client/Cargo.toml
+++ b/crates/miden-multisig-client/Cargo.toml
@@ -11,9 +11,9 @@ description = "High-level SDK for interacting with multisig accounts on Miden vi
 
 [dependencies]
 # Internal crates
-guardian-client = { version = "=0.15.1", path = "../client" }
-guardian-shared = { version = "=0.15.1", path = "../shared" }
-miden-confidential-contracts = { version = "=0.15.1", path = "../contracts" }
+guardian-client = { version = "=0.16.0", path = "../client" }
+guardian-shared = { version = "=0.16.0", path = "../shared" }
+miden-confidential-contracts = { version = "=0.16.0", path = "../contracts" }
 
 # Miden
 miden-client = { workspace = true, features = ["tonic"] }

--- a/docs/openapi-client.json
+++ b/docs/openapi-client.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0",
       "identifier": "AGPL-3.0"
     },
-    "version": "0.15.1"
+    "version": "0.16.0"
   },
   "paths": {
     "/configure": {

--- a/docs/openapi-dashboard.json
+++ b/docs/openapi-dashboard.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0",
       "identifier": "AGPL-3.0"
     },
-    "version": "0.15.1"
+    "version": "0.16.0"
   },
   "paths": {
     "/auth/challenge": {

--- a/docs/openapi-evm.json
+++ b/docs/openapi-evm.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0",
       "identifier": "AGPL-3.0"
     },
-    "version": "0.15.1"
+    "version": "0.16.0"
   },
   "paths": {
     "/evm/accounts": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0",
       "identifier": "AGPL-3.0"
     },
-    "version": "0.15.1"
+    "version": "0.16.0"
   },
   "paths": {
     "/auth/challenge": {

--- a/packages/guardian-client/package-lock.json
+++ b/packages/guardian-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openzeppelin/guardian-client",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openzeppelin/guardian-client",
-      "version": "0.15.2",
+      "version": "0.16.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.7.2",

--- a/packages/guardian-client/package.json
+++ b/packages/guardian-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/guardian-client",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "description": "TypeScript HTTP client for Guardian server",
   "repository": {
     "type": "git",

--- a/packages/guardian-evm-client/package-lock.json
+++ b/packages/guardian-evm-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openzeppelin/guardian-evm-client",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openzeppelin/guardian-evm-client",
-      "version": "0.15.2",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
         "viem": "^2.47.5"

--- a/packages/guardian-evm-client/package.json
+++ b/packages/guardian-evm-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/guardian-evm-client",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "description": "TypeScript EVM client for Guardian server proposal workflows",
   "repository": {
     "type": "git",

--- a/packages/guardian-operator-client/package-lock.json
+++ b/packages/guardian-operator-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openzeppelin/guardian-operator-client",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openzeppelin/guardian-operator-client",
-      "version": "0.15.2",
+      "version": "0.16.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.7.2",

--- a/packages/guardian-operator-client/package.json
+++ b/packages/guardian-operator-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/guardian-operator-client",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "description": "TypeScript HTTP client for Guardian operator dashboard endpoints",
   "repository": {
     "type": "git",

--- a/packages/miden-multisig-client/package-lock.json
+++ b/packages/miden-multisig-client/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@openzeppelin/miden-multisig-client",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openzeppelin/miden-multisig-client",
-      "version": "0.15.2",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
         "@miden-sdk/miden-sdk": "^0.15.8",
         "@noble/curves": "^1.9.7",
         "@noble/hashes": "^2.0.1",
-        "@openzeppelin/guardian-client": "^0.15.0"
+        "@openzeppelin/guardian-client": "^0.16.0"
       },
       "devDependencies": {
         "typescript": "^5.7.2",

--- a/packages/miden-multisig-client/package.json
+++ b/packages/miden-multisig-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/miden-multisig-client",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "description": "TypeScript SDK for Miden multisig accounts with GUARDIAN integration",
   "repository": {
     "type": "git",
@@ -39,7 +39,7 @@
     "@miden-sdk/miden-sdk": "^0.15.8",
     "@noble/curves": "^1.9.7",
     "@noble/hashes": "^2.0.1",
-    "@openzeppelin/guardian-client": "^0.15.0"
+    "@openzeppelin/guardian-client": "^0.16.0"
   },
   "devDependencies": {
     "typescript": "^5.7.2",


### PR DESCRIPTION
Coordinated SDK release. Signals a major-version-style bump on the 0.15.x Miden dependency line to cover two breaking changes already merged to main:

- Remove silent devnet network defaults (#330)
- Human-readable error envelope { code, message, meta } (#304)

Bumps the publishable surface (Rust workspace + 4 TS packages) and refreshes lockfiles. miden-multisig-client's guardian-client dependency range moves to ^0.16.0; its lockfile resolved entry is refreshed after guardian-client 0.16.0 is published.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `@openzeppelin/guardian-operator-client` package to the publishable SDK lineup.

- **Release Updates**
  - Released the SDK suite as version 0.16.0.
  - Updated related package and client versions for compatibility.
  - Updated the multisig client to use the latest Guardian client release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->