### PR TITLE
chore: update miden-multisig-client npm lockfile

### DIFF
--- a/packages/miden-multisig-client/package-lock.json
+++ b/packages/miden-multisig-client/package-lock.json
@@ -549,9 +549,9 @@
       }
     },
     "node_modules/@openzeppelin/guardian-client": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/guardian-client/-/guardian-client-0.15.0.tgz",
-      "integrity": "sha512-fbqYORBQSu4uLol+2emvmtmG8Cx5MlYrLRLvCkUBlSGvVaNBKxOZUkW2XLNbNu+WblFKFTFwL+UKr8msMBcqFw==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/guardian-client/-/guardian-client-0.16.0.tgz",
+      "integrity": "sha512-/ixcnXpLA4bPXvHMiANMS6+GaFPSiJkJohPSHYyk+t/bc1GGykUq4ZMhZyDY/pqSEnz5/70LWBBGplQklMFFoQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1710,6 +1710,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",


### PR DESCRIPTION
Update miden-multisig-client lockfile to match newly released guardian-client v0.16.0 version.