### PR TITLE
chore(release): v0.16.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3131,7 +3131,7 @@ dependencies = [
 
 [[package]]
 name = "guardian-client"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "chrono",
  "guardian-shared",
@@ -3211,7 +3211,7 @@ dependencies = [
 
 [[package]]
 name = "guardian-server"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "aes-gcm",
  "alloy",
@@ -3301,7 +3301,7 @@ dependencies = [
 
 [[package]]
 name = "guardian-shared"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "base64",
  "hex",
@@ -4509,7 +4509,7 @@ dependencies = [
 
 [[package]]
 name = "miden-confidential-contracts"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4766,7 +4766,7 @@ dependencies = [
 
 [[package]]
 name = "miden-multisig-client"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.16.0"
+version = "0.16.1"
 edition = "2024"
 rust-version = "1.93"
 authors = ["OpenZeppelin"]

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -11,7 +11,7 @@ description = "Client library for Guardian"
 include = ["src/**/*", "proto/**/*", "build.rs", "Cargo.toml", "LICENSE", "README.md"]
 
 [dependencies]
-guardian-shared = { version = "=0.16.0", path = "../shared" }
+guardian-shared = { version = "=0.16.1", path = "../shared" }
 miden-protocol = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/contracts/Cargo.toml
+++ b/crates/contracts/Cargo.toml
@@ -18,7 +18,7 @@ miden-testing = { workspace = true }
 
 anyhow = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "net", "macros", "fs"] }
-guardian-shared = { version = "=0.16.0", path = "../shared" }
+guardian-shared = { version = "=0.16.1", path = "../shared" }
 
 [dev-dependencies]
 miden-client = { workspace = true, features = ["testing", "tonic"] }

--- a/crates/miden-multisig-client/Cargo.toml
+++ b/crates/miden-multisig-client/Cargo.toml
@@ -11,9 +11,9 @@ description = "High-level SDK for interacting with multisig accounts on Miden vi
 
 [dependencies]
 # Internal crates
-guardian-client = { version = "=0.16.0", path = "../client" }
-guardian-shared = { version = "=0.16.0", path = "../shared" }
-miden-confidential-contracts = { version = "=0.16.0", path = "../contracts" }
+guardian-client = { version = "=0.16.1", path = "../client" }
+guardian-shared = { version = "=0.16.1", path = "../shared" }
+miden-confidential-contracts = { version = "=0.16.1", path = "../contracts" }
 
 # Miden
 miden-client = { workspace = true, features = ["tonic"] }

--- a/docs/openapi-client.json
+++ b/docs/openapi-client.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0",
       "identifier": "AGPL-3.0"
     },
-    "version": "0.16.0"
+    "version": "0.16.1"
   },
   "paths": {
     "/configure": {

--- a/docs/openapi-dashboard.json
+++ b/docs/openapi-dashboard.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0",
       "identifier": "AGPL-3.0"
     },
-    "version": "0.16.0"
+    "version": "0.16.1"
   },
   "paths": {
     "/auth/challenge": {

--- a/docs/openapi-evm.json
+++ b/docs/openapi-evm.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0",
       "identifier": "AGPL-3.0"
     },
-    "version": "0.16.0"
+    "version": "0.16.1"
   },
   "paths": {
     "/evm/accounts": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0",
       "identifier": "AGPL-3.0"
     },
-    "version": "0.16.0"
+    "version": "0.16.1"
   },
   "paths": {
     "/auth/challenge": {

--- a/packages/guardian-client/package-lock.json
+++ b/packages/guardian-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openzeppelin/guardian-client",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openzeppelin/guardian-client",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.7.2",

--- a/packages/guardian-client/package.json
+++ b/packages/guardian-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/guardian-client",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "TypeScript HTTP client for Guardian server",
   "repository": {
     "type": "git",

--- a/packages/guardian-evm-client/package-lock.json
+++ b/packages/guardian-evm-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openzeppelin/guardian-evm-client",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openzeppelin/guardian-evm-client",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "MIT",
       "dependencies": {
         "viem": "^2.47.5"

--- a/packages/guardian-evm-client/package.json
+++ b/packages/guardian-evm-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/guardian-evm-client",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "TypeScript EVM client for Guardian server proposal workflows",
   "repository": {
     "type": "git",

--- a/packages/guardian-operator-client/package-lock.json
+++ b/packages/guardian-operator-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openzeppelin/guardian-operator-client",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openzeppelin/guardian-operator-client",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.7.2",

--- a/packages/guardian-operator-client/package.json
+++ b/packages/guardian-operator-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/guardian-operator-client",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "TypeScript HTTP client for Guardian operator dashboard endpoints",
   "repository": {
     "type": "git",

--- a/packages/miden-multisig-client/package-lock.json
+++ b/packages/miden-multisig-client/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@openzeppelin/miden-multisig-client",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openzeppelin/miden-multisig-client",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "MIT",
       "dependencies": {
         "@miden-sdk/miden-sdk": "^0.15.8",
         "@noble/curves": "^1.9.7",
         "@noble/hashes": "^2.0.1",
-        "@openzeppelin/guardian-client": "^0.16.0"
+        "@openzeppelin/guardian-client": "^0.16.1"
       },
       "devDependencies": {
         "typescript": "^5.7.2",

--- a/packages/miden-multisig-client/package.json
+++ b/packages/miden-multisig-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/miden-multisig-client",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "TypeScript SDK for Miden multisig accounts with GUARDIAN integration",
   "repository": {
     "type": "git",
@@ -39,7 +39,7 @@
     "@miden-sdk/miden-sdk": "^0.15.8",
     "@noble/curves": "^1.9.7",
     "@noble/hashes": "^2.0.1",
-    "@openzeppelin/guardian-client": "^0.16.0"
+    "@openzeppelin/guardian-client": "^0.16.1"
   },
   "devDependencies": {
     "typescript": "^5.7.2",


### PR DESCRIPTION
Coordinated SDK release bump 0.16.0 → 0.16.1 with what is currently on `main` (through f9f45c6).

## Changes
- Workspace `Cargo.toml` version → 0.16.1 (+ `Cargo.lock`)
- Internal `=0.16.1` dependency pins in `crates/client`, `crates/contracts`, `crates/miden-multisig-client`
- All four npm package versions + `@openzeppelin/guardian-client` range in `miden-multisig-client` → `^0.16.1`
- npm lockfiles refreshed (miden-multisig-client lockfile root bumped by hand — `guardian-client@0.16.1` is not on npm yet; nested entry gets refreshed post-publish, same as #355)
- `docs/openapi*.json` info versions → 0.16.1

## Validation
- `cargo test` for guardian-shared, guardian-client, miden-confidential-contracts, miden-multisig-client — all green
- npm test + build for all four packages (67/10/401/88 tests) — all green
- `cargo publish --dry-run` (multi-package, dependency-ordered) — all four crates verify and package
- `npm publish --dry-run` — all four packages pack cleanly at 0.16.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated all published packages and components to version 0.16.1.
  * Aligned internal package references with the new release version.
  * Updated API specification metadata to 0.16.1; no API endpoints or schemas changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->