### PR TITLE
feat: publish rust crates via GH workflow

### DIFF
--- a/.agents/skills/release-guardian-sdk-packages/SKILL.md
+++ b/.agents/skills/release-guardian-sdk-packages/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release-guardian-sdk-packages
-description: Version, validate, dry-run, and publish the repository's Rust and TypeScript Guardian SDK packages to crates.io and npm. Use when Codex needs to choose the next coordinated release version, update release manifests and lockfiles, run targeted checks, prepare or execute publish commands in dependency order, and minimize the user's work to registry login or final irreversible publish confirmation.
+description: Version, validate, dry-run, and publish the repository's Rust and TypeScript Guardian SDK packages to crates.io and npm. Use when Codex needs to choose the next coordinated release version, update release manifests and lockfiles, run targeted checks, prepare the Rust publication workflow or npm commands, and minimize the user's work to approval or final irreversible publish confirmation.
 ---
 
 # Release Guardian SDK Packages
@@ -38,7 +38,7 @@ Do as much of the release prep as possible without user intervention:
 - use the target version provided by the user
 - update manifests and lockfiles
 - run targeted tests, builds, and dry-runs
-- give the user the exact remaining auth or publish commands
+- give the user the exact remaining workflow, approval, auth, or publish commands
 
 Before changing versions or preparing publishes:
 
@@ -52,7 +52,15 @@ If the user does not provide a version:
 - propose the next valid version on the active line
 - stop for confirmation unless the user explicitly asked Codex to choose the next version automatically
 
-Unless the user explicitly asks Codex to perform the real publish and credentials are already valid, stop before irreversible `cargo publish` or `npm publish` steps.
+Unless the user explicitly asks Codex to perform the real publish and required
+trust/authentication is already valid, stop before an irreversible Rust
+workflow dispatch, published GitHub Release, or `npm publish` step.
+
+Normal Rust publication is performed by
+`.github/workflows/publish-crates.yml`, not by a maintainer running
+`cargo publish` locally. Stop before dispatching a non-dry-run workflow or
+publishing a GitHub Release unless the user explicitly approves that
+irreversible action.
 
 ## Version Policy
 
@@ -126,13 +134,14 @@ cd packages/guardian-operator-client && npm test
 cd packages/guardian-operator-client && npm run build
 ```
 
-Then run publish dry-runs:
+Then run publication dry-runs:
 
 ```bash
-cargo publish -p guardian-shared --dry-run
-cargo publish -p guardian-client --dry-run
-cargo publish -p miden-confidential-contracts --dry-run
-cargo publish -p miden-multisig-client --dry-run
+cargo publish --dry-run --locked \
+  -p guardian-shared \
+  -p guardian-client \
+  -p miden-confidential-contracts \
+  -p miden-multisig-client
 ```
 
 ```bash
@@ -164,16 +173,39 @@ If the branch already exists:
 git checkout release/v<version>
 ```
 
-## Publish Order
+## Rust Publication Workflow
 
-Rust crates must be published in dependency order:
+The stable workflow filename is `.github/workflows/publish-crates.yml`.
+crates.io must have one trusted-publisher entry per Rust crate with:
+
+```text
+GitHub owner: OpenZeppelin
+Repository: guardian
+Workflow: publish-crates.yml
+Environment: release
+```
+
+Published releases force-select all four crates and use OIDC trusted
+publishing. Manual runs expose `dry-run` and one boolean per crate. Pull
+requests changing the workflow force an all-crate credential-free dry run.
+
+Cargo receives the selected packages in the fixed display order below and
+publishes dependency-safe topological batches:
 
 1. `guardian-shared`
 2. `guardian-client`
 3. `miden-confidential-contracts`
 4. `miden-multisig-client`
 
-Wait for crates.io indexing between dependent publishes.
+Exact versions already on crates.io are skipped. The selected packages are
+passed to one native multi-package Cargo command, which owns dependency
+ordering and index polling. A partial repair may select a dependent only when
+its unselected prerequisites are already available at the coordinated version.
+
+Trusted-publishing failure must fail closed. The workflow has no long-lived
+registry-token fallback.
+
+## TypeScript Publish Order
 
 TypeScript packages must be published in dependency order:
 
@@ -187,19 +219,25 @@ TypeScript packages must be published in dependency order:
 The user should usually only need to handle:
 
 - moving to or confirming the release branch
-- `cargo login <CRATES_IO_TOKEN>` or equivalent registry auth check
 - `npm whoami` or `npm login`
-- any final publish confirmation the user wants to own
+- confirming a Rust workflow dry run
+- approving any non-dry-run Rust workflow or published GitHub Release
 - cutting the GitHub Release (`gh release create`), which also triggers the server image build
 
-When auth is missing or unverified, give a short ordered command sequence. Prefer:
+For a normal Rust release, do not request `cargo login` or a local crates.io
+token. Verify the four external trusted-publisher entries and use:
 
 ```bash
-cargo login <CRATES_IO_TOKEN>
-npm whoami || npm login
+gh workflow run publish-crates.yml \
+  --ref <release-ref> \
+  -f dry-run=true \
+  -f guardian-shared=true \
+  -f guardian-client=true \
+  -f miden-confidential-contracts=true \
+  -f miden-multisig-client=true
 ```
 
-If the user has already authenticated, continue with the automated prep and only surface the exact real publish commands that remain.
+Continue TypeScript authentication checks with `npm whoami || npm login`.
 
 ## Post-Release
 
@@ -229,9 +267,10 @@ To skip the review step and publish immediately, omit `--draft`:
 gh release create v<version> --generate-notes
 ```
 
-Publishing a GitHub Release auto-triggers the **Docker Publish** workflow, which
-builds and pushes the Guardian server image for that tag. The build waits for
-required-reviewer approval on the `release` environment before it pushes:
+Publishing a GitHub Release auto-triggers the **Publish Rust Crates**,
+**Publish NPM Packages**, and **Docker Publish** workflows. Each retains its own
+approval and result flow. The Docker build waits for required-reviewer approval
+on the `release` environment before it pushes:
 
 - approve the run when the release should also ship a server image
 - decline it for SDK-only releases (the SDK and server share the same `vX.Y.Z`
@@ -254,6 +293,7 @@ Default to a short release handoff:
 - expected release branch
 - files updated
 - checks and dry-runs completed
-- exact remaining commands for branch, auth, publish, and tagging
+- exact remaining commands for branch, workflow dispatch, approval, npm auth,
+  publish, and tagging
 
 If the user asks to publish, separate dry-run commands from real publish commands and keep the final sequence copy-pasteable.

--- a/.agents/skills/release-guardian-sdk-packages/references/release-surface.md
+++ b/.agents/skills/release-guardian-sdk-packages/references/release-surface.md
@@ -49,14 +49,40 @@ Current coordinated SDK release line: `0.16.x`
 - `packages/miden-multisig-client/package-lock.json`
 - `docs/MULTISIG_SDK.md` if release examples or tag snippets need updating
 
-## Default Publish Sequence
+## Rust Publication Automation
 
-```bash
-cargo publish -p guardian-shared
-cargo publish -p guardian-client
-cargo publish -p miden-confidential-contracts
-cargo publish -p miden-multisig-client
+Stable workflow:
+
+```text
+.github/workflows/publish-crates.yml
 ```
+
+Published releases select all four Rust crates. Manual runs provide `dry-run`,
+and one boolean per crate. Pull requests changing the workflow run an
+all-crate dry run without credentials.
+
+The fixed selection and summary order is:
+
+1. `guardian-shared`
+2. `guardian-client`
+3. `miden-confidential-contracts`
+4. `miden-multisig-client`
+
+Cargo receives selected crates in one multi-package command and owns dependency
+ordering. Actual runs skip exact versions already visible on crates.io.
+
+Each crate's crates.io trusted publisher is bound to:
+
+```text
+GitHub owner: OpenZeppelin
+Repository: guardian
+Workflow: publish-crates.yml
+Environment: release
+```
+
+OIDC trusted publishing is the only publication authentication path.
+
+## TypeScript Publish Sequence
 
 ```bash
 cd packages/guardian-client && npm publish --access public

--- a/.agents/skills/release-guardian-sdk-packages/references/release-surface.md
+++ b/.agents/skills/release-guardian-sdk-packages/references/release-surface.md
@@ -88,4 +88,5 @@ OIDC trusted publishing is the only publication authentication path.
 cd packages/guardian-client && npm publish --access public
 cd packages/guardian-evm-client && npm publish --access public
 cd packages/miden-multisig-client && npm publish --access public
+cd packages/guardian-operator-client && npm publish --access public
 ```

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -242,12 +242,6 @@ jobs:
             echo "- Authentication: \`none\`"
             echo "- Selected: \`$(jq -r 'join(", ")' <<<"${SELECTED}")\`"
             echo "- Result: \`${STATUS}\`"
-            echo
-            echo "| Crate | Validation |"
-            echo "|---|---|"
-            while IFS= read -r crate; do
-              echo "| \`${crate}\` | \`${STATUS}\` |"
-            done < <(jq -r '.[]' <<<"${SELECTED}")
           } >> "${GITHUB_STEP_SUMMARY}"
 
   publish:
@@ -359,10 +353,11 @@ jobs:
           STATUS: ${{ job.status }}
           VERSION: ${{ needs.validate.outputs.version }}
         run: |
-          authentication=none
-          if jq -e 'length > 0' <<<"${PACKAGES:-[]}" >/dev/null; then
-            authentication=trusted-publishing
-          fi
+          case "${AUTH_OUTCOME}" in
+            success) authentication=trusted-publishing ;;
+            failure) authentication=failed ;;
+            *) authentication=none ;;
+          esac
 
           {
             echo "## Rust crate publication"

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,0 +1,400 @@
+name: Publish Rust Crates
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Validate packages without publishing"
+        type: boolean
+        required: false
+        default: false
+      guardian-shared:
+        description: "Select guardian-shared"
+        type: boolean
+        required: false
+        default: false
+      guardian-client:
+        description: "Select guardian-client"
+        type: boolean
+        required: false
+        default: false
+      miden-confidential-contracts:
+        description: "Select miden-confidential-contracts"
+        type: boolean
+        required: false
+        default: false
+      miden-multisig-client:
+        description: "Select miden-multisig-client"
+        type: boolean
+        required: false
+        default: false
+  pull_request:
+    paths:
+      - ".github/workflows/publish-crates.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      mode: ${{ steps.prepare.outputs.mode }}
+      selected: ${{ steps.prepare.outputs.selected }}
+      source_ref: ${{ steps.prepare.outputs.source_ref }}
+      source_sha: ${{ steps.prepare.outputs.source_sha }}
+      trigger: ${{ steps.prepare.outputs.trigger }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Resolve publication request
+        id: prepare
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_DRY_RUN: ${{ inputs['dry-run'] }}
+          INPUT_GUARDIAN_CLIENT: ${{ inputs['guardian-client'] }}
+          INPUT_GUARDIAN_SHARED: ${{ inputs['guardian-shared'] }}
+          INPUT_CONTRACTS: ${{ inputs['miden-confidential-contracts'] }}
+          INPUT_MULTISIG: ${{ inputs['miden-multisig-client'] }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          SOURCE_REF: ${{ github.ref }}
+          SOURCE_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          all_crates=(
+            guardian-shared
+            guardian-client
+            miden-confidential-contracts
+            miden-multisig-client
+          )
+          selected=()
+
+          case "${EVENT_NAME}" in
+            release)
+              trigger=release
+              mode=publish
+              source_ref="${RELEASE_TAG}"
+              selected=("${all_crates[@]}")
+              ;;
+            pull_request)
+              trigger=pull_request
+              mode=dry_run
+              source_ref="${SOURCE_REF}"
+              selected=("${all_crates[@]}")
+              ;;
+            workflow_dispatch)
+              trigger=manual
+              source_ref="${SOURCE_REF}"
+              [[ "${INPUT_GUARDIAN_SHARED}" == "true" ]] && selected+=(guardian-shared)
+              [[ "${INPUT_GUARDIAN_CLIENT}" == "true" ]] && selected+=(guardian-client)
+              [[ "${INPUT_CONTRACTS}" == "true" ]] && selected+=(miden-confidential-contracts)
+              [[ "${INPUT_MULTISIG}" == "true" ]] && selected+=(miden-multisig-client)
+              if [[ "${INPUT_DRY_RUN}" == "true" ]]; then
+                mode=dry_run
+              else
+                mode=publish
+              fi
+              ;;
+            *)
+              echo "Unsupported event: ${EVENT_NAME}" >&2
+              exit 1
+              ;;
+          esac
+
+          if (( ${#selected[@]} == 0 )); then
+            echo "Select at least one Rust crate." >&2
+            exit 1
+          fi
+
+          selected_json="$(printf '%s\n' "${selected[@]}" | jq -R . | jq -sc .)"
+          {
+            echo "trigger=${trigger}"
+            echo "mode=${mode}"
+            echo "source_ref=${source_ref}"
+            echo "source_sha=${SOURCE_SHA}"
+            echo "selected=${selected_json}"
+          } >> "${GITHUB_OUTPUT}"
+
+          {
+            echo "## Rust crate publication request"
+            echo
+            echo "- Trigger: \`${trigger}\`"
+            echo "- Mode: \`${mode}\`"
+            echo "- Source: \`${source_ref}\`"
+            echo "- Commit: \`${SOURCE_SHA}\`"
+            echo "- Selected: \`$(jq -r 'join(", ")' <<<"${selected_json}")\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  validate:
+    needs: prepare
+    runs-on: ubuntu-latest
+    outputs:
+      source_sha: ${{ steps.metadata.outputs.source_sha }}
+      version: ${{ steps.metadata.outputs.version }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout source
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ needs.prepare.outputs.source_sha }}
+          persist-credentials: false
+
+      - name: Install Rust 1.93.0
+        run: |
+          rustup toolchain install 1.93.0 --profile minimal
+          rustup default 1.93.0
+
+      - name: Install packaging prerequisites
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libpq-dev
+
+      - name: Validate coordinated version
+        id: metadata
+        env:
+          EXPECTED_SHA: ${{ needs.prepare.outputs.source_sha }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RUN_TRIGGER: ${{ needs.prepare.outputs.trigger }}
+        run: |
+          set -euo pipefail
+          actual_sha="$(git rev-parse HEAD)"
+          [[ "${actual_sha}" == "${EXPECTED_SHA}" ]] || {
+            echo "Checked out ${actual_sha}, expected ${EXPECTED_SHA}." >&2
+            exit 1
+          }
+
+          metadata="$(cargo metadata --format-version 1 --no-deps --locked)"
+          crates=(
+            guardian-shared
+            guardian-client
+            miden-confidential-contracts
+            miden-multisig-client
+          )
+          version=
+          for crate in "${crates[@]}"; do
+            crate_version="$(jq -er --arg crate "${crate}" \
+              '.packages[] | select(.name == $crate) | .version' <<<"${metadata}")"
+            if [[ -z "${version}" ]]; then
+              version="${crate_version}"
+            elif [[ "${crate_version}" != "${version}" ]]; then
+              echo "${crate} is ${crate_version}; expected coordinated version ${version}." >&2
+              exit 1
+            fi
+          done
+
+          if [[ "${version}" == *+* ]]; then
+            echo "Build metadata is not supported in release versions." >&2
+            exit 1
+          fi
+          if [[ "${RUN_TRIGGER}" == "release" && "${RELEASE_TAG}" != "v${version}" ]]; then
+            echo "Release tag ${RELEASE_TAG} does not match v${version}." >&2
+            exit 1
+          fi
+
+          {
+            echo "source_sha=${actual_sha}"
+            echo "version=${version}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Test selected crates
+        if: needs.prepare.outputs.trigger != 'pull_request'
+        env:
+          SELECTED: ${{ needs.prepare.outputs.selected }}
+        run: |
+          set -euo pipefail
+          args=(test --locked)
+          while IFS= read -r crate; do
+            args+=(-p "${crate}")
+          done < <(jq -r '.[]' <<<"${SELECTED}")
+          cargo "${args[@]}"
+
+      - name: Dry-run selected crates
+        env:
+          SELECTED: ${{ needs.prepare.outputs.selected }}
+        run: |
+          set -euo pipefail
+          args=(publish --dry-run --locked)
+          while IFS= read -r crate; do
+            args+=(-p "${crate}")
+          done < <(jq -r '.[]' <<<"${SELECTED}")
+          cargo "${args[@]}"
+
+      - name: Summarize validation
+        if: always()
+        env:
+          MODE: ${{ needs.prepare.outputs.mode }}
+          SELECTED: ${{ needs.prepare.outputs.selected }}
+          STATUS: ${{ job.status }}
+          VERSION: ${{ steps.metadata.outputs.version }}
+        run: |
+          {
+            echo "## Rust crate validation"
+            echo
+            echo "- Mode: \`${MODE}\`"
+            echo "- Version: \`${VERSION:-unknown}\`"
+            echo "- Authentication: \`none\`"
+            echo "- Selected: \`$(jq -r 'join(", ")' <<<"${SELECTED}")\`"
+            echo "- Result: \`${STATUS}\`"
+            echo
+            echo "| Crate | Validation |"
+            echo "|---|---|"
+            while IFS= read -r crate; do
+              echo "| \`${crate}\` | \`${STATUS}\` |"
+            done < <(jq -r '.[]' <<<"${SELECTED}")
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  publish:
+    needs: [prepare, validate]
+    if: >-
+      needs.validate.result == 'success' &&
+      needs.prepare.outputs.mode == 'publish' &&
+      github.repository == 'OpenZeppelin/guardian'
+    runs-on: ubuntu-latest
+    environment: release
+    concurrency:
+      group: publish-rust-crates
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout approved source
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ needs.validate.outputs.source_sha }}
+          persist-credentials: false
+
+      - name: Install Rust 1.93.0
+        run: |
+          rustup toolchain install 1.93.0 --profile minimal
+          rustup default 1.93.0
+
+      - name: Install packaging prerequisites
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libpq-dev
+
+      - name: Skip versions already on crates.io
+        id: preflight
+        env:
+          EXPECTED_SHA: ${{ needs.validate.outputs.source_sha }}
+          SELECTED: ${{ needs.prepare.outputs.selected }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          set -euo pipefail
+          [[ "$(git rev-parse HEAD)" == "${EXPECTED_SHA}" ]] || {
+            echo "Approved source SHA changed." >&2
+            exit 1
+          }
+
+          packages=()
+          while IFS= read -r crate; do
+            status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
+              --connect-timeout 5 --max-time 15 --retry 2 --retry-all-errors \
+              --user-agent "guardian-publish-crates/${GITHUB_RUN_ID}" \
+              "https://crates.io/api/v1/crates/${crate}/${VERSION}")"
+            case "${status}" in
+              200)
+                echo "${crate}@${VERSION} is already published; skipping."
+                ;;
+              404)
+                packages+=("${crate}")
+                ;;
+              *)
+                echo "Could not determine crates.io state for ${crate}@${VERSION} (HTTP ${status})." >&2
+                exit 1
+                ;;
+            esac
+          done < <(jq -r '.[]' <<<"${SELECTED}")
+
+          packages_json='[]'
+          if (( ${#packages[@]} > 0 )); then
+            packages_json="$(printf '%s\n' "${packages[@]}" | jq -R . | jq -sc .)"
+          fi
+          {
+            echo "packages=${packages_json}"
+            echo "has_packages=$(( ${#packages[@]} > 0 ))"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Authenticate with crates.io trusted publishing
+        id: auth
+        if: steps.preflight.outputs.has_packages == '1'
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+
+      - name: Publish selected crates
+        id: publish
+        if: steps.preflight.outputs.has_packages == '1'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+          PACKAGES: ${{ steps.preflight.outputs.packages }}
+        run: |
+          set -euo pipefail
+          args=(publish --locked)
+          while IFS= read -r crate; do
+            args+=(-p "${crate}")
+          done < <(jq -r '.[]' <<<"${PACKAGES}")
+          cargo "${args[@]}"
+
+      - name: Summarize publication
+        if: always()
+        env:
+          AUTH_OUTCOME: ${{ steps.auth.outcome }}
+          PACKAGES: ${{ steps.preflight.outputs.packages }}
+          PREFLIGHT_OUTCOME: ${{ steps.preflight.outcome }}
+          PUBLISH_OUTCOME: ${{ steps.publish.outcome }}
+          REPOSITORY: ${{ github.repository }}
+          SELECTED: ${{ needs.prepare.outputs.selected }}
+          SOURCE_REF: ${{ needs.prepare.outputs.source_ref }}
+          SOURCE_SHA: ${{ needs.validate.outputs.source_sha }}
+          STATUS: ${{ job.status }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          authentication=none
+          if jq -e 'length > 0' <<<"${PACKAGES:-[]}" >/dev/null; then
+            authentication=trusted-publishing
+          fi
+
+          {
+            echo "## Rust crate publication"
+            echo
+            echo "- Source: \`${SOURCE_REF}\` at [\`${SOURCE_SHA}\`](https://github.com/${REPOSITORY}/commit/${SOURCE_SHA})"
+            echo "- Version: \`${VERSION}\`"
+            echo "- Authentication: \`${authentication}\`"
+            echo "- Selected: \`$(jq -r 'join(", ")' <<<"${SELECTED}")\`"
+            echo "- Attempted: \`$(jq -r 'if length == 0 then "none" else join(", ") end' <<<"${PACKAGES:-[]}")\`"
+            echo "- Registry preflight: \`${PREFLIGHT_OUTCOME}\`"
+            echo "- Publish: \`${PUBLISH_OUTCOME}\`"
+            echo "- Result: \`${STATUS}\`"
+            echo
+            echo "| Crate | Outcome |"
+            echo "|---|---|"
+            while IFS= read -r crate; do
+              if [[ "${PREFLIGHT_OUTCOME}" != "success" ]]; then
+                outcome=registry_check_failed
+              elif jq -e --arg crate "${crate}" 'index($crate) != null' \
+                <<<"${PACKAGES:-[]}" >/dev/null; then
+                if [[ "${AUTH_OUTCOME}" == "failure" ]]; then
+                  outcome=authentication_failed
+                elif [[ "${PUBLISH_OUTCOME}" == "success" ]]; then
+                  outcome=published
+                elif [[ "${PUBLISH_OUTCOME}" == "failure" ]]; then
+                  outcome=attempted_check_registry
+                else
+                  outcome=not_attempted
+                fi
+              else
+                outcome=already_published
+              fi
+              echo "| \`${crate}\` | \`${outcome}\` |"
+            done < <(jq -r '.[]' <<<"${SELECTED}")
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/docs/MULTISIG_SDK.md
+++ b/docs/MULTISIG_SDK.md
@@ -1004,6 +1004,7 @@ cargo test --locked \
 cd packages/guardian-client && npm test
 cd packages/guardian-evm-client && npm test
 cd packages/miden-multisig-client && npm test
+cd packages/guardian-operator-client && npm test
 ```
 
 2. TypeScript packages build cleanly:
@@ -1012,6 +1013,7 @@ cd packages/miden-multisig-client && npm test
 cd packages/guardian-client && npm run build
 cd packages/guardian-evm-client && npm run build
 cd packages/miden-multisig-client && npm run build
+cd packages/guardian-operator-client && npm run build
 ```
 
 3. Version numbers are updated in all files (see below).
@@ -1039,6 +1041,7 @@ Update the version in these files:
 | `packages/guardian-client/package.json` | `version` | - |
 | `packages/guardian-evm-client/package.json` | `version` | - |
 | `packages/miden-multisig-client/package.json` | `version` + `@openzeppelin/guardian-client` dep version | - |
+| `packages/guardian-operator-client/package.json` | `version` | - |
 
 The `server`, `miden-rpc-client`, `miden-keystore`, and example crates have their own independent versions and are not published.
 
@@ -1094,6 +1097,7 @@ Publish in dependency order:
 cd packages/guardian-client && npm run build
 cd packages/guardian-evm-client && npm run build
 cd packages/miden-multisig-client && npm run build
+cd packages/guardian-operator-client && npm run build
 
 # 2. Publish base clients first (no internal deps)
 cd packages/guardian-client && npm publish --access public
@@ -1101,6 +1105,9 @@ cd packages/guardian-evm-client && npm publish --access public
 
 # 3. Publish miden-multisig-client (depends on guardian-client)
 cd packages/miden-multisig-client && npm publish --access public
+
+# 4. Publish operator-client (no internal dependencies)
+cd packages/guardian-operator-client && npm publish --access public
 ```
 
 ### Post-Release
@@ -1108,14 +1115,14 @@ cd packages/miden-multisig-client && npm publish --access public
 1. Create a draft GitHub Release for review:
 
 ```bash
-gh release create v0.16.1 --generate-notes --draft
+gh release create v<version> --generate-notes --draft
 ```
 
 2. Publish the draft when the coordinated Rust, TypeScript, and server-image
    release workflows should start:
 
 ```bash
-gh release edit v0.16.1 --draft=false
+gh release edit v<version> --draft=false
 ```
 
 3. Approve the `release` environment jobs that should publish. The Rust

--- a/docs/MULTISIG_SDK.md
+++ b/docs/MULTISIG_SDK.md
@@ -994,8 +994,11 @@ Steps for publishing a new version of the SDK (Rust crates + TypeScript packages
 
 ```bash
 # Rust
-cargo test -p guardian-shared
-cargo test -p guardian-server --lib
+cargo test --locked \
+  -p guardian-shared \
+  -p guardian-client \
+  -p miden-confidential-contracts \
+  -p miden-multisig-client
 
 # TypeScript
 cd packages/guardian-client && npm test
@@ -1012,6 +1015,16 @@ cd packages/miden-multisig-client && npm run build
 ```
 
 3. Version numbers are updated in all files (see below).
+
+4. The coordinated Rust publication archive passes:
+
+```bash
+cargo publish --dry-run --locked \
+  -p guardian-shared \
+  -p guardian-client \
+  -p miden-confidential-contracts \
+  -p miden-multisig-client
+```
 
 ### Version Bump
 
@@ -1031,21 +1044,46 @@ The `server`, `miden-rpc-client`, `miden-keystore`, and example crates have thei
 
 ### Publishing Rust Crates
 
-Publish in dependency order (leaves first). Each crate must be available on crates.io before its dependents can be published.
+Rust crates are published by the
+[`Publish Rust Crates`](../.github/workflows/publish-crates.yml) workflow.
+Publishing a GitHub Release automatically selects all four crates, validates
+that the tag is `v` followed by their coordinated version, requests one
+`release` environment approval, and uses crates.io trusted publishing. Cargo
+receives all selected packages in one command and handles dependency-safe
+publication.
 
-```bash
-# 1. No internal deps
-cargo publish -p guardian-shared
+Configure a crates.io trusted publisher for each crate before the first
+automated publication:
 
-# 2. Depends on shared
-cargo publish -p guardian-client
-cargo publish -p miden-confidential-contracts
-
-# 3. Depends on shared + client + contracts
-cargo publish -p miden-multisig-client
+```text
+GitHub owner: OpenZeppelin
+Repository: guardian
+Workflow: publish-crates.yml
+Environment: release
 ```
 
-Wait for each step to finish before proceeding to the next (crates.io index needs to update).
+Use a manual dry run to validate one or more selected crates without requesting
+approval or credentials:
+
+```bash
+gh workflow run publish-crates.yml \
+  --ref main \
+  -f dry-run=true \
+  -f guardian-shared=true \
+  -f guardian-client=true \
+  -f miden-confidential-contracts=true \
+  -f miden-multisig-client=true
+```
+
+A manual run with `dry-run=false` publishes only the selected crates after one
+approval. If an unselected internal prerequisite is not already visible at the
+exact coordinated version, validation fails before publication.
+
+Publication is rerunnable. Exact versions already on crates.io are reported as
+already published and omitted from the Cargo command. If a publication is
+interrupted, rerun it; the preflight skips versions that reached crates.io and
+Cargo processes the remainder. Trusted-publishing failure fails closed; the
+workflow has no registry-token fallback.
 
 ### Publishing TypeScript Packages
 
@@ -1067,14 +1105,22 @@ cd packages/miden-multisig-client && npm publish --access public
 
 ### Post-Release
 
-1. Tag the release:
+1. Create a draft GitHub Release for review:
 
 ```bash
-git tag v0.15.1
-git push origin v0.15.1
+gh release create v0.16.1 --generate-notes --draft
 ```
 
-2. Create a GitHub release from the tag with release notes.
+2. Publish the draft when the coordinated Rust, TypeScript, and server-image
+   release workflows should start:
+
+```bash
+gh release edit v0.16.1 --draft=false
+```
+
+3. Approve the `release` environment jobs that should publish. The Rust
+   workflow summary records the source SHA, coordinated version,
+   authentication mode, and ordered per-crate outcomes without credentials.
 
 ---
 


### PR DESCRIPTION
This PR will add GH workflow to publish rust crates.

NOTE: Trusted publishing needs to be configured once PR approved/merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added coordinated automation for publishing Rust packages, including validation, version checks, dependency-safe ordering, and optional dry runs.
  - Release publishing now supports approved artifact workflows across Rust, npm, and Docker.

- **Documentation**
  - Updated release guidance with clearer pre-release checks, trusted publishing requirements, manual dry-run instructions, and approval steps.
  - Simplified Rust testing and publication procedures using locked, workspace-wide commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->