### PR TITLE
feat: SDK note export/import and demo flow for out-of-band private note transfer (#356)

### DIFF
--- a/.agents/skills/smoke-test-rust-multisig-sdk/references/workflow-matrix.md
+++ b/.agents/skills/smoke-test-rust-multisig-sdk/references/workflow-matrix.md
@@ -191,7 +191,7 @@ Steps:
 5. In tab B, sync, then open `[4] Proposal management -> [1] Create proposal -> [4] Consume notes` and confirm the private note is NOT listed (only its commitment is on chain).
 6. In the consume flow, enter `i` (or choose `[2] Import a note file` from the empty-notes menu) and give the exported file's path. The demo imports the note and syncs automatically.
 7. Select the imported note and create the consume-notes proposal in tab B.
-8. In tab A, sign the consume-notes proposal.
+8. In tab A, sync until the private note shows as consumable there too, then sign the consume-notes proposal. (The sender's store knows the full note and self-heals once a sync attaches the inclusion proof; a cosigner tab that never created nor imported the note must import the note file first.)
 9. Execute once signatures are sufficient, then sync both tabs.
 10. Verify the vault balance reflects the reconsumed asset.
 
@@ -209,6 +209,7 @@ Canary checks:
 - if the export offer never appears after executing a private P2ID, report that as a canary failure
 - if the private note IS visible in tab B before import, report it — the note leaked publicly and the private path is not being exercised
 - if import succeeds but the note never becomes consumable after sync, report the sync attempt count and elapsed wait
+- if signing fails with `metadata does not match tx_summary`, the signer's store does not yet hold the note with its inclusion proof — sync (or import the note file) until the note lists as consumable and retry; report it as a failure only if it persists after that
 - if consume execution fails with a note-binding or missing-note error, report it with the exact message
 - record elapsed time for P2ID execute, note export, note import, first consumability after import, and consume execute
 

--- a/.agents/skills/smoke-test-rust-multisig-sdk/references/workflow-matrix.md
+++ b/.agents/skills/smoke-test-rust-multisig-sdk/references/workflow-matrix.md
@@ -170,6 +170,48 @@ Canary checks:
 - if the self-P2ID executes but no received note appears after final sync, report that as a failure
 - record elapsed time for faucet PoW, faucet mint response, first note visibility, consume execute, P2ID execute, and final note visibility
 
+## `private-note-roundtrip-canary`
+
+Use when:
+
+- private P2ID note behavior or note export/import changed (issues #322, #356)
+- the demo's post-execution note-export offer or consume-flow note import changed
+- the prompt asks to validate out-of-band note transfer or private note consumption
+
+Setup:
+
+1. Run the `payment-roundtrip-canary` setup through vault funding: two demo tabs A and B on one 2-of-2 multisig, faucet receipt consumed so the vault holds an asset.
+
+Steps:
+
+1. In tab A, create a `Transfer assets (P2ID)` proposal to the same multisig `Account ID`, choosing `private` at the `Note visibility` prompt.
+2. In tab B, sign the proposal.
+3. In tab A, execute the proposal. After execution the demo announces the created PRIVATE note and prompts `Export the note file now? [Y/n]`.
+4. Accept the export and record the printed note ID and file path (default `note_<id>.mno` in the demo's working directory).
+5. In tab B, sync, then open `[4] Proposal management -> [1] Create proposal -> [4] Consume notes` and confirm the private note is NOT listed (only its commitment is on chain).
+6. In the consume flow, enter `i` (or choose `[2] Import a note file` from the empty-notes menu) and give the exported file's path. The demo imports the note and syncs automatically.
+7. Select the imported note and create the consume-notes proposal in tab B.
+8. In tab A, sign the consume-notes proposal.
+9. Execute once signatures are sufficient, then sync both tabs.
+10. Verify the vault balance reflects the reconsumed asset.
+
+Expect:
+
+- the P2ID proposal reports `Note: private` before confirmation
+- execution succeeds and the demo offers the note-file export with the note ID
+- the exported file is created at the chosen path
+- before import, tab B's consume flow cannot see the private note
+- after import + sync, the note is listed as consumable in tab B
+- the consume-notes proposal over the imported note signs and executes normally
+
+Canary checks:
+
+- if the export offer never appears after executing a private P2ID, report that as a canary failure
+- if the private note IS visible in tab B before import, report it — the note leaked publicly and the private path is not being exercised
+- if import succeeds but the note never becomes consumable after sync, report the sync attempt count and elapsed wait
+- if consume execution fails with a note-binding or missing-note error, report it with the exact message
+- record elapsed time for P2ID execute, note export, note import, first consumability after import, and consume execute
+
 ## `switch-guardian-offline-canary`
 
 Use when:
@@ -329,6 +371,8 @@ Prefer `Switch GUARDIAN provider`, `Add cosigner`, or threshold updates when the
 Use `add-cosigner-canary` as the first online workflow unless the prompt explicitly asks for another proposal type.
 
 Use `payment-roundtrip-canary` when the prompt specifically asks for public note receipt, consume-notes, or P2ID payment validation.
+
+Use `private-note-roundtrip-canary` when the prompt specifically asks for private notes, note export/import, or out-of-band note transfer validation.
 
 Use `switch-guardian-offline-canary` when the prompt specifically asks for provider migration, offline `Switch GUARDIAN`, or verifying failover from a dead GUARDIAN instance.
 

--- a/.agents/skills/smoke-test-ts-multisig-sdk/references/workflow-matrix.md
+++ b/.agents/skills/smoke-test-ts-multisig-sdk/references/workflow-matrix.md
@@ -254,8 +254,9 @@ Steps:
    const imported = await window.smoke.importNote({ noteFileBase64 });
    ```
    `importNote` syncs afterwards; the note should appear in `imported.status.consumableNotes`.
-7. In B, create a consume-notes proposal with the imported note ID; sign it in A; execute.
-8. Sync both browsers and verify the vault balance reflects the reconsumed asset.
+7. In B, create a consume-notes proposal with the imported note ID.
+8. In A, `sync()` until the note appears in `listConsumableNotes()` there too, then sign the proposal. (The sender's store knows the full note and self-heals once a sync attaches the inclusion proof; a cosigner browser that never created nor imported the note must `importNote` first.)
+9. Execute, sync both browsers, and verify the vault balance reflects the reconsumed asset.
 
 Expect:
 
@@ -270,6 +271,7 @@ Canary checks:
 - if the private note IS visible in B before import, report it — the note leaked publicly and the private path is not being exercised
 - if `exportNote` fails with a not-found error in A after execution, report it with the exact message
 - if import succeeds but the note never becomes consumable after sync, report the sync attempt count and elapsed wait
+- if signing fails with `metadata does not match tx_summary`, the signer's store does not yet hold the note with its inclusion proof — sync (or `importNote`) until the note lists as consumable and retry; report it as a failure only if it persists after that
 - if consume execution fails with a note-binding or missing-note error, report it with the exact message
 - record elapsed time for P2ID execute, export, import, first consumability after import, and consume execute
 

--- a/.agents/skills/smoke-test-ts-multisig-sdk/references/workflow-matrix.md
+++ b/.agents/skills/smoke-test-ts-multisig-sdk/references/workflow-matrix.md
@@ -213,6 +213,66 @@ Canary checks:
 - if consume executes but the vault remains empty, mark the canary failed
 - if self-P2ID executes but no new note appears after final sync, mark the canary failed
 
+## `private-note-roundtrip-canary`
+
+Use when:
+
+- private P2ID note behavior or note export/import changed (issues #322, #356)
+- `exportNote` / `importNote` / `getP2idNoteId` harness commands changed
+- the prompt asks to validate out-of-band note transfer or private note consumption
+
+Setup:
+
+1. Run the `payment-roundtrip-canary` setup through vault funding: browsers A and B on one 2-of-2 account, faucet receipt consumed so the vault holds an asset.
+
+Steps:
+
+1. In A, create a self-addressed **private** P2ID proposal:
+   ```js
+   const { detectedConfig, multisig } = await window.smoke.status();
+   const asset = detectedConfig.vaultBalances[0];
+   const payment = await window.smoke.createProposal({
+     type: 'p2id',
+     recipientId: multisig.accountId,
+     faucetId: asset.faucetId,
+     amount: asset.amount,
+     noteType: 'private',
+   });
+   ```
+2. Still in A, resolve the note ID **before executing** (it derives from the pre-execution vault state):
+   ```js
+   const { noteId } = await window.smoke.getP2idNoteId({ proposalId: payment.proposal.id });
+   ```
+3. In B, sign the proposal. In A, execute it.
+4. In B, `sync()` and confirm `listConsumableNotes()` does NOT show the private note (only its commitment is on chain; B has a separate local store).
+5. In A, export the note file:
+   ```js
+   const { noteFileBase64 } = await window.smoke.exportNote({ noteId });
+   ```
+6. Hand the base64 string to B out-of-band (copy between consoles) and import it there:
+   ```js
+   const imported = await window.smoke.importNote({ noteFileBase64 });
+   ```
+   `importNote` syncs afterwards; the note should appear in `imported.status.consumableNotes`.
+7. In B, create a consume-notes proposal with the imported note ID; sign it in A; execute.
+8. Sync both browsers and verify the vault balance reflects the reconsumed asset.
+
+Expect:
+
+- the proposal metadata carries `noteType: 'private'`
+- `getP2idNoteId` returns the same ID the export later resolves
+- before import, B cannot see the private note via sync
+- `exportNote` returns non-empty base64 and `importNote` in B returns the note ID
+- after import, the note is consumable in B and the consume proposal executes normally
+
+Canary checks:
+
+- if the private note IS visible in B before import, report it — the note leaked publicly and the private path is not being exercised
+- if `exportNote` fails with a not-found error in A after execution, report it with the exact message
+- if import succeeds but the note never becomes consumable after sync, report the sync attempt count and elapsed wait
+- if consume execution fails with a note-binding or missing-note error, report it with the exact message
+- record elapsed time for P2ID execute, export, import, first consumability after import, and consume execute
+
 ## `switch-guardian-offline-canary`
 
 Use when:

--- a/crates/miden-multisig-client/Cargo.toml
+++ b/crates/miden-multisig-client/Cargo.toml
@@ -23,7 +23,7 @@ miden-tx = { workspace = true }
 miden-standards = { workspace = true }
 
 # Async
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["fs", "macros", "rt-multi-thread"] }
 futures = { workspace = true }
 
 # Serialization

--- a/crates/miden-multisig-client/src/client/io.rs
+++ b/crates/miden-multisig-client/src/client/io.rs
@@ -157,16 +157,18 @@ impl MultisigClient {
     ///
     /// A private note publishes only its commitment on chain, so the recipient
     /// can never learn its contents via sync; the sender must hand them the
-    /// note file produced here, which they load with [`Self::import_note`].
+    /// note file produced here, which they load with
+    /// [`Self::import_note_from_file`].
     ///
     /// # Example
     ///
     /// ```ignore
-    /// client.export_note(&note_id_hex, Path::new("note.mno")).await?;
+    /// client.export_note_to_file(&note_id_hex, Path::new("note.mno")).await?;
     /// ```
-    pub async fn export_note(&self, note_id: &str, path: &std::path::Path) -> Result<()> {
+    pub async fn export_note_to_file(&self, note_id: &str, path: &std::path::Path) -> Result<()> {
         let bytes = self.export_note_to_bytes(note_id).await?;
-        std::fs::write(path, bytes)
+        tokio::fs::write(path, bytes)
+            .await
             .map_err(|e| MultisigError::InvalidConfig(format!("failed to write file: {}", e)))?;
         Ok(())
     }
@@ -220,18 +222,20 @@ impl MultisigClient {
     /// # Example
     ///
     /// ```ignore
-    /// let note_id = client.import_note(Path::new("note.mno")).await?;
+    /// let note_id = client.import_note_from_file(Path::new("note.mno")).await?;
     /// client.sync().await?;
     /// ```
-    pub async fn import_note(&mut self, path: &std::path::Path) -> Result<String> {
-        let bytes = std::fs::read(path)
+    pub async fn import_note_from_file(&mut self, path: &std::path::Path) -> Result<String> {
+        let bytes = tokio::fs::read(path)
+            .await
             .map_err(|e| MultisigError::InvalidConfig(format!("failed to read file: {}", e)))?;
         self.import_note_from_bytes(&bytes).await
     }
 
     /// Imports a note from serialized `NoteFile` bytes (issue #356).
     ///
-    /// See [`Self::import_note`] for the returned identifier semantics.
+    /// See [`Self::import_note_from_file`] for the returned identifier
+    /// semantics.
     pub async fn import_note_from_bytes(&mut self, bytes: &[u8]) -> Result<String> {
         let note_file = NoteFile::read_from_bytes(bytes).map_err(|e| {
             MultisigError::InvalidConfig(format!("failed to decode note file: {}", e))

--- a/crates/miden-multisig-client/src/client/io.rs
+++ b/crates/miden-multisig-client/src/client/io.rs
@@ -1,10 +1,16 @@
 //! Export/import operations for MultisigClient.
 //!
 //! This module handles exporting proposals to files/strings and
-//! importing them back for offline sharing workflows.
+//! importing them back for offline sharing workflows, as well as
+//! exporting/importing note files for out-of-band note transfer
+//! (issue #356).
 
 use guardian_client::delta_status::Status;
 use guardian_shared::SignatureScheme;
+use miden_client::note::NoteFile;
+use miden_client::store::NoteExportType;
+use miden_protocol::note::NoteId;
+use miden_protocol::utils::serde::{Deserializable, Serializable};
 
 use super::MultisigClient;
 use crate::error::{MultisigError, Result};
@@ -144,5 +150,187 @@ impl MultisigClient {
         self.verify_proposal_summary_binding(&proposal).await?;
 
         Ok(exported)
+    }
+
+    /// Exports a note created by this account to a file for out-of-band
+    /// delivery (issue #356).
+    ///
+    /// A private note publishes only its commitment on chain, so the recipient
+    /// can never learn its contents via sync; the sender must hand them the
+    /// note file produced here, which they load with [`Self::import_note`].
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// client.export_note(&note_id_hex, Path::new("note.mno")).await?;
+    /// ```
+    pub async fn export_note(&self, note_id: &str, path: &std::path::Path) -> Result<()> {
+        let bytes = self.export_note_to_bytes(note_id).await?;
+        std::fs::write(path, bytes)
+            .map_err(|e| MultisigError::InvalidConfig(format!("failed to write file: {}", e)))?;
+        Ok(())
+    }
+
+    /// Exports a note created by this account to serialized `NoteFile` bytes
+    /// for programmatic out-of-band delivery (issue #356).
+    ///
+    /// The note must be an output note of this client (i.e. created by a
+    /// transaction this client executed). When the note's on-chain inclusion
+    /// proof is already known (after a post-commit sync) the full note with
+    /// proof is exported; otherwise the note details are exported and the
+    /// importer's client tracks the note until it commits on chain.
+    pub async fn export_note_to_bytes(&self, note_id: &str) -> Result<Vec<u8>> {
+        let note_id = NoteId::try_from_hex(note_id.trim())
+            .map_err(|e| MultisigError::InvalidConfig(format!("invalid note id: {}", e)))?;
+
+        let record = self
+            .miden_client
+            .get_output_note(note_id)
+            .await
+            .map_err(|e| MultisigError::MidenClient(format!("failed to get output note: {}", e)))?
+            .ok_or_else(|| {
+                MultisigError::MidenClient(format!(
+                    "output note {} not found in the local store; only notes created by \
+                     this client can be exported",
+                    note_id.to_hex()
+                ))
+            })?;
+
+        let export_type = if record.inclusion_proof().is_some() {
+            NoteExportType::NoteWithProof
+        } else {
+            NoteExportType::NoteDetails
+        };
+
+        let note_file = record.into_note_file(&export_type).map_err(|e| {
+            MultisigError::MidenClient(format!("failed to convert note for export: {}", e))
+        })?;
+
+        Ok(note_file.to_bytes())
+    }
+
+    /// Imports a note file received out-of-band (issue #356) so the note can
+    /// be consumed by this account.
+    ///
+    /// Returns the note ID when the file carries one (full note with proof or
+    /// ID-only file), or the note's details commitment for a details-only
+    /// file. Sync afterwards so the note's on-chain commitment is tracked and
+    /// the note shows up in [`Self::list_consumable_notes`].
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let note_id = client.import_note(Path::new("note.mno")).await?;
+    /// client.sync().await?;
+    /// ```
+    pub async fn import_note(&mut self, path: &std::path::Path) -> Result<String> {
+        let bytes = std::fs::read(path)
+            .map_err(|e| MultisigError::InvalidConfig(format!("failed to read file: {}", e)))?;
+        self.import_note_from_bytes(&bytes).await
+    }
+
+    /// Imports a note from serialized `NoteFile` bytes (issue #356).
+    ///
+    /// See [`Self::import_note`] for the returned identifier semantics.
+    pub async fn import_note_from_bytes(&mut self, bytes: &[u8]) -> Result<String> {
+        let note_file = NoteFile::read_from_bytes(bytes).map_err(|e| {
+            MultisigError::InvalidConfig(format!("failed to decode note file: {}", e))
+        })?;
+
+        // A details-only file has no note ID yet; fall back to the details
+        // commitment `import_notes` reports (mirrors the web SDK behavior).
+        let known_id = note_file_note_id(&note_file);
+
+        let commitments = self
+            .miden_client
+            .import_notes(std::slice::from_ref(&note_file))
+            .await
+            .map_err(|e| MultisigError::MidenClient(format!("failed to import note: {}", e)))?;
+
+        match known_id {
+            Some(id) => Ok(id),
+            None => commitments
+                .first()
+                .map(|c| format!("0x{}", hex::encode(c.to_bytes())))
+                .ok_or_else(|| {
+                    MultisigError::MidenClient("note import reported no imported notes".to_string())
+                }),
+        }
+    }
+}
+
+/// Returns the note ID a note file resolves to, when it carries one. A
+/// details-only file has no metadata and therefore no note ID yet.
+fn note_file_note_id(note_file: &NoteFile) -> Option<String> {
+    match note_file {
+        NoteFile::NoteId(id) => Some(id.to_hex()),
+        NoteFile::NoteWithProof(note, _) => Some(note.id().to_hex()),
+        NoteFile::NoteDetails { .. } => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use miden_protocol::Word;
+    use miden_protocol::account::AccountId;
+    use miden_protocol::block::BlockNumber;
+    use miden_protocol::crypto::rand::RandomCoin;
+    use miden_protocol::note::{Note, NoteType};
+    use miden_standards::note::P2idNote;
+
+    use super::*;
+
+    fn build_test_note() -> Note {
+        let sender = AccountId::from_hex("0x7b7b7b7a7b7b7b017b7b7b7b7b7b7b").unwrap();
+        let target = AccountId::from_hex("0x1b1b1b1a1b1b1b011b1b1b1b1b1b1b").unwrap();
+        let mut rng = RandomCoin::new(Word::default());
+        P2idNote::create(
+            sender,
+            target,
+            vec![],
+            NoteType::Private,
+            Default::default(),
+            &mut rng,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn note_file_note_id_by_variant() {
+        let note = build_test_note();
+        let expected = note.id().to_hex();
+
+        // An ID-only file resolves to the note ID.
+        let id_file = NoteFile::NoteId(note.id());
+        assert_eq!(note_file_note_id(&id_file), Some(expected));
+
+        // A details-only file has no note ID yet.
+        let details_file = NoteFile::NoteDetails {
+            details: note.into(),
+            after_block_num: BlockNumber::from(0u32),
+            tag: None,
+        };
+        assert_eq!(note_file_note_id(&details_file), None);
+    }
+
+    #[test]
+    fn note_file_roundtrips_through_bytes() {
+        let note = build_test_note();
+        let file = NoteFile::NoteDetails {
+            details: note.into(),
+            after_block_num: BlockNumber::from(7u32),
+            tag: None,
+        };
+
+        let bytes = file.to_bytes();
+        let decoded = NoteFile::read_from_bytes(&bytes).unwrap();
+        match decoded {
+            NoteFile::NoteDetails {
+                after_block_num, ..
+            } => assert_eq!(after_block_num, BlockNumber::from(7u32)),
+            _ => panic!("expected details variant"),
+        }
+
+        assert!(NoteFile::read_from_bytes(b"not a note file").is_err());
     }
 }

--- a/crates/miden-multisig-client/src/client/io.rs
+++ b/crates/miden-multisig-client/src/client/io.rs
@@ -237,8 +237,6 @@ impl MultisigClient {
             MultisigError::InvalidConfig(format!("failed to decode note file: {}", e))
         })?;
 
-        // A details-only file has no note ID yet; fall back to the details
-        // commitment `import_notes` reports (mirrors the web SDK behavior).
         let known_id = note_file_note_id(&note_file);
 
         let commitments = self

--- a/crates/miden-multisig-client/src/client/notes.rs
+++ b/crates/miden-multisig-client/src/client/notes.rs
@@ -6,10 +6,13 @@
 use miden_client::note::NoteConsumptionStatus;
 use miden_protocol::account::AccountId;
 use miden_protocol::asset::Asset;
+use miden_protocol::crypto::rand::RandomCoin;
 use miden_protocol::note::NoteId;
+use miden_standards::note::P2idNote;
 
 use super::MultisigClient;
 use crate::error::{MultisigError, Result};
+use crate::proposal::{Proposal, TransactionType};
 
 /// A wrapper type for a consumable note with simplified information.
 #[derive(Debug, Clone)]
@@ -234,6 +237,48 @@ impl MultisigClient {
             .collect();
 
         Ok(filtered)
+    }
+
+    /// Computes the ID of the note a P2ID proposal will create when executed.
+    ///
+    /// The P2ID note is rebuilt deterministically from the proposal salt, so
+    /// the ID is known ahead of execution. For a private P2ID this is the ID
+    /// to pass to `export_note` after executing, so the note file can be
+    /// delivered to the recipient out-of-band (issue #356).
+    ///
+    /// Call this before executing the proposal: the asset is derived from the
+    /// current vault state, which execution itself changes.
+    pub fn p2id_note_id(&self, proposal: &Proposal) -> Result<NoteId> {
+        let account = self.require_account()?;
+        let TransactionType::P2ID {
+            recipient,
+            faucet_id,
+            amount,
+            note_type,
+        } = &proposal.transaction_type
+        else {
+            return Err(MultisigError::UnsupportedTransactionType(
+                "p2id_note_id requires a P2ID proposal".to_string(),
+            ));
+        };
+
+        let salt = proposal.metadata.salt()?;
+        let asset = crate::execution::build_transfer_asset(account.inner(), *faucet_id, *amount)?;
+
+        let mut rng = RandomCoin::new(salt);
+        let note = P2idNote::create(
+            account.id(),
+            *recipient,
+            vec![asset.into()],
+            *note_type,
+            Default::default(),
+            &mut rng,
+        )
+        .map_err(|e| {
+            MultisigError::TransactionExecution(format!("failed to build P2ID note: {}", e))
+        })?;
+
+        Ok(note.id())
     }
 }
 

--- a/crates/miden-multisig-client/src/client/notes.rs
+++ b/crates/miden-multisig-client/src/client/notes.rs
@@ -243,7 +243,7 @@ impl MultisigClient {
     ///
     /// The P2ID note is rebuilt deterministically from the proposal salt, so
     /// the ID is known ahead of execution. For a private P2ID this is the ID
-    /// to pass to `export_note` after executing, so the note file can be
+    /// to pass to `export_note_to_file` after executing, so the note file can be
     /// delivered to the recipient out-of-band (issue #356).
     ///
     /// Call this before executing the proposal: the asset is derived from the

--- a/crates/miden-multisig-client/src/client/notes.rs
+++ b/crates/miden-multisig-client/src/client/notes.rs
@@ -262,6 +262,11 @@ impl MultisigClient {
             ));
         };
 
+        if proposal.metadata.salt_hex.is_none() {
+            return Err(MultisigError::InvalidConfig(
+                "p2id_note_id requires proposal metadata with a salt".to_string(),
+            ));
+        }
         let salt = proposal.metadata.salt()?;
         let asset = crate::execution::build_transfer_asset(account.inner(), *faucet_id, *amount)?;
 

--- a/docs/MULTISIG_SDK.md
+++ b/docs/MULTISIG_SDK.md
@@ -412,6 +412,15 @@ const noteFileBytes = await multisig.exportNote(noteId);
 const importedNoteId = await multisig.importNote(noteFileBytes);
 ```
 
+> **Note:** every cosigner device that verifies or signs the consume-notes
+> proposal needs the note in its local store with the on-chain inclusion
+> proof — deliver the note file to each of them (import + sync), not just to
+> the proposer. A cosigner whose store lacks the authenticated note rebuilds
+> the transaction differently (the input-notes commitment distinguishes
+> authenticated from unauthenticated consumption) and rejects the proposal
+> with `metadata does not match tx_summary`. The sender's own device heals
+> itself: it already knows the full note, so a post-commit sync is enough.
+
 #### Consume Notes (Claim Received Funds)
 
 ```typescript
@@ -799,6 +808,15 @@ client.sync().await?;
 
 `export_note_to_bytes` / `import_note_from_bytes` are the in-memory variants
 for programmatic delivery.
+
+Every cosigner device that verifies or signs the consume-notes proposal needs
+the note in its local store with the on-chain inclusion proof — deliver the
+note file to each of them (import + sync), not just to the proposer. A
+cosigner whose store lacks the authenticated note rebuilds the transaction
+differently (the input-notes commitment distinguishes authenticated from
+unauthenticated consumption) and rejects the proposal with `metadata does not
+match tx_summary`. The sender's own device heals itself: it already knows the
+full note, so a post-commit sync is enough.
 
 ### API Reference
 

--- a/docs/MULTISIG_SDK.md
+++ b/docs/MULTISIG_SDK.md
@@ -396,20 +396,24 @@ const privateProposal = await multisig.createP2idProposal(
 > **Warning:** a `private` P2ID note publishes only its hash on chain. The
 > recipient cannot discover the note by syncing; the full note details must
 > be shared with them out-of-band before they can consume it. Use
-> `exportNote` / `importNote` for that transfer (issue #356):
+> `exportNoteToBytes` / `importNoteFromBytes` (or the browser file variants
+> `exportNoteToFile` / `importNoteFromFile`) for that transfer (issue #356):
 
 ```typescript
 // Sender: resolve the note ID BEFORE executing (it derives from the
 // pre-execution vault state), then export after execution.
 const noteId = await multisig.getP2idNoteId(privateProposal);
 // ...sign + execute the proposal...
-const noteFileBytes = await multisig.exportNote(noteId);
+const noteFileBytes = await multisig.exportNoteToBytes(noteId);
 // Deliver `noteFileBytes` to the recipient out-of-band (file, message, ...).
+// Or, in a browser, trigger a download of the note file directly:
+await multisig.exportNoteToFile(noteId);
 
-// Recipient: import the bytes, then sync so the note's on-chain commitment
-// is tracked; it then appears in getConsumableNotes() and can be consumed
-// with createConsumeNotesProposal as usual.
-const importedNoteId = await multisig.importNote(noteFileBytes);
+// Recipient: import the bytes (or a File from an <input type="file">), then
+// sync so the note's on-chain commitment is tracked; it then appears in
+// getConsumableNotes() and can be consumed with createConsumeNotesProposal
+// as usual.
+const importedNoteId = await multisig.importNoteFromBytes(noteFileBytes);
 ```
 
 > **Note:** every cosigner device that verifies or signs the consume-notes
@@ -433,8 +437,9 @@ const proposal = await multisig.createConsumeNotesProposal(noteIds);
 ```
 
 A private note received out-of-band must first be loaded with
-`importNote(noteFileBytes)` (see the P2ID section above); after a sync it
-shows up in `getConsumableNotes()` like any public note.
+`importNoteFromBytes(noteFileBytes)` or `importNoteFromFile(file)` (see the
+P2ID section above); after a sync it shows up in `getConsumableNotes()` like
+any public note.
 
 #### Add Signer
 
@@ -539,8 +544,10 @@ await multisig.executeProposal(signedProposal.id);
 | `createP2idProposal(recipient, faucet, amount, nonce?, { noteType }?)` | Create transfer proposal (`noteType`: `NoteType.Public` (default) or `NoteType.Private`) |
 | `createConsumeNotesProposal(noteIds, nonce?)` | Create note consumption proposal |
 | `getP2idNoteId(proposal)` | Compute the note ID a P2ID proposal creates (call before executing) |
-| `exportNote(noteId)` | Export a created note as note-file bytes for out-of-band delivery |
-| `importNote(noteBytes)` | Import a note file received out-of-band |
+| `exportNoteToBytes(noteId)` | Export a created note as note-file bytes for out-of-band delivery |
+| `exportNoteToFile(noteId, filename?)` | Browser-only: download the note file |
+| `importNoteFromBytes(noteBytes)` | Import a note file received out-of-band |
+| `importNoteFromFile(file)` | Import a note file from a browser `File`/`Blob` |
 | `createAddSignerProposal(commitment, nonce?, threshold?)` | Create add signer proposal |
 | `createRemoveSignerProposal(commitment, nonce?, threshold?)` | Create remove signer proposal |
 | `createChangeThresholdProposal(threshold, nonce?)` | Create threshold change proposal |
@@ -796,13 +803,13 @@ note and deliver the file out-of-band (issue #356):
 // pre-execution vault state), then export after execution.
 let note_id = client.p2id_note_id(&proposal)?;
 client.execute_proposal(&proposal.id).await?;
-client.export_note(&note_id.to_hex(), Path::new("note.mno")).await?;
+client.export_note_to_file(&note_id.to_hex(), Path::new("note.mno")).await?;
 // Deliver note.mno to the recipient out-of-band (file, message, ...).
 
 // Recipient: import the file, then sync so the note's on-chain commitment
 // is tracked; it then appears in list_consumable_notes() and can be
 // consumed with a regular consume-notes proposal.
-let imported_note_id = client.import_note(Path::new("note.mno")).await?;
+let imported_note_id = client.import_note_from_file(Path::new("note.mno")).await?;
 client.sync().await?;
 ```
 
@@ -849,8 +856,10 @@ full note, so a post-commit sync is enough.
 | `list_consumable_notes()` | List available notes |
 | `list_consumable_notes_filtered(filter)` | Filter notes |
 | `p2id_note_id(proposal)` | Compute the note ID a P2ID proposal creates (call before executing) |
-| `export_note(note_id, path)` | Export a created note to a file for out-of-band delivery |
-| `import_note(path)` | Import a note file received out-of-band |
+| `export_note_to_file(note_id, path)` | Export a created note to a file for out-of-band delivery |
+| `export_note_to_bytes(note_id)` | Export a created note as note-file bytes |
+| `import_note_from_file(path)` | Import a note file received out-of-band |
+| `import_note_from_bytes(bytes)` | Import a note from note-file bytes |
 
 #### MultisigAccount
 

--- a/docs/MULTISIG_SDK.md
+++ b/docs/MULTISIG_SDK.md
@@ -395,7 +395,22 @@ const privateProposal = await multisig.createP2idProposal(
 
 > **Warning:** a `private` P2ID note publishes only its hash on chain. The
 > recipient cannot discover the note by syncing; the full note details must
-> be shared with them out-of-band before they can consume it.
+> be shared with them out-of-band before they can consume it. Use
+> `exportNote` / `importNote` for that transfer (issue #356):
+
+```typescript
+// Sender: resolve the note ID BEFORE executing (it derives from the
+// pre-execution vault state), then export after execution.
+const noteId = await multisig.getP2idNoteId(privateProposal);
+// ...sign + execute the proposal...
+const noteFileBytes = await multisig.exportNote(noteId);
+// Deliver `noteFileBytes` to the recipient out-of-band (file, message, ...).
+
+// Recipient: import the bytes, then sync so the note's on-chain commitment
+// is tracked; it then appears in getConsumableNotes() and can be consumed
+// with createConsumeNotesProposal as usual.
+const importedNoteId = await multisig.importNote(noteFileBytes);
+```
 
 #### Consume Notes (Claim Received Funds)
 
@@ -407,6 +422,10 @@ const notes = await multisig.getConsumableNotes();
 const noteIds = notes.map(n => n.id);
 const proposal = await multisig.createConsumeNotesProposal(noteIds);
 ```
+
+A private note received out-of-band must first be loaded with
+`importNote(noteFileBytes)` (see the P2ID section above); after a sync it
+shows up in `getConsumableNotes()` like any public note.
 
 #### Add Signer
 
@@ -510,6 +529,9 @@ await multisig.executeProposal(signedProposal.id);
 | `listProposals()` | Get cached proposals |
 | `createP2idProposal(recipient, faucet, amount, nonce?, { noteType }?)` | Create transfer proposal (`noteType`: `NoteType.Public` (default) or `NoteType.Private`) |
 | `createConsumeNotesProposal(noteIds, nonce?)` | Create note consumption proposal |
+| `getP2idNoteId(proposal)` | Compute the note ID a P2ID proposal creates (call before executing) |
+| `exportNote(noteId)` | Export a created note as note-file bytes for out-of-band delivery |
+| `importNote(noteBytes)` | Import a note file received out-of-band |
 | `createAddSignerProposal(commitment, nonce?, threshold?)` | Create add signer proposal |
 | `createRemoveSignerProposal(commitment, nonce?, threshold?)` | Create remove signer proposal |
 | `createChangeThresholdProposal(threshold, nonce?)` | Create threshold change proposal |
@@ -642,8 +664,9 @@ responses, and per-account `get_state` failures are returned as errors.
 let tx = TransactionType::transfer(recipient_id, faucet_id, 1000);
 
 // P2ID Transfer with a private note (only the note hash is published on
-// chain; the recipient needs the note shared out-of-band). `NoteType` is
-// re-exported from `miden_protocol::note`.
+// chain; the recipient needs the note shared out-of-band — see
+// "Out-of-Band Note Transfer" below). `NoteType` is re-exported from
+// `miden_protocol::note`.
 let tx = TransactionType::transfer_with_note_type(
     recipient_id, faucet_id, 1000, NoteType::Private,
 );
@@ -753,6 +776,30 @@ for note in notes {
 }
 ```
 
+### Out-of-Band Note Transfer (Private Notes)
+
+A private P2ID note publishes only its commitment on chain, so the recipient's
+client can never learn the note contents via sync. The sender must export the
+note and deliver the file out-of-band (issue #356):
+
+```rust
+// Sender: resolve the note ID BEFORE executing (it derives from the
+// pre-execution vault state), then export after execution.
+let note_id = client.p2id_note_id(&proposal)?;
+client.execute_proposal(&proposal.id).await?;
+client.export_note(&note_id.to_hex(), Path::new("note.mno")).await?;
+// Deliver note.mno to the recipient out-of-band (file, message, ...).
+
+// Recipient: import the file, then sync so the note's on-chain commitment
+// is tracked; it then appears in list_consumable_notes() and can be
+// consumed with a regular consume-notes proposal.
+let imported_note_id = client.import_note(Path::new("note.mno")).await?;
+client.sync().await?;
+```
+
+`export_note_to_bytes` / `import_note_from_bytes` are the in-memory variants
+for programmatic delivery.
+
 ### API Reference
 
 #### MultisigClient
@@ -783,6 +830,9 @@ for note in notes {
 | `import_proposal(path)` | Import from file |
 | `list_consumable_notes()` | List available notes |
 | `list_consumable_notes_filtered(filter)` | Filter notes |
+| `p2id_note_id(proposal)` | Compute the note ID a P2ID proposal creates (call before executing) |
+| `export_note(note_id, path)` | Export a created note to a file for out-of-band delivery |
+| `import_note(path)` | Import a note file received out-of-band |
 
 #### MultisigAccount
 

--- a/examples/_shared/multisig-browser/package-lock.json
+++ b/examples/_shared/multisig-browser/package-lock.json
@@ -26,7 +26,7 @@
     },
     "../../../packages/guardian-client": {
       "name": "@openzeppelin/guardian-client",
-      "version": "0.15.2",
+      "version": "0.16.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.7.2",
@@ -38,13 +38,13 @@
     },
     "../../../packages/miden-multisig-client": {
       "name": "@openzeppelin/miden-multisig-client",
-      "version": "0.15.2",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
         "@miden-sdk/miden-sdk": "^0.15.8",
         "@noble/curves": "^1.9.7",
         "@noble/hashes": "^2.0.1",
-        "@openzeppelin/guardian-client": "^0.15.0"
+        "@openzeppelin/guardian-client": "^0.16.0"
       },
       "devDependencies": {
         "typescript": "^5.7.2",

--- a/examples/demo/src/actions/proposal_management.rs
+++ b/examples/demo/src/actions/proposal_management.rs
@@ -589,7 +589,7 @@ async fn offer_private_note_export(
         }
     };
     if !confirm.is_empty() && confirm.to_lowercase() != "y" {
-        print_info("Skipped. The note can be exported later with the SDK's export_note.");
+        print_info("Skipped. The note can be exported later with the SDK's export_note_to_file.");
         return;
     }
 
@@ -604,7 +604,7 @@ async fn offer_private_note_export(
     };
 
     let export_result = match state.get_client() {
-        Ok(client) => client.export_note(note_id, Path::new(&path)).await,
+        Ok(client) => client.export_note_to_file(note_id, Path::new(&path)).await,
         Err(e) => {
             print_error(&e);
             return;
@@ -635,7 +635,7 @@ async fn import_note_file(
     print_waiting("Importing note file");
     let client = state.get_client_mut()?;
     let note_id = client
-        .import_note(Path::new(&path))
+        .import_note_from_file(Path::new(&path))
         .await
         .map_err(|e| format!("Failed to import note: {}", e))?;
 
@@ -1340,7 +1340,7 @@ async fn prompt_consume_notes(
             println!("  [b] Cancel");
 
             let choice = prompt_input(editor, "\nChoice: ")?;
-            match choice.as_str() {
+            match choice.to_lowercase().as_str() {
                 "1" => {
                     print_waiting("Syncing account state from network...");
                     state
@@ -1354,7 +1354,8 @@ async fn prompt_consume_notes(
                         print_error(&e);
                     }
                 }
-                _ => return Err("No consumable notes available".to_string()),
+                "b" => return Err("Cancelled".to_string()),
+                _ => print_error("Invalid choice"),
             }
             continue;
         }

--- a/examples/demo/src/actions/proposal_management.rs
+++ b/examples/demo/src/actions/proposal_management.rs
@@ -492,7 +492,29 @@ async fn action_execute_proposal(
         return Err("Invalid selection".to_string());
     }
 
-    let proposal_id = proposals[idx - 1].id.clone();
+    let proposal = proposals[idx - 1].clone();
+    let proposal_id = proposal.id.clone();
+
+    // A private P2ID note must be handed to the recipient out-of-band (issue
+    // #356). Its ID is deterministic from the proposal salt but derives from
+    // the pre-execution vault state, so compute it before executing.
+    let private_note_id = match &proposal.transaction_type {
+        TransactionType::P2ID {
+            note_type: NoteType::Private,
+            ..
+        } => match state.get_client()?.p2id_note_id(&proposal) {
+            Ok(id) => Some(id.to_hex()),
+            Err(e) => {
+                print_info(&format!(
+                    "  Note: could not precompute the private note id ({}); \
+                     the note can still be exported later via the SDK.",
+                    e
+                ));
+                None
+            }
+        },
+        _ => None,
+    };
 
     print_waiting("Executing proposal");
 
@@ -529,6 +551,10 @@ async fn action_execute_proposal(
                 print_success("State synced successfully");
             }
 
+            if let Some(note_id) = private_note_id {
+                offer_private_note_export(state, editor, &note_id).await;
+            }
+
             Ok(())
         }
         Err(e) => {
@@ -539,6 +565,89 @@ async fn action_execute_proposal(
             Err(e)
         }
     }
+}
+
+/// Offer to export a just-created private P2ID note to a file for
+/// out-of-band delivery to the recipient (issue #356).
+///
+/// Export failure is reported but never bubbled: the transaction already
+/// executed, and the note can still be exported later via the SDK.
+async fn offer_private_note_export(
+    state: &SessionState,
+    editor: &mut DefaultEditor,
+    note_id: &str,
+) {
+    print_info("\nThis proposal created a PRIVATE note: only its commitment is on chain,");
+    print_info("so the recipient must receive the note file out-of-band to consume it.");
+    print_info(&format!("Note ID: {}", note_id));
+
+    let confirm = match prompt_input(editor, "Export the note file now? [Y/n]: ") {
+        Ok(choice) => choice,
+        Err(e) => {
+            print_error(&e);
+            return;
+        }
+    };
+    if !confirm.is_empty() && confirm.to_lowercase() != "y" {
+        print_info("Skipped. The note can be exported later with the SDK's export_note.");
+        return;
+    }
+
+    let default_path = format!("note_{}.mno", shorten_hex(note_id).replace("...", "_"));
+    let path = match prompt_input(editor, &format!("File path [{}]: ", default_path)) {
+        Ok(input) if input.is_empty() => default_path,
+        Ok(input) => input,
+        Err(e) => {
+            print_error(&e);
+            return;
+        }
+    };
+
+    let export_result = match state.get_client() {
+        Ok(client) => client.export_note(note_id, Path::new(&path)).await,
+        Err(e) => {
+            print_error(&e);
+            return;
+        }
+    };
+
+    match export_result {
+        Ok(()) => {
+            print_success(&format!("Note exported to: {}", path));
+            print_info("Share this file with the recipient; they import it in the");
+            print_info("consume-notes flow before proposing consumption.");
+        }
+        Err(e) => print_error(&format!("Failed to export note: {}", e)),
+    }
+}
+
+/// Import a note file received out-of-band (issue #356) and sync so the note
+/// becomes consumable.
+async fn import_note_file(
+    state: &mut SessionState,
+    editor: &mut DefaultEditor,
+) -> Result<(), String> {
+    let path = prompt_input(editor, "Note file path: ")?;
+    if path.is_empty() {
+        return Err("File path is required".to_string());
+    }
+
+    print_waiting("Importing note file");
+    let client = state.get_client_mut()?;
+    let note_id = client
+        .import_note(Path::new(&path))
+        .await
+        .map_err(|e| format!("Failed to import note: {}", e))?;
+
+    print_success(&format!("Note imported: {}", shorten_hex(&note_id)));
+
+    print_waiting("Syncing so the note's on-chain commitment is tracked");
+    client
+        .sync()
+        .await
+        .map_err(|e| format!("Failed to sync after import: {}", e))?;
+
+    Ok(())
 }
 
 // =============================================================================
@@ -1216,63 +1325,70 @@ async fn prompt_consume_notes(
     state: &mut SessionState,
     editor: &mut DefaultEditor,
 ) -> Result<TransactionType, String> {
-    let client = state.get_client_mut()?;
-
-    print_waiting("Fetching consumable notes...");
-    let mut notes = client
-        .list_consumable_notes()
-        .await
-        .map_err(|e| format!("Failed to list notes: {}", e))?;
-
-    if notes.is_empty() {
-        print_info("No consumable notes in local cache.");
-        let confirm = prompt_input(editor, "Sync account now and retry? [y/N]: ")?;
-        if confirm.to_lowercase() != "y" {
-            return Err("No consumable notes available".to_string());
-        }
-
-        print_waiting("Syncing account state from network...");
-        client
-            .sync()
-            .await
-            .map_err(|e| format!("Failed to sync: {}", e))?;
-
-        print_waiting("Fetching consumable notes (local cache)...");
-        notes = client
+    let (notes, selection) = loop {
+        print_waiting("Fetching consumable notes...");
+        let notes = state
+            .get_client_mut()?
             .list_consumable_notes()
             .await
             .map_err(|e| format!("Failed to list notes: {}", e))?;
 
         if notes.is_empty() {
-            return Err("No consumable notes available".to_string());
-        }
-    }
+            print_info("No consumable notes in local cache.");
+            println!("  [1] Sync account and retry");
+            println!("  [2] Import a note file received out-of-band (private notes)");
+            println!("  [b] Cancel");
 
-    println!("\nConsumable notes:");
-    for (idx, note) in notes.iter().enumerate() {
-        println!("  [{}] {}", idx + 1, shorten_hex(&note.id.to_hex()));
-
-        for asset in &note.assets {
-            match asset {
-                Asset::Fungible(f) => {
-                    println!(
-                        "      - {} tokens (faucet: {})",
-                        f.amount(),
-                        shorten_hex(&f.faucet_id().to_hex())
-                    );
+            let choice = prompt_input(editor, "\nChoice: ")?;
+            match choice.as_str() {
+                "1" => {
+                    print_waiting("Syncing account state from network...");
+                    state
+                        .get_client_mut()?
+                        .sync()
+                        .await
+                        .map_err(|e| format!("Failed to sync: {}", e))?;
                 }
-                Asset::NonFungible(nft) => {
-                    println!(
-                        "      - NFT (faucet: {})",
-                        shorten_hex(&nft.faucet_id().to_hex())
-                    );
+                "2" => import_note_file(state, editor).await?,
+                _ => return Err("No consumable notes available".to_string()),
+            }
+            continue;
+        }
+
+        println!("\nConsumable notes:");
+        for (idx, note) in notes.iter().enumerate() {
+            println!("  [{}] {}", idx + 1, shorten_hex(&note.id.to_hex()));
+
+            for asset in &note.assets {
+                match asset {
+                    Asset::Fungible(f) => {
+                        println!(
+                            "      - {} tokens (faucet: {})",
+                            f.amount(),
+                            shorten_hex(&f.faucet_id().to_hex())
+                        );
+                    }
+                    Asset::NonFungible(nft) => {
+                        println!(
+                            "      - NFT (faucet: {})",
+                            shorten_hex(&nft.faucet_id().to_hex())
+                        );
+                    }
                 }
             }
         }
-    }
 
-    print_info("\nEnter note numbers to consume (comma-separated, e.g., 1,2,3):");
-    let selection = prompt_input(editor, "  Notes: ")?;
+        print_info("\nEnter note numbers to consume (comma-separated, e.g., 1,2,3),");
+        print_info("or 'i' to import a note file received out-of-band (private notes):");
+        let selection = prompt_input(editor, "  Notes: ")?;
+
+        if selection.trim().eq_ignore_ascii_case("i") {
+            import_note_file(state, editor).await?;
+            continue;
+        }
+
+        break (notes, selection);
+    };
 
     let indices: Vec<usize> = selection
         .split(',')

--- a/examples/demo/src/actions/proposal_management.rs
+++ b/examples/demo/src/actions/proposal_management.rs
@@ -1349,7 +1349,11 @@ async fn prompt_consume_notes(
                         .await
                         .map_err(|e| format!("Failed to sync: {}", e))?;
                 }
-                "2" => import_note_file(state, editor).await?,
+                "2" => {
+                    if let Err(e) = import_note_file(state, editor).await {
+                        print_error(&e);
+                    }
+                }
                 _ => return Err("No consumable notes available".to_string()),
             }
             continue;
@@ -1383,7 +1387,9 @@ async fn prompt_consume_notes(
         let selection = prompt_input(editor, "  Notes: ")?;
 
         if selection.trim().eq_ignore_ascii_case("i") {
-            import_note_file(state, editor).await?;
+            if let Err(e) = import_note_file(state, editor).await {
+                print_error(&e);
+            }
             continue;
         }
 

--- a/examples/smoke-web/package-lock.json
+++ b/examples/smoke-web/package-lock.json
@@ -38,7 +38,7 @@
     },
     "../../packages/guardian-client": {
       "name": "@openzeppelin/guardian-client",
-      "version": "0.15.2",
+      "version": "0.16.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.7.2",
@@ -50,13 +50,13 @@
     },
     "../../packages/miden-multisig-client": {
       "name": "@openzeppelin/miden-multisig-client",
-      "version": "0.15.2",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
         "@miden-sdk/miden-sdk": "^0.15.8",
         "@noble/curves": "^1.9.7",
         "@noble/hashes": "^2.0.1",
-        "@openzeppelin/guardian-client": "^0.15.0"
+        "@openzeppelin/guardian-client": "^0.16.0"
       },
       "devDependencies": {
         "typescript": "^5.7.2",

--- a/examples/smoke-web/src/smokeHarness.ts
+++ b/examples/smoke-web/src/smokeHarness.ts
@@ -249,11 +249,12 @@ async function waitForCondition(
 }
 
 function bytesToBase64(bytes: Uint8Array): string {
-  let binary = '';
-  for (const byte of bytes) {
-    binary += String.fromCharCode(byte);
+  const chunkSize = 0x8000;
+  const chunks: string[] = [];
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    chunks.push(String.fromCharCode(...bytes.subarray(i, i + chunkSize)));
   }
-  return btoa(binary);
+  return btoa(chunks.join(''));
 }
 
 function base64ToBytes(base64: string): Uint8Array {
@@ -1308,7 +1309,7 @@ export function useSmokeHarness(): {
         }
 
         const trimmedNoteId = noteId.trim();
-        const noteFileBytes = await currentMultisig.exportNote(trimmedNoteId);
+        const noteFileBytes = await currentMultisig.exportNoteToBytes(trimmedNoteId);
         return { noteId: trimmedNoteId, noteFileBase64: bytesToBase64(noteFileBytes) };
       }),
     [multisigRef, withCommand],
@@ -1327,7 +1328,7 @@ export function useSmokeHarness(): {
           throw new Error('No multisig account is loaded');
         }
 
-        const noteId = await currentMultisig.importNote(base64ToBytes(noteFileBase64.trim()));
+        const noteId = await currentMultisig.importNoteFromBytes(base64ToBytes(noteFileBase64.trim()));
         const refreshed = await refreshMultisigState(currentMultisig);
         return {
           noteId,

--- a/examples/smoke-web/src/smokeHarness.ts
+++ b/examples/smoke-web/src/smokeHarness.ts
@@ -155,6 +155,12 @@ export interface SmokeApi {
   executeCustomProposal(input: ExecuteCustomProposalInput): Promise<BrowserSessionSnapshot>;
   signProposal(input: { proposalId: string }): Promise<Array<ReturnType<typeof serializeProposal>>>;
   executeProposal(input: { proposalId: string }): Promise<BrowserSessionSnapshot>;
+  getP2idNoteId(input: { proposalId: string }): Promise<{ noteId: string }>;
+  exportNote(input: { noteId: string }): Promise<{ noteId: string; noteFileBase64: string }>;
+  importNote(input: { noteFileBase64: string }): Promise<{
+    noteId: string;
+    status: BrowserSessionSnapshot;
+  }>;
   exportProposal(input: { proposalId: string }): Promise<{ json: string }>;
   signProposalOffline(input: SignProposalOfflineInput): Promise<{
     proposalId: string;
@@ -240,6 +246,23 @@ async function waitForCondition(
     }
     await sleep(intervalMs);
   }
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+}
+
+function base64ToBytes(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
 }
 
 async function syncBrowserClientState(client: MidenClient): Promise<void> {
@@ -1249,6 +1272,77 @@ export function useSmokeHarness(): {
     [multisigRef, withCommand],
   );
 
+  const getP2idNoteId = useCallback(
+    async ({ proposalId }: { proposalId: string }): Promise<{ noteId: string }> =>
+      withCommand('getP2idNoteId', async () => {
+        requireSessionReady();
+        const currentMultisig = multisigRef.current;
+        if (!currentMultisig) {
+          throw new Error('No multisig account is loaded');
+        }
+
+        const normalized = proposalId.trim().toLowerCase().replace(/^0x/, '');
+        const proposal = proposalsRef.current.find(
+          (candidate) => candidate.id.toLowerCase().replace(/^0x/, '') === normalized,
+        );
+        if (!proposal) {
+          throw new Error(`Proposal not found: ${proposalId}`);
+        }
+
+        return { noteId: await currentMultisig.getP2idNoteId(proposal) };
+      }),
+    [multisigRef, proposalsRef, withCommand],
+  );
+
+  const exportNote = useCallback(
+    async ({
+      noteId,
+    }: {
+      noteId: string;
+    }): Promise<{ noteId: string; noteFileBase64: string }> =>
+      withCommand('exportNote', async () => {
+        requireSessionReady();
+        const currentMultisig = multisigRef.current;
+        if (!currentMultisig) {
+          throw new Error('No multisig account is loaded');
+        }
+
+        const trimmedNoteId = noteId.trim();
+        const noteFileBytes = await currentMultisig.exportNote(trimmedNoteId);
+        return { noteId: trimmedNoteId, noteFileBase64: bytesToBase64(noteFileBytes) };
+      }),
+    [multisigRef, withCommand],
+  );
+
+  const importNote = useCallback(
+    async ({
+      noteFileBase64,
+    }: {
+      noteFileBase64: string;
+    }): Promise<{ noteId: string; status: BrowserSessionSnapshot }> =>
+      withCommand('importNote', async () => {
+        requireSessionReady();
+        const currentMultisig = multisigRef.current;
+        if (!currentMultisig) {
+          throw new Error('No multisig account is loaded');
+        }
+
+        const noteId = await currentMultisig.importNote(base64ToBytes(noteFileBase64.trim()));
+        const refreshed = await refreshMultisigState(currentMultisig);
+        return {
+          noteId,
+          status: buildCurrentSnapshot({
+            guardianState: refreshed.state,
+            detectedConfig: refreshed.config,
+            proposals: refreshed.proposals,
+            consumableNotes: refreshed.notes,
+            lastError: null,
+          }),
+        };
+      }),
+    [buildCurrentSnapshot, multisigRef, refreshMultisigState, withCommand],
+  );
+
   const signProposalOffline = useCallback(
     async (
       input: SignProposalOfflineInput,
@@ -1375,6 +1469,9 @@ export function useSmokeHarness(): {
     executeCustomProposal,
     signProposal,
     executeProposal,
+    getP2idNoteId,
+    exportNote,
+    importNote,
     exportProposal,
     signProposalOffline,
     importProposal,

--- a/packages/miden-multisig-client/src/multisig.test.ts
+++ b/packages/miden-multisig-client/src/multisig.test.ts
@@ -8,10 +8,11 @@ import {
   executeForSummary,
 } from './transaction.js';
 
-const { mockRpcGetAccountDetails, mockAccountDeserialize, mockDetectConfig } = vi.hoisted(() => ({
+const { mockRpcGetAccountDetails, mockAccountDeserialize, mockDetectConfig, mockNoteFileDeserialize } = vi.hoisted(() => ({
   mockRpcGetAccountDetails: vi.fn(),
   mockAccountDeserialize: vi.fn(),
   mockDetectConfig: vi.fn(),
+  mockNoteFileDeserialize: vi.fn(),
 }));
 
 // Mock the Miden SDK
@@ -25,6 +26,14 @@ vi.mock('@miden-sdk/miden-sdk', () => ({
   NoteType: {
     Private: 0,
     Public: 1,
+  },
+  NoteExportFormat: {
+    Id: 0,
+    Full: 1,
+    Details: 2,
+  },
+  NoteFile: {
+    deserialize: mockNoteFileDeserialize,
   },
   TransactionSummary: {
     deserialize: vi.fn().mockReturnValue({
@@ -90,6 +99,9 @@ vi.mock('./transaction.js', () => ({
   buildP2idTransactionRequest: vi.fn().mockReturnValue({
     request: {},
     salt: { toHex: () => '0x' + 'd'.repeat(64) },
+  }),
+  buildP2idNoteFromMetadata: vi.fn().mockReturnValue({
+    id: () => ({ toString: () => '0x' + 'ab'.repeat(32) }),
   }),
   // Mirrors the real implementations against the mocked NoteType values
   // (Private = 0, Public = 1).
@@ -1395,6 +1407,116 @@ describe('Multisig', () => {
 
       expect(proposal.metadata.proposalType).toBe('p2id');
       expect((proposal.metadata as { noteType?: string }).noteType).toBe('private');
+    });
+  });
+
+  describe('exportNote / importNote (issue #356)', () => {
+    const config = {
+      threshold: 1,
+      signerCommitments: ['0x' + '1'.repeat(64)],
+      guardianCommitment: '0x' + '3'.repeat(64),
+    };
+
+    it('exports the full note with proof when the inclusion proof is known', async () => {
+      const noteFile = { serialize: () => new Uint8Array([9, 9, 9]) };
+      mockWebClient.getOutputNote = vi.fn().mockResolvedValue({
+        inclusionProof: () => ({}),
+      });
+      mockWebClient.exportNoteFile = vi.fn().mockResolvedValue(noteFile);
+
+      const multisig = createTestMultisig(config);
+      const bytes = await multisig.exportNote('0x' + 'ab'.repeat(32));
+
+      expect(bytes).toEqual(new Uint8Array([9, 9, 9]));
+      // NoteExportFormat.Full = 1 in the SDK mock
+      expect(mockWebClient.exportNoteFile).toHaveBeenCalledWith('0x' + 'ab'.repeat(32), 1);
+    });
+
+    it('falls back to a details-only export before the note commits on chain', async () => {
+      const noteFile = { serialize: () => new Uint8Array([7]) };
+      mockWebClient.getOutputNote = vi.fn().mockResolvedValue({
+        inclusionProof: () => undefined,
+      });
+      mockWebClient.exportNoteFile = vi.fn().mockResolvedValue(noteFile);
+
+      const multisig = createTestMultisig(config);
+      await multisig.exportNote('0x' + 'ab'.repeat(32));
+
+      // NoteExportFormat.Details = 2 in the SDK mock
+      expect(mockWebClient.exportNoteFile).toHaveBeenCalledWith('0x' + 'ab'.repeat(32), 2);
+    });
+
+    it('rejects exporting a note the local store does not know', async () => {
+      mockWebClient.getOutputNote = vi.fn().mockRejectedValue(new Error('no such note'));
+      mockWebClient.exportNoteFile = vi.fn();
+
+      const multisig = createTestMultisig(config);
+      await expect(multisig.exportNote('0x' + 'ab'.repeat(32))).rejects.toThrow(
+        /not found in the local store/,
+      );
+      expect(mockWebClient.exportNoteFile).not.toHaveBeenCalled();
+    });
+
+    it('imports note file bytes and returns the resolved identifier', async () => {
+      const decoded = { marker: 'note-file' };
+      mockNoteFileDeserialize.mockReturnValue(decoded);
+      mockWebClient.importNoteFile = vi.fn().mockResolvedValue('0x' + 'cd'.repeat(32));
+
+      const multisig = createTestMultisig(config);
+      const noteId = await multisig.importNote(new Uint8Array([1, 2, 3]));
+
+      expect(mockNoteFileDeserialize).toHaveBeenCalledWith(new Uint8Array([1, 2, 3]));
+      expect(mockWebClient.importNoteFile).toHaveBeenCalledWith(decoded);
+      expect(noteId).toBe('0x' + 'cd'.repeat(32));
+    });
+
+    it('rejects bytes that do not decode as a note file', async () => {
+      mockNoteFileDeserialize.mockImplementation(() => {
+        throw new Error('bad bytes');
+      });
+      mockWebClient.importNoteFile = vi.fn();
+
+      const multisig = createTestMultisig(config);
+      await expect(multisig.importNote(new Uint8Array([0]))).rejects.toThrow(
+        /failed to decode note file: bad bytes/,
+      );
+      expect(mockWebClient.importNoteFile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getP2idNoteId (issue #356)', () => {
+    const config = {
+      threshold: 1,
+      signerCommitments: ['0x' + '1'.repeat(64)],
+      guardianCommitment: '0x' + '3'.repeat(64),
+    };
+
+    it('computes the deterministic note ID from p2id proposal metadata', async () => {
+      const multisig = createTestMultisig(config);
+      const proposal = {
+        metadata: {
+          proposalType: 'p2id',
+          recipientId: '0x' + 'b'.repeat(30),
+          faucetId: '0x' + 'c'.repeat(30),
+          amount: '100',
+          saltHex: '0x' + 'd'.repeat(64),
+          noteType: 'private',
+        },
+      } as any;
+
+      const noteId = await multisig.getP2idNoteId(proposal);
+      expect(noteId).toBe('0x' + 'ab'.repeat(32));
+    });
+
+    it('rejects non-p2id proposals', async () => {
+      const multisig = createTestMultisig(config);
+      const proposal = {
+        metadata: { proposalType: 'consume_notes' },
+      } as any;
+
+      await expect(multisig.getP2idNoteId(proposal)).rejects.toThrow(
+        /requires a P2ID proposal/,
+      );
     });
   });
 

--- a/packages/miden-multisig-client/src/multisig.test.ts
+++ b/packages/miden-multisig-client/src/multisig.test.ts
@@ -1410,7 +1410,7 @@ describe('Multisig', () => {
     });
   });
 
-  describe('exportNote / importNote (issue #356)', () => {
+  describe('exportNoteToBytes / importNoteFromBytes (issue #356)', () => {
     const config = {
       threshold: 1,
       signerCommitments: ['0x' + '1'.repeat(64)],
@@ -1425,7 +1425,7 @@ describe('Multisig', () => {
       mockWebClient.exportNoteFile = vi.fn().mockResolvedValue(noteFile);
 
       const multisig = createTestMultisig(config);
-      const bytes = await multisig.exportNote('0x' + 'ab'.repeat(32));
+      const bytes = await multisig.exportNoteToBytes('0x' + 'ab'.repeat(32));
 
       expect(bytes).toEqual(new Uint8Array([9, 9, 9]));
       // NoteExportFormat.Full = 1 in the SDK mock
@@ -1440,9 +1440,9 @@ describe('Multisig', () => {
       mockWebClient.exportNoteFile = vi.fn().mockResolvedValue(noteFile);
 
       const multisig = createTestMultisig(config);
-      await multisig.exportNote('0x' + 'ab'.repeat(32));
+      await multisig.exportNoteToBytes(' 0x' + 'ab'.repeat(32) + ' ');
 
-      // NoteExportFormat.Details = 2 in the SDK mock
+      // NoteExportFormat.Details = 2 in the SDK mock; the id is trimmed
       expect(mockWebClient.exportNoteFile).toHaveBeenCalledWith('0x' + 'ab'.repeat(32), 2);
     });
 
@@ -1451,7 +1451,18 @@ describe('Multisig', () => {
       mockWebClient.exportNoteFile = vi.fn();
 
       const multisig = createTestMultisig(config);
-      await expect(multisig.exportNote('0x' + 'ab'.repeat(32))).rejects.toThrow(
+      await expect(multisig.exportNoteToBytes('0x' + 'ab'.repeat(32))).rejects.toThrow(
+        /not found in the local store/,
+      );
+      expect(mockWebClient.exportNoteFile).not.toHaveBeenCalled();
+    });
+
+    it('rejects exporting when the store resolves no record', async () => {
+      mockWebClient.getOutputNote = vi.fn().mockResolvedValue(undefined);
+      mockWebClient.exportNoteFile = vi.fn();
+
+      const multisig = createTestMultisig(config);
+      await expect(multisig.exportNoteToBytes('0x' + 'ab'.repeat(32))).rejects.toThrow(
         /not found in the local store/,
       );
       expect(mockWebClient.exportNoteFile).not.toHaveBeenCalled();
@@ -1463,7 +1474,7 @@ describe('Multisig', () => {
       mockWebClient.importNoteFile = vi.fn().mockResolvedValue('0x' + 'cd'.repeat(32));
 
       const multisig = createTestMultisig(config);
-      const noteId = await multisig.importNote(new Uint8Array([1, 2, 3]));
+      const noteId = await multisig.importNoteFromBytes(new Uint8Array([1, 2, 3]));
 
       expect(mockNoteFileDeserialize).toHaveBeenCalledWith(new Uint8Array([1, 2, 3]));
       expect(mockWebClient.importNoteFile).toHaveBeenCalledWith(decoded);
@@ -1477,10 +1488,37 @@ describe('Multisig', () => {
       mockWebClient.importNoteFile = vi.fn();
 
       const multisig = createTestMultisig(config);
-      await expect(multisig.importNote(new Uint8Array([0]))).rejects.toThrow(
+      await expect(multisig.importNoteFromBytes(new Uint8Array([0]))).rejects.toThrow(
         /failed to decode note file: bad bytes/,
       );
       expect(mockWebClient.importNoteFile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('exportNoteToFile / importNoteFromFile (issue #356)', () => {
+    const config = {
+      threshold: 1,
+      signerCommitments: ['0x' + '1'.repeat(64)],
+      guardianCommitment: '0x' + '3'.repeat(64),
+    };
+
+    it('rejects exportNoteToFile outside a browser environment', async () => {
+      const multisig = createTestMultisig(config);
+      await expect(multisig.exportNoteToFile('0x' + 'ab'.repeat(32))).rejects.toThrow(
+        /requires a browser environment/,
+      );
+    });
+
+    it('imports from a File/Blob by delegating to importNoteFromBytes', async () => {
+      const decoded = { marker: 'note-file' };
+      mockNoteFileDeserialize.mockReturnValue(decoded);
+      mockWebClient.importNoteFile = vi.fn().mockResolvedValue('0x' + 'cd'.repeat(32));
+
+      const multisig = createTestMultisig(config);
+      const noteId = await multisig.importNoteFromFile(new Blob([new Uint8Array([1, 2, 3])]));
+
+      expect(mockNoteFileDeserialize).toHaveBeenCalledWith(new Uint8Array([1, 2, 3]));
+      expect(noteId).toBe('0x' + 'cd'.repeat(32));
     });
   });
 

--- a/packages/miden-multisig-client/src/multisig.ts
+++ b/packages/miden-multisig-client/src/multisig.ts
@@ -29,6 +29,8 @@ import {
   Endpoint,
   FeltArray,
   Note,
+  NoteExportFormat,
+  NoteFile,
   NoteType,
   RpcClient,
   Signature,
@@ -42,6 +44,7 @@ import {
   buildUpdateProcedureThresholdTransactionRequest,
   buildUpdateGuardianTransactionRequest,
   buildConsumeNotesTransactionRequest,
+  buildP2idNoteFromMetadata,
   buildP2idTransactionRequest,
   parseP2idNoteType,
   p2idNoteTypeToMetadata,
@@ -947,6 +950,105 @@ export class Multisig {
     }
 
     return notes;
+  }
+
+  /**
+   * Export a note created by this multisig account as serialized note-file
+   * bytes for out-of-band delivery (issue #356).
+   *
+   * A private note publishes only its commitment on chain, so the recipient
+   * can never learn its contents via sync; the sender must hand them the
+   * bytes produced here, which they load with {@link importNote}.
+   *
+   * The note must be an output note of this client (created by a transaction
+   * this client executed). When the note's on-chain inclusion proof is
+   * already known (after a post-commit sync) the full note with proof is
+   * exported; otherwise the note details are exported and the importer's
+   * client tracks the note until it commits on chain.
+   *
+   * @param noteId - ID of the note to export (hex string)
+   * @returns Serialized note file bytes
+   */
+  async exportNote(noteId: string): Promise<Uint8Array> {
+    const webClient = await this.getRawClient();
+
+    let record;
+    try {
+      record = await webClient.getOutputNote(noteId);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `Output note ${noteId} not found in the local store; only notes created by this client can be exported: ${detail}`,
+      );
+    }
+
+    const format = record?.inclusionProof()
+      ? NoteExportFormat.Full
+      : NoteExportFormat.Details;
+    const noteFile = await webClient.exportNoteFile(noteId, format);
+    return noteFile.serialize();
+  }
+
+  /**
+   * Import a note file received out-of-band (issue #356) so the note can be
+   * consumed by this multisig account.
+   *
+   * Sync the Miden client with the network afterwards so the note's on-chain
+   * commitment is tracked and the note shows up in {@link getConsumableNotes};
+   * it can then be consumed via {@link createConsumeNotesProposal}.
+   *
+   * @param noteBytes - Serialized note file bytes produced by {@link exportNote}
+   * @returns The note ID when the file carries one, or the note's details
+   *   commitment for a details-only file
+   */
+  async importNote(noteBytes: Uint8Array): Promise<string> {
+    const webClient = await this.getRawClient();
+
+    let noteFile: NoteFile;
+    try {
+      noteFile = NoteFile.deserialize(noteBytes);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      throw new Error(`failed to decode note file: ${detail}`);
+    }
+
+    return webClient.importNoteFile(noteFile);
+  }
+
+  /**
+   * Compute the ID of the note a P2ID proposal will create when executed.
+   *
+   * The P2ID note is rebuilt deterministically from the proposal salt, so the
+   * ID is known ahead of execution. For a private P2ID this is the ID to pass
+   * to {@link exportNote} after executing, so the note file can be delivered
+   * to the recipient out-of-band (issue #356).
+   *
+   * Call this before executing the proposal: the asset is derived from the
+   * current vault state, which execution itself changes.
+   */
+  async getP2idNoteId(proposal: Proposal): Promise<string> {
+    const metadata = proposal.metadata;
+    if (
+      metadata.proposalType !== 'p2id' ||
+      !metadata.recipientId ||
+      !metadata.faucetId ||
+      !metadata.amount ||
+      !metadata.saltHex
+    ) {
+      throw new Error('getP2idNoteId requires a P2ID proposal with recipient, faucet, amount, and salt metadata');
+    }
+
+    const account = await this.getStoreAccount();
+    const note = buildP2idNoteFromMetadata(
+      this._accountId,
+      metadata.recipientId,
+      metadata.faucetId,
+      BigInt(metadata.amount),
+      account,
+      parseP2idNoteType(metadata.noteType),
+      metadata.saltHex,
+    );
+    return note.id().toString();
   }
 
   /**

--- a/packages/miden-multisig-client/src/multisig.ts
+++ b/packages/miden-multisig-client/src/multisig.ts
@@ -958,7 +958,7 @@ export class Multisig {
    *
    * A private note publishes only its commitment on chain, so the recipient
    * can never learn its contents via sync; the sender must hand them the
-   * bytes produced here, which they load with {@link importNote}.
+   * bytes produced here, which they load with {@link importNoteFromBytes}.
    *
    * The note must be an output note of this client (created by a transaction
    * this client executed). When the note's on-chain inclusion proof is
@@ -969,24 +969,59 @@ export class Multisig {
    * @param noteId - ID of the note to export (hex string)
    * @returns Serialized note file bytes
    */
-  async exportNote(noteId: string): Promise<Uint8Array> {
+  async exportNoteToBytes(noteId: string): Promise<Uint8Array> {
     const webClient = await this.getRawClient();
+    const trimmedNoteId = noteId.trim();
 
     let record;
     try {
-      record = await webClient.getOutputNote(noteId);
+      record = await webClient.getOutputNote(trimmedNoteId);
     } catch (err) {
       const detail = err instanceof Error ? err.message : String(err);
       throw new Error(
-        `Output note ${noteId} not found in the local store; only notes created by this client can be exported: ${detail}`,
+        `Output note ${trimmedNoteId} not found in the local store; only notes created by this client can be exported: ${detail}`,
+      );
+    }
+    if (!record) {
+      throw new Error(
+        `Output note ${trimmedNoteId} not found in the local store; only notes created by this client can be exported`,
       );
     }
 
-    const format = record?.inclusionProof()
+    const format = record.inclusionProof()
       ? NoteExportFormat.Full
       : NoteExportFormat.Details;
-    const noteFile = await webClient.exportNoteFile(noteId, format);
+    const noteFile = await webClient.exportNoteFile(trimmedNoteId, format);
     return noteFile.serialize();
+  }
+
+  /**
+   * Export a note created by this multisig account as a note file downloaded
+   * by the browser (issue #356). Browser-only convenience over
+   * {@link exportNoteToBytes}; use that method directly in non-DOM
+   * environments.
+   *
+   * @param noteId - ID of the note to export (hex string)
+   * @param filename - Download filename; defaults to `note_<id>.mno`
+   */
+  async exportNoteToFile(noteId: string, filename?: string): Promise<void> {
+    if (typeof document === 'undefined') {
+      throw new Error('exportNoteToFile requires a browser environment; use exportNoteToBytes instead');
+    }
+
+    const trimmedNoteId = noteId.trim();
+    const noteBytes = await this.exportNoteToBytes(trimmedNoteId);
+
+    const blob = new Blob([noteBytes as BlobPart], { type: 'application/octet-stream' });
+    const url = URL.createObjectURL(blob);
+    try {
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = filename ?? `note_${trimmedNoteId}.mno`;
+      anchor.click();
+    } finally {
+      URL.revokeObjectURL(url);
+    }
   }
 
   /**
@@ -997,11 +1032,12 @@ export class Multisig {
    * commitment is tracked and the note shows up in {@link getConsumableNotes};
    * it can then be consumed via {@link createConsumeNotesProposal}.
    *
-   * @param noteBytes - Serialized note file bytes produced by {@link exportNote}
+   * @param noteBytes - Serialized note file bytes produced by
+   *   {@link exportNoteToBytes}
    * @returns The note ID when the file carries one, or the note's details
    *   commitment for a details-only file
    */
-  async importNote(noteBytes: Uint8Array): Promise<string> {
+  async importNoteFromBytes(noteBytes: Uint8Array): Promise<string> {
     const webClient = await this.getRawClient();
 
     let noteFile: NoteFile;
@@ -1016,11 +1052,21 @@ export class Multisig {
   }
 
   /**
+   * Import a note file received out-of-band (issue #356) from a browser
+   * `File`/`Blob` (e.g. a file-input selection). See
+   * {@link importNoteFromBytes} for the returned identifier semantics.
+   */
+  async importNoteFromFile(file: Blob): Promise<string> {
+    const noteBytes = new Uint8Array(await file.arrayBuffer());
+    return this.importNoteFromBytes(noteBytes);
+  }
+
+  /**
    * Compute the ID of the note a P2ID proposal will create when executed.
    *
    * The P2ID note is rebuilt deterministically from the proposal salt, so the
    * ID is known ahead of execution. For a private P2ID this is the ID to pass
-   * to {@link exportNote} after executing, so the note file can be delivered
+   * to {@link exportNoteToBytes} after executing, so the note file can be delivered
    * to the recipient out-of-band (issue #356).
    *
    * Call this before executing the proposal: the asset is derived from the

--- a/packages/miden-multisig-client/src/transaction.ts
+++ b/packages/miden-multisig-client/src/transaction.ts
@@ -3,6 +3,7 @@ export {
 } from './transaction/consumeNotes.js';
 export { executeForSummary } from './transaction/summary.js';
 export {
+  buildP2idNoteFromMetadata,
   buildP2idTransactionRequest,
   parseP2idNoteType,
   p2idNoteTypeToMetadata,

--- a/packages/miden-multisig-client/src/transaction/p2id.ts
+++ b/packages/miden-multisig-client/src/transaction/p2id.ts
@@ -114,6 +114,31 @@ function buildP2idNote(
   return new Note(noteAssets, noteMetadata, noteRecipient);
 }
 
+/**
+ * Rebuilds the P2ID note a proposal creates, from its metadata fields. The
+ * note is deterministic in the salt, so the resulting ID matches the note the
+ * proposal produces on execution (issue #356). The asset is derived from the
+ * account's current vault state, so call this before the transfer executes.
+ */
+export function buildP2idNoteFromMetadata(
+  senderId: string,
+  recipientId: string,
+  faucetId: string,
+  amount: bigint,
+  account: Account,
+  noteType: NoteType,
+  saltHex: string,
+): Note {
+  const sender = AccountId.fromHex(senderId);
+  const recipient = AccountId.fromHex(recipientId);
+  const faucet = AccountId.fromHex(faucetId);
+
+  const asset = resolveFungibleAssetFromVault(account, faucet, amount);
+  const noteAssets = new NoteAssets([asset]);
+
+  return buildP2idNote(sender, recipient, noteAssets, noteType, saltHex);
+}
+
 export function buildP2idTransactionRequest(
   senderId: string,
   recipientId: string,
@@ -122,20 +147,14 @@ export function buildP2idTransactionRequest(
   account: Account,
   options: P2idTransactionOptions = {},
 ): { request: TransactionRequest; salt: Word } {
-  const sender = AccountId.fromHex(senderId);
-  const recipient = AccountId.fromHex(recipientId);
-  const faucet = AccountId.fromHex(faucetId);
-
   const authSaltHex = options.salt ? options.salt.toHex() : randomWord().toHex();
 
-  const asset = resolveFungibleAssetFromVault(account, faucet, amount);
-
-  const noteAssets = new NoteAssets([asset]);
-
-  const note = buildP2idNote(
-    sender,
-    recipient,
-    noteAssets,
+  const note = buildP2idNoteFromMetadata(
+    senderId,
+    recipientId,
+    faucetId,
+    amount,
+    account,
     options.noteType ?? NoteType.Public,
     authSaltHex,
   );


### PR DESCRIPTION
Closes #356. Follow-up to #338, which made proposals honor the P2ID note type but left no way to hand a private note to its recipient without dropping to the raw Miden client.

## What's included

**SDK wrappers**
- Rust `MultisigClient`: `export_note` / `export_note_to_bytes` (full note with proof when the inclusion proof is known, details-only otherwise), `import_note` / `import_note_from_bytes`, and `p2id_note_id(&proposal)` — the deterministic note ID of a P2ID proposal, resolvable ahead of execution.
- TS `Multisig`: `exportNote` / `importNote` over the web SDK's `NoteFile`, plus `getP2idNoteId` built on the shared P2ID note builder (extracted as `buildP2idNoteFromMetadata` so proposal creation and ID recomputation can't drift).

**Demo**
- After executing a private P2ID, the demo announces the created note and offers to export the note file.
- The consume-notes flow gains an import option (menu entry when no notes are cached, `i` shortcut otherwise) that imports and syncs before listing.

**Smoke coverage**
- New `getP2idNoteId` / `exportNote` / `importNote` commands on the smoke-web harness.
- New `private-note-roundtrip-canary` scenario in both workflow matrices: private P2ID → export → import → consume across separate local stores.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added private note export and import for offline, out-of-band transfers.
  - Added deterministic P2ID note ID lookup before transaction execution.
  - Added support for importing notes and making them consumable after synchronization.
  - Improved demo flows with prompts to export, import, sync, and consume private notes.

- **Documentation**
  - Added guidance for private note sharing, export/import workflows, and synchronization requirements.
  - Expanded SDK references for the new note management capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->