### PR TITLE
fix(server): reconstruct first-tx SwitchGuardian with the guardian selector re-enabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4788,6 +4788,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tonic",
+ "tracing",
  "url",
 ]
 

--- a/crates/miden-multisig-client/Cargo.toml
+++ b/crates/miden-multisig-client/Cargo.toml
@@ -35,6 +35,9 @@ base64 = { workspace = true }
 
 # Error handling
 thiserror = { workspace = true }
+
+# Logging (facade only; host applications install the subscriber)
+tracing = "0.1"
 anyhow = { workspace = true }
 
 # Utilities

--- a/crates/miden-multisig-client/src/client/proposals.rs
+++ b/crates/miden-multisig-client/src/client/proposals.rs
@@ -263,14 +263,28 @@ impl MultisigClient {
                 .await?;
             signature_advice.push(guardian_advice);
         } else {
-            let _ = self
+            // SwitchGuardian: push the delta to the pre-switch GUARDIAN so it
+            // canonicalizes there and the account is released (issue #305).
+            // Best-effort — an unreachable GUARDIAN must not block the switch —
+            // but the outcome must be observable: a silently lost push leaves
+            // the old GUARDIAN serving a released account (split-brain) with
+            // nothing in any log to diagnose it by.
+            if let Err(error) = self
                 .get_guardian_ack_signature(
                     &account,
                     proposal.nonce,
                     &proposal.tx_summary,
                     tx_summary_commitment,
                 )
-                .await;
+                .await
+            {
+                tracing::warn!(
+                    %error,
+                    "best-effort SwitchGuardian delta push to the pre-switch \
+                     GUARDIAN failed; it will keep serving this account until \
+                     reconciliation"
+                );
+            }
         }
 
         // Build the final transaction request with all signatures

--- a/crates/server/src/network/miden/mod.rs
+++ b/crates/server/src/network/miden/mod.rs
@@ -194,13 +194,25 @@ impl NetworkClient for MidenNetworkClient {
         let account_delta = tx_summary.account_delta();
 
         // Check if this is a full state delta (new account deployment) or partial delta (update)
-        let mut guardian_enabled_pre_tx = false;
+        let guardian_enabled_pre_tx;
         let mut account = if account_delta.is_full_state() {
             // For new accounts, convert the full state delta directly to an Account
             tracing::debug!(
                 account_id = %account_delta.id().to_hex(),
                 "Processing full state delta for new account deployment"
             );
+            // The pre-tx selector for a first transaction comes from the stored initial
+            // state (registered via `/configure`), not from the delta: a first-tx abort
+            // summary captures the selector mid-script exactly like the partial path
+            // (OFF during a `SwitchGuardian`), while the guardian-verified execution
+            // re-enables it on-chain. Without this, a first-tx SwitchGuardian
+            // reconstructs with the selector OFF, its commitment never matches the
+            // chain, and the candidate is condemned as diverged instead of
+            // canonicalizing — so release-on-switch (#305) never fires. An unparseable
+            // prev state falls back to `false`, preserving the delta's own selector.
+            guardian_enabled_pre_tx = Account::from_json(prev_state_json)
+                .map(|prev| MidenAccountInspector::new(&prev).has_guardian_auth())
+                .unwrap_or(false);
             Account::try_from(account_delta).map_err(|e| {
                 tracing::error!(
                     account_id = %account_delta.id().to_hex(),
@@ -240,11 +252,13 @@ impl NetworkClient for MidenNetworkClient {
             // during a SwitchGuardian; re-enable here to match the on-chain commitment. Gated on
             // the selector being ON *before* the tx: `enable_guardian` runs only when guardian auth
             // was required, so a guardian-disabled account never reaches it and must keep its OFF
-            // selector through reconstruction. The full-state (deployment) path carries the
-            // authoritative selector in the delta itself, so it is never forced here. Parity is
+            // selector through reconstruction. The full-state (deployment) path derives the
+            // pre-tx selector from the stored initial state, since its delta captures the
+            // mid-script selector just like a partial abort summary. Parity is
             // pinned by `test_switch_guardian_server_reconstruction_matches_execution`
-            // (crates/contracts/tests/auth/multisig.rs) for the enabled case and
-            // `test_apply_delta_guardian_disabled_keeps_selector_off` for the disabled case.
+            // (crates/contracts/tests/auth/multisig.rs) for the enabled case,
+            // `test_apply_delta_guardian_disabled_keeps_selector_off` for the disabled case,
+            // and `test_apply_delta_first_tx_switch_reenables_selector` for the first-tx case.
             const GUARDIAN_SELECTOR_SLOT_NAME: &str = "openzeppelin::guardian::selector";
             const GUARDIAN_ON: [u32; 4] = [1, 0, 0, 0];
 
@@ -801,6 +815,115 @@ mod tests {
         assert_eq!(
             selector, guardian_off,
             "guardian-disabled account must keep its OFF selector after reconstruction"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_apply_delta_first_tx_switch_reenables_selector() {
+        use miden_protocol::Felt;
+        use miden_protocol::account::delta::{AccountStorageDelta, AccountVaultDelta};
+        use miden_protocol::account::{
+            AccountCode, AccountDelta, AccountId, AccountIdVersion, AccountStorage, AccountType,
+            StorageSlot, StorageSlotName,
+        };
+        use miden_protocol::asset::AssetVault;
+
+        const GUARDIAN_SELECTOR_SLOT_NAME: &str = "openzeppelin::guardian::selector";
+        let guardian_on = Word::from([1u32, 0, 0, 0]);
+        let guardian_off = Word::from([0u32, 0, 0, 0]);
+
+        let network = NetworkType::MidenTestnet;
+        let client = MidenNetworkClient::lazy_for_test(network);
+
+        let selector_name =
+            StorageSlotName::new(GUARDIAN_SELECTOR_SLOT_NAME).expect("valid slot name");
+        let account_id =
+            AccountId::dummy([8u8; 15], AccountIdVersion::Version1, AccountType::Private);
+
+        // The stored initial state (registered via `/configure`): guardian enabled.
+        let prev_storage = AccountStorage::new(vec![StorageSlot::with_value(
+            selector_name.clone(),
+            guardian_on,
+        )])
+        .expect("valid storage");
+        let prev_account = Account::new_existing(
+            account_id,
+            AssetVault::new(&[]).expect("empty vault"),
+            prev_storage,
+            AccountCode::mock(),
+            Felt::new_unchecked(1),
+        );
+        let prev_state_json = prev_account.to_json();
+
+        // A first-transaction SwitchGuardian abort summary: a FULL-STATE delta whose
+        // storage captured the selector OFF mid-script. On-chain the guardian-verified
+        // execution ends with `enable_guardian`, so reconstruction must end selector ON.
+        let mut storage_delta = AccountStorageDelta::new();
+        storage_delta
+            .set_item(selector_name.clone(), guardian_off)
+            .expect("set selector in delta");
+        let full_state_delta = AccountDelta::new(
+            account_id,
+            storage_delta,
+            AccountVaultDelta::default(),
+            Felt::new_unchecked(1),
+        )
+        .expect("valid delta")
+        .with_code(Some(AccountCode::mock()));
+        assert!(
+            full_state_delta.is_full_state(),
+            "delta must be full-state so the first-tx path is exercised"
+        );
+        let tx_summary = TransactionSummary::new(
+            full_state_delta,
+            InputNotes::new(Vec::new()).expect("empty input notes"),
+            RawOutputNotes::new(Vec::new()).expect("empty output notes"),
+            Word::default(),
+        );
+        let delta_payload = tx_summary.to_json();
+
+        let (new_state_json, _new_commitment) = client
+            .apply_delta(&prev_state_json, &delta_payload)
+            .expect("apply_delta should succeed");
+
+        let reconstructed =
+            Account::from_json(&new_state_json).expect("valid reconstructed account");
+        let selector = reconstructed
+            .storage()
+            .get_item(&selector_name)
+            .expect("selector slot present");
+        assert_eq!(
+            selector, guardian_on,
+            "first-tx reconstruction must re-enable the selector when the stored \
+             initial state had guardian enabled (issue #305 first-tx switch)"
+        );
+
+        // Control: when the stored initial state has guardian DISABLED, the delta's
+        // own selector must be preserved — no forcing.
+        let off_storage = AccountStorage::new(vec![StorageSlot::with_value(
+            selector_name.clone(),
+            guardian_off,
+        )])
+        .expect("valid storage");
+        let off_prev = Account::new_existing(
+            account_id,
+            AssetVault::new(&[]).expect("empty vault"),
+            off_storage,
+            AccountCode::mock(),
+            Felt::new_unchecked(1),
+        );
+        let (off_state_json, _) = client
+            .apply_delta(&off_prev.to_json(), &delta_payload)
+            .expect("apply_delta should succeed");
+        let off_reconstructed =
+            Account::from_json(&off_state_json).expect("valid reconstructed account");
+        assert_eq!(
+            off_reconstructed
+                .storage()
+                .get_item(&selector_name)
+                .expect("selector slot present"),
+            guardian_off,
+            "guardian-disabled initial state must keep the delta's OFF selector"
         );
     }
 }

--- a/crates/server/src/network/miden/mod.rs
+++ b/crates/server/src/network/miden/mod.rs
@@ -209,10 +209,24 @@ impl NetworkClient for MidenNetworkClient {
             // reconstructs with the selector OFF, its commitment never matches the
             // chain, and the candidate is condemned as diverged instead of
             // canonicalizing — so release-on-switch (#305) never fires. An unparseable
-            // prev state falls back to `false`, preserving the delta's own selector.
-            guardian_enabled_pre_tx = Account::from_json(prev_state_json)
-                .map(|prev| MidenAccountInspector::new(&prev).has_guardian_auth())
-                .unwrap_or(false);
+            // prev state falls back to `false`, preserving the delta's own selector —
+            // but that fallback silently reintroduces exactly this divergence for
+            // guardian accounts, and a configured account always has a parseable
+            // initial state, so the warn below is silent in healthy operation and
+            // loud precisely when it matters.
+            guardian_enabled_pre_tx = match Account::from_json(prev_state_json) {
+                Ok(prev) => MidenAccountInspector::new(&prev).has_guardian_auth(),
+                Err(e) => {
+                    tracing::warn!(
+                        account_id = %account_delta.id().to_hex(),
+                        error = %e,
+                        "Unparseable prev state while reconstructing a full-state \
+                         delta; assuming guardian-disabled — a first-tx \
+                         SwitchGuardian will reconstruct diverged"
+                    );
+                    false
+                }
+            };
             Account::try_from(account_delta).map_err(|e| {
                 tracing::error!(
                     account_id = %account_delta.id().to_hex(),
@@ -720,7 +734,10 @@ mod tests {
 
         let delta_payload = tx_summary.to_json();
 
-        // For full state deltas, prev_state_json is ignored since we're creating a new account
+        // Full-state deltas read prev_state_json only for the pre-tx guardian
+        // selector; an unparseable prev state falls back to guardian-disabled
+        // (with a warn), which is fine here — this account has no guardian
+        // component, so the empty prev state exercises exactly that fallback.
         let empty_prev_state = serde_json::json!({});
 
         let (new_state_json, new_commitment) = client

--- a/packages/miden-multisig-client/src/multisig.ts
+++ b/packages/miden-multisig-client/src/multisig.ts
@@ -1228,8 +1228,15 @@ export class Multisig {
           ...switchDelta,
           deltaPayload: switchDelta.deltaPayload.txSummary,
         });
-      } catch {
-        // best-effort; see above
+      } catch (error) {
+        // Best-effort — see above — but the failure must be visible: a
+        // silently lost push leaves the pre-switch GUARDIAN serving this
+        // account (split-brain, issue #305) with nothing to diagnose by.
+        console.warn(
+          'SwitchGuardian delta push to the pre-switch GUARDIAN failed; it ' +
+            'will keep serving this account until reconciliation',
+          error,
+        );
       }
 
       try {


### PR DESCRIPTION
## Problem

Release-on-switch (#305 / #311) never fires for an account whose **first transaction** is a `SwitchGuardian`, leaving the pre-switch guardian serving the account forever — the exact split-brain #305 was opened for. Reported live on the OpenZeppelin Guardian v0.16.0 (see the discussion on #369): switched-away accounts still `released_at: null`.

Root cause: a first transaction pushes a **full-state** delta, and `apply_delta` took that delta's guardian **selector** slot as authoritative. But a `SwitchGuardian` abort summary captures the selector mid-script (OFF — it is disabled during the switch), while the guardian-verified execution ends with `enable_guardian`, so the chain's post state has it ON. The reconstructed commitment therefore never matches the chain, the canonicalization worker condemns the candidate as **diverged** (~2 ticks), discards it together with its proposal, and the release hook — which only runs on successful canonicalization — never executes.

The partial-delta path already handles this with a pre-tx-gated re-enable; the full-state path skipped it on the assumption that "the full-state delta carries the authoritative selector", which is wrong for exactly this transaction type.

## Fix

Derive `guardian_enabled_pre_tx` for the full-state path from `prev_state_json` — the initial state registered via `/configure` — mirroring the partial-path rule. An unparseable prev state falls back to the delta's own selector (previous behavior). Regression test `test_apply_delta_first_tx_switch_reenables_selector` pins both directions: guardian-enabled initial state → selector re-enabled; guardian-disabled initial state → delta's OFF selector preserved.

Second commit: both clients previously discarded the best-effort switch-push error entirely (Rust `let _ =`, TS `catch {}`). A lost push produces this same split-brain with no trace anywhere to diagnose it by — the failure is still non-blocking, but now logged (`tracing::warn` / `console.warn`).

## Notes

- This does not close #369: the reconciliation sweep is still needed for pushes that are lost before reaching the server, for pre-#311 switches, and for clients that never push.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved guardian-switch handling for first transactions, preserving the correct authorization state when guardian protection is enabled or disabled.
  * Guardian-switch execution now continues safely when optional state updates or canonicalization fail.
* **Improvements**
  * Added warning logs when non-blocking guardian-switch operations encounter errors, making issues easier to identify without interrupting execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->