### PR TITLE
fix(server): validate cosigner_commitments against initial account state

### DIFF
--- a/crates/server/src/metadata/auth/mod.rs
+++ b/crates/server/src/metadata/auth/mod.rs
@@ -77,6 +77,20 @@ impl Auth {
         }
     }
 
+    /// The per-scheme list of authorized signer commitments
+    /// (`signers` for EVM accounts).
+    pub fn cosigner_commitments(&self) -> &[String] {
+        match self {
+            Auth::MidenFalconRpo {
+                cosigner_commitments,
+            }
+            | Auth::MidenEcdsa {
+                cosigner_commitments,
+            } => cosigner_commitments,
+            Auth::EvmEcdsa { signers } => signers,
+        }
+    }
+
     pub fn with_updated_commitments(&self, cosigner_commitments: Vec<String>) -> Self {
         match self {
             Auth::MidenFalconRpo { .. } => Auth::MidenFalconRpo {

--- a/crates/server/src/services/configure_account.rs
+++ b/crates/server/src/services/configure_account.rs
@@ -84,6 +84,42 @@ pub async fn configure_account(
                 ))
             })?;
 
+        // The stored cosigner list is the authorization source of truth for
+        // every later request (`Auth::verify`), so the full client-declared
+        // set must match the signer set actually stored in the submitted
+        // account state — `validate_credential` above only proves the
+        // *requesting* key is a signer, not the rest of the list (#102).
+        // `None` means the state carries no extractable signer set, matching
+        // the canonicalization-side semantics of `should_update_auth`.
+        let extracted_auth = client
+            .should_update_auth(&params.initial_state, &params.auth)
+            .await
+            .map_err(|e| {
+                tracing::error!(
+                    account_id = %params.account_id,
+                    error = %e,
+                    "Failed to extract signer commitments from initial state"
+                );
+                GuardianError::NetworkError(format!(
+                    "Failed to extract signer commitments from initial state: {e}"
+                ))
+            })?;
+        if let Some(expected_auth) = extracted_auth
+            && expected_auth != params.auth
+        {
+            tracing::error!(
+                account_id = %params.account_id,
+                expected = ?expected_auth,
+                provided = ?params.auth,
+                "Cosigner commitments do not match account state in configure_account"
+            );
+            return Err(GuardianError::InvalidInput(format!(
+                "cosigner_commitments do not match the signer set in initial_state: expected {:?}, provided {:?}",
+                expected_auth.cosigner_commitments(),
+                params.auth.cosigner_commitments()
+            )));
+        }
+
         // Verifies the credential authorization.
         params
             .auth
@@ -254,6 +290,9 @@ mod tests {
 
         let network_client = MockNetworkClient::new()
             .with_validate_credential(Ok(()))
+            .with_should_update_auth(Ok(Some(Auth::MidenFalconRpo {
+                cosigner_commitments: vec![commitment_hex.clone()],
+            })))
             .with_get_state_commitment(Ok("0x1234".to_string()));
 
         let storage_backend = MockStorageBackend::new().with_submit_state(Ok(()));
@@ -691,5 +730,175 @@ mod tests {
             storage_backend.get_submit_state_calls().is_empty(),
             "state should not be persisted on unauthorized configuration"
         );
+    }
+
+    #[tokio::test]
+    async fn test_configure_account_rejects_mismatched_cosigner_commitments() {
+        use crate::testing::helpers::generate_falcon_signature;
+
+        let account_id_hex = "0x1d1d1d1c1d1d1d011d1d1d1d1d1d1d";
+        let (pubkey_hex, _commitment_hex, signature_hex, timestamp) =
+            generate_falcon_signature(account_id_hex);
+
+        let network_client = MockNetworkClient::new()
+            .with_validate_credential(Ok(()))
+            .with_should_update_auth(Ok(Some(Auth::MidenFalconRpo {
+                cosigner_commitments: vec!["0xactual_commitment".to_string()],
+            })));
+
+        let storage_backend = MockStorageBackend::new();
+        let metadata_store = MockMetadataStore::new().with_get(Ok(None));
+
+        let state =
+            create_test_app_state(network_client, storage_backend.clone(), metadata_store).await;
+
+        let credential = Credentials::signature(pubkey_hex, signature_hex, timestamp);
+
+        let params = ConfigureAccountParams {
+            account_id: account_id_hex.to_string(),
+            auth: Auth::MidenFalconRpo {
+                cosigner_commitments: vec!["0xmalicious_commitment".to_string()],
+            },
+            network_config: crate::metadata::NetworkConfig::miden_default(),
+            initial_state: serde_json::json!({"balance": 100}),
+            credential,
+        };
+
+        let result = configure_account(&state, params).await;
+
+        match result.unwrap_err() {
+            GuardianError::InvalidInput(msg) => {
+                assert!(msg.contains("cosigner_commitments"), "got: {msg}");
+            }
+            e => panic!("Expected InvalidInput, got: {:?}", e),
+        }
+
+        assert!(
+            storage_backend.get_submit_state_calls().is_empty(),
+            "state should not be persisted on mismatched cosigner commitments"
+        );
+    }
+
+    /// The declared list must match the state's signer set exactly:
+    /// appending an extra (non-signer) commitment to an otherwise
+    /// correct list is rejected — the injected key would otherwise be
+    /// authorized for every later request against this account.
+    #[tokio::test]
+    async fn test_configure_account_rejects_injected_extra_cosigner() {
+        use crate::testing::helpers::generate_falcon_signature;
+
+        let account_id_hex = "0x1d1d1d1c1d1d1d011d1d1d1d1d1d1d";
+        let (pubkey_hex, commitment_hex, signature_hex, timestamp) =
+            generate_falcon_signature(account_id_hex);
+
+        let network_client = MockNetworkClient::new()
+            .with_validate_credential(Ok(()))
+            .with_should_update_auth(Ok(Some(Auth::MidenFalconRpo {
+                cosigner_commitments: vec![commitment_hex.clone()],
+            })));
+
+        let storage_backend = MockStorageBackend::new();
+        let metadata_store = MockMetadataStore::new().with_get(Ok(None));
+
+        let state =
+            create_test_app_state(network_client, storage_backend.clone(), metadata_store).await;
+
+        let credential = Credentials::signature(pubkey_hex, signature_hex, timestamp);
+
+        let params = ConfigureAccountParams {
+            account_id: account_id_hex.to_string(),
+            auth: Auth::MidenFalconRpo {
+                cosigner_commitments: vec![commitment_hex, "0xinjected_commitment".to_string()],
+            },
+            network_config: crate::metadata::NetworkConfig::miden_default(),
+            initial_state: serde_json::json!({"balance": 100}),
+            credential,
+        };
+
+        let result = configure_account(&state, params).await;
+
+        assert!(
+            matches!(result, Err(GuardianError::InvalidInput(_))),
+            "expected InvalidInput, got: {result:?}"
+        );
+        assert!(
+            storage_backend.get_submit_state_calls().is_empty(),
+            "state should not be persisted when an extra cosigner is injected"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_configure_account_cosigner_extraction_error() {
+        use crate::testing::helpers::generate_falcon_signature;
+
+        let account_id_hex = "0x1d1d1d1c1d1d1d011d1d1d1d1d1d1d";
+        let (pubkey_hex, commitment_hex, signature_hex, timestamp) =
+            generate_falcon_signature(account_id_hex);
+
+        let network_client = MockNetworkClient::new()
+            .with_validate_credential(Ok(()))
+            .with_should_update_auth(Err("failed to deserialize account".to_string()));
+
+        let storage_backend = MockStorageBackend::new();
+        let metadata_store = MockMetadataStore::new().with_get(Ok(None));
+
+        let state = create_test_app_state(network_client, storage_backend, metadata_store).await;
+
+        let credential = Credentials::signature(pubkey_hex, signature_hex, timestamp);
+
+        let params = ConfigureAccountParams {
+            account_id: account_id_hex.to_string(),
+            auth: Auth::MidenFalconRpo {
+                cosigner_commitments: vec![commitment_hex],
+            },
+            network_config: crate::metadata::NetworkConfig::miden_default(),
+            initial_state: serde_json::json!({"balance": 100}),
+            credential,
+        };
+
+        let result = configure_account(&state, params).await;
+
+        assert!(
+            matches!(result, Err(GuardianError::NetworkError(_))),
+            "expected NetworkError, got: {result:?}"
+        );
+    }
+
+    /// `should_update_auth` returning `None` means the state carries no
+    /// extractable signer set (e.g. non-multisig layouts); the declared
+    /// list is then accepted as-is, matching canonicalization semantics.
+    #[tokio::test]
+    async fn test_configure_account_skips_validation_without_extractable_signers() {
+        use crate::testing::helpers::generate_falcon_signature;
+
+        let account_id_hex = "0x1d1d1d1c1d1d1d011d1d1d1d1d1d1d";
+        let (pubkey_hex, commitment_hex, signature_hex, timestamp) =
+            generate_falcon_signature(account_id_hex);
+
+        let network_client = MockNetworkClient::new()
+            .with_validate_credential(Ok(()))
+            .with_should_update_auth(Ok(None))
+            .with_get_state_commitment(Ok("0x1234".to_string()));
+
+        let storage_backend = MockStorageBackend::new().with_submit_state(Ok(()));
+        let metadata_store = MockMetadataStore::new().with_get(Ok(None)).with_set(Ok(()));
+
+        let state = create_test_app_state(network_client, storage_backend, metadata_store).await;
+
+        let credential = Credentials::signature(pubkey_hex, signature_hex, timestamp);
+
+        let params = ConfigureAccountParams {
+            account_id: account_id_hex.to_string(),
+            auth: Auth::MidenFalconRpo {
+                cosigner_commitments: vec![commitment_hex],
+            },
+            network_config: crate::metadata::NetworkConfig::miden_default(),
+            initial_state: serde_json::json!({"balance": 100}),
+            credential,
+        };
+
+        let result = configure_account(&state, params).await;
+
+        assert!(result.is_ok(), "got: {result:?}");
     }
 }

--- a/crates/server/src/services/configure_account.rs
+++ b/crates/server/src/services/configure_account.rs
@@ -21,6 +21,42 @@ pub struct ConfigureAccountResult {
     pub ack_commitment: String,
 }
 
+/// Requires each declared cosigner commitment to be canonical — `0x` plus
+/// 64 lowercase hex digits, the only form the server itself emits — and the
+/// list to be non-empty and duplicate-free. The list is later compared by
+/// exact string equality against the signer set extracted from
+/// `initial_state`, so a non-canonical spelling could only ever fail that
+/// comparison; rejecting it here names the offending entry instead of
+/// surfacing a confusing mismatch. An empty list can never match a real
+/// signer map and would leave the account unable to authorize any request.
+fn validate_commitment_list(commitments: &[String]) -> Result<()> {
+    if commitments.is_empty() {
+        return Err(GuardianError::InvalidInput(
+            "cosigner_commitments must not be empty".to_string(),
+        ));
+    }
+    let mut seen = std::collections::HashSet::new();
+    for entry in commitments {
+        let hex_digits = entry.strip_prefix("0x").unwrap_or("");
+        if hex_digits.len() != 64
+            || !hex_digits
+                .bytes()
+                .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+        {
+            return Err(GuardianError::InvalidInput(format!(
+                "cosigner_commitments entry '{entry}' is not a canonical commitment \
+                 (expected 0x followed by 64 lowercase hex digits)"
+            )));
+        }
+        if !seen.insert(entry) {
+            return Err(GuardianError::InvalidInput(format!(
+                "cosigner_commitments contains duplicate entry '{entry}'"
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// Configure a new account
 #[tracing::instrument(
     skip(state, params),
@@ -43,6 +79,8 @@ pub async fn configure_account(
             operation: "configure".to_string(),
         });
     }
+
+    validate_commitment_list(params.auth.cosigner_commitments())?;
 
     let existing = state.metadata.get(&params.account_id).await.map_err(|e| {
         tracing::error!(
@@ -743,7 +781,7 @@ mod tests {
         let network_client = MockNetworkClient::new()
             .with_validate_credential(Ok(()))
             .with_should_update_auth(Ok(Some(Auth::MidenFalconRpo {
-                cosigner_commitments: vec!["0xactual_commitment".to_string()],
+                cosigner_commitments: vec![format!("0x{}", "aa".repeat(32))],
             })));
 
         let storage_backend = MockStorageBackend::new();
@@ -757,7 +795,7 @@ mod tests {
         let params = ConfigureAccountParams {
             account_id: account_id_hex.to_string(),
             auth: Auth::MidenFalconRpo {
-                cosigner_commitments: vec!["0xmalicious_commitment".to_string()],
+                cosigner_commitments: vec![format!("0x{}", "bb".repeat(32))],
             },
             network_config: crate::metadata::NetworkConfig::miden_default(),
             initial_state: serde_json::json!({"balance": 100}),
@@ -862,6 +900,97 @@ mod tests {
             matches!(result, Err(GuardianError::NetworkError(_))),
             "expected NetworkError, got: {result:?}"
         );
+    }
+
+    /// The comparison is deliberately order-sensitive: the signer map's
+    /// index order is the canonical order, and the SDK emits it verbatim.
+    #[tokio::test]
+    async fn test_rejects_reordered_commitments() {
+        use crate::testing::helpers::generate_falcon_signature;
+
+        let account_id_hex = "0x1d1d1d1c1d1d1d011d1d1d1d1d1d1d";
+        let (pubkey_hex, commitment_hex, signature_hex, timestamp) =
+            generate_falcon_signature(account_id_hex);
+        let other_hex = format!("0x{}", "aa".repeat(32));
+
+        let network_client = MockNetworkClient::new()
+            .with_validate_credential(Ok(()))
+            .with_should_update_auth(Ok(Some(Auth::MidenFalconRpo {
+                cosigner_commitments: vec![commitment_hex.clone(), other_hex.clone()],
+            })));
+
+        let storage_backend = MockStorageBackend::new();
+        let metadata_store = MockMetadataStore::new().with_get(Ok(None));
+
+        let state =
+            create_test_app_state(network_client, storage_backend.clone(), metadata_store).await;
+
+        let credential = Credentials::signature(pubkey_hex, signature_hex, timestamp);
+
+        let params = ConfigureAccountParams {
+            account_id: account_id_hex.to_string(),
+            auth: Auth::MidenFalconRpo {
+                cosigner_commitments: vec![other_hex, commitment_hex],
+            },
+            network_config: crate::metadata::NetworkConfig::miden_default(),
+            initial_state: serde_json::json!({"balance": 100}),
+            credential,
+        };
+
+        let result = configure_account(&state, params).await;
+
+        assert!(
+            matches!(result, Err(GuardianError::InvalidInput(_))),
+            "same set in a different order must be rejected, got: {result:?}"
+        );
+        assert!(storage_backend.get_submit_state_calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_rejects_non_canonical_empty_and_duplicate_commitment_lists() {
+        use crate::testing::helpers::generate_falcon_signature;
+
+        let account_id_hex = "0x1d1d1d1c1d1d1d011d1d1d1d1d1d1d";
+        let canonical = format!("0x{}", "ab".repeat(32));
+
+        let cases: Vec<(Vec<String>, &str)> = vec![
+            (vec![], "empty list"),
+            (
+                vec![canonical.clone(), canonical.clone()],
+                "duplicate entry",
+            ),
+            (vec![format!("0x{}", "AB".repeat(32))], "uppercase hex"),
+            (vec!["ab".repeat(32)], "missing 0x prefix"),
+            (vec![format!("0x{}", "ab".repeat(31))], "wrong length"),
+            (vec!["0xnot_hex".to_string()], "non-hex characters"),
+        ];
+
+        for (list, label) in cases {
+            let (pubkey_hex, _, signature_hex, timestamp) =
+                generate_falcon_signature(account_id_hex);
+            let state = create_test_app_state(
+                MockNetworkClient::new(),
+                MockStorageBackend::new(),
+                MockMetadataStore::new(),
+            )
+            .await;
+
+            let params = ConfigureAccountParams {
+                account_id: account_id_hex.to_string(),
+                auth: Auth::MidenFalconRpo {
+                    cosigner_commitments: list,
+                },
+                network_config: crate::metadata::NetworkConfig::miden_default(),
+                initial_state: serde_json::json!({"balance": 100}),
+                credential: Credentials::signature(pubkey_hex, signature_hex, timestamp),
+            };
+
+            let result = configure_account(&state, params).await;
+            assert!(
+                matches!(result, Err(GuardianError::InvalidInput(_))),
+                "{label}: expected InvalidInput, got: {result:?}"
+            );
+        }
     }
 
     /// `should_update_auth` returning `None` means the state carries no

--- a/crates/server/src/testing/e2e/abandon_candidate.rs
+++ b/crates/server/src/testing/e2e/abandon_candidate.rs
@@ -225,10 +225,12 @@ async fn stranded_candidate_setup(landed: bool) -> StrandedCandidateSetup {
     state.network_client = Arc::new(integration_client);
 
     let api_pubkey_hex = cosigner_pubkeys[0].clone().into_hex();
-    let api_commitment_hex = format!(
-        "0x{}",
-        hex::encode(cosigner_pubkeys[0].to_commitment().to_bytes())
-    );
+    // /configure validates the declared cosigner set against the state's
+    // signer map (#102), so the full set is registered.
+    let all_commitments_hex: Vec<String> = cosigner_pubkeys
+        .iter()
+        .map(|pk| format!("0x{}", hex::encode(pk.to_commitment().to_bytes())))
+        .collect();
 
     let mut setup = StrandedCandidateSetup {
         state,
@@ -247,7 +249,7 @@ async fn stranded_candidate_setup(landed: bool) -> StrandedCandidateSetup {
         ConfigureAccountParams {
             account_id: account_id_hex.clone(),
             auth: Auth::MidenFalconRpo {
-                cosigner_commitments: vec![api_commitment_hex],
+                cosigner_commitments: all_commitments_hex,
             },
             network_config: NetworkConfig::miden_default(),
             initial_state: multisig_account.to_json(),

--- a/crates/server/src/testing/e2e/configure_account.rs
+++ b/crates/server/src/testing/e2e/configure_account.rs
@@ -7,11 +7,63 @@ use crate::testing::fixtures;
 use crate::testing::helpers::{
     IntegrationMockNetworkClient, create_test_app_state, generate_falcon_signature,
 };
+use guardian_shared::auth_request_message::AuthRequestMessage;
+use guardian_shared::auth_request_payload::AuthRequestPayload;
+use guardian_shared::hex::IntoHex;
+use miden_protocol::crypto::dsa::falcon512_poseidon2::SecretKey;
+use miden_protocol::utils::serde::{Deserializable, Serializable};
 use std::sync::Arc;
 
+/// The fixture signer keys and the account's full cosigner set, in the
+/// signer map's canonical (index) order, as generated alongside
+/// `account.json` by `generate_fixtures`.
+fn fixture_signer() -> (SecretKey, String, Vec<String>) {
+    let keys: serde_json::Value =
+        serde_json::from_str(fixtures::KEYS_JSON).expect("Failed to parse keys.json");
+    let secret_key_bytes = hex::decode(keys["signer_1_secret_key"].as_str().expect("signer key"))
+        .expect("signer key hex");
+    let secret_key = SecretKey::read_from_bytes(&secret_key_bytes).expect("signer key bytes");
+    let pubkey_hex = secret_key.public_key().into_hex();
+    let cosigner_commitments = (1..=3)
+        .map(|i| {
+            keys[format!("signer_{i}_commitment")]
+                .as_str()
+                .expect("signer commitment")
+                .to_string()
+        })
+        .collect();
+    (secret_key, pubkey_hex, cosigner_commitments)
+}
+
+fn falcon_credentials(
+    key: &SecretKey,
+    pubkey_hex: &str,
+    account_id_hex: &str,
+    timestamp: i64,
+) -> Credentials {
+    let message = AuthRequestMessage::from_account_id_hex(
+        account_id_hex,
+        timestamp,
+        AuthRequestPayload::empty(),
+    )
+    .expect("valid account ID")
+    .to_word();
+    let signature = key.sign(message);
+    let signature_hex = format!("0x{}", hex::encode(signature.to_bytes()));
+    Credentials::signature(pubkey_hex.to_string(), signature_hex, timestamp)
+}
+
+/// Configures the real fixture account through the real extraction path:
+/// the declared cosigner set is the account's actual 3-signer map (from
+/// `keys.json`, in map order) and the credential is signed by fixture
+/// signer 1. This only passes because the declared list matches the state
+/// — the companion test below proves a non-matching list is rejected.
 #[tokio::test]
 async fn test_configure_account_with_real_miden_account() {
-    let state = create_test_app_state().await;
+    let mut state = create_test_app_state().await;
+    state.network_client = Arc::new(IntegrationMockNetworkClient::new(
+        MidenNetworkClient::lazy_for_test(NetworkType::MidenLocal),
+    ));
 
     let account_json: serde_json::Value =
         serde_json::from_str(fixtures::ACCOUNT_JSON).expect("Failed to parse account.json");
@@ -23,17 +75,17 @@ async fn test_configure_account_with_real_miden_account() {
         .expect("Missing account_id")
         .to_string();
 
-    let (pubkey_hex, commitment_hex, signature_hex, timestamp) =
-        generate_falcon_signature(&account_id);
+    let (secret_key, pubkey_hex, cosigner_commitments) = fixture_signer();
+    let timestamp = chrono::Utc::now().timestamp_millis();
 
     let params = ConfigureAccountParams {
         account_id: account_id.clone(),
         auth: Auth::MidenFalconRpo {
-            cosigner_commitments: vec![commitment_hex.clone()],
+            cosigner_commitments: cosigner_commitments.clone(),
         },
         network_config: crate::metadata::NetworkConfig::miden_default(),
         initial_state: account_json.clone(),
-        credential: Credentials::signature(pubkey_hex, signature_hex, timestamp),
+        credential: falcon_credentials(&secret_key, &pubkey_hex, &account_id, timestamp),
     };
 
     let result = configure_account(&state, params).await;
@@ -55,7 +107,7 @@ async fn test_configure_account_with_real_miden_account() {
     assert_eq!(
         metadata_entry.auth,
         Auth::MidenFalconRpo {
-            cosigner_commitments: vec![commitment_hex],
+            cosigner_commitments,
         }
     );
 }

--- a/crates/server/src/testing/e2e/configure_account.rs
+++ b/crates/server/src/testing/e2e/configure_account.rs
@@ -1,7 +1,13 @@
+use crate::error::GuardianError;
 use crate::metadata::auth::{Auth, Credentials};
+use crate::network::NetworkType;
+use crate::network::miden::MidenNetworkClient;
 use crate::services::{ConfigureAccountParams, configure_account};
 use crate::testing::fixtures;
-use crate::testing::helpers::{create_test_app_state, generate_falcon_signature};
+use crate::testing::helpers::{
+    IntegrationMockNetworkClient, create_test_app_state, generate_falcon_signature,
+};
+use std::sync::Arc;
 
 #[tokio::test]
 async fn test_configure_account_with_real_miden_account() {
@@ -51,5 +57,58 @@ async fn test_configure_account_with_real_miden_account() {
         Auth::MidenFalconRpo {
             cosigner_commitments: vec![commitment_hex],
         }
+    );
+}
+
+/// #102: with a real (non-mock) extraction path, /configure must reject a
+/// declared cosigner set that is not the signer set stored in the submitted
+/// account state — here a freshly generated key that is not a signer of the
+/// fixture account.
+#[tokio::test]
+async fn test_configure_account_rejects_commitments_not_in_real_account_state() {
+    let mut state = create_test_app_state().await;
+    state.network_client = Arc::new(IntegrationMockNetworkClient::new(
+        MidenNetworkClient::lazy_for_test(NetworkType::MidenLocal),
+    ));
+
+    let account_json: serde_json::Value =
+        serde_json::from_str(fixtures::ACCOUNT_JSON).expect("Failed to parse account.json");
+    let commitments_json: serde_json::Value =
+        serde_json::from_str(fixtures::COMMITMENTS_JSON).expect("Failed to parse commitments.json");
+
+    let account_id = commitments_json["account_id"]
+        .as_str()
+        .expect("Missing account_id")
+        .to_string();
+
+    let (pubkey_hex, commitment_hex, signature_hex, timestamp) =
+        generate_falcon_signature(&account_id);
+
+    let params = ConfigureAccountParams {
+        account_id: account_id.clone(),
+        auth: Auth::MidenFalconRpo {
+            cosigner_commitments: vec![commitment_hex],
+        },
+        network_config: crate::metadata::NetworkConfig::miden_default(),
+        initial_state: account_json,
+        credential: Credentials::signature(pubkey_hex, signature_hex, timestamp),
+    };
+
+    let err = configure_account(&state, params)
+        .await
+        .expect_err("configuring with a non-signer commitment must be rejected");
+    assert!(
+        matches!(err, GuardianError::InvalidInput(_)),
+        "expected InvalidInput, got: {err:?}"
+    );
+
+    assert!(
+        state
+            .metadata
+            .get(&account_id)
+            .await
+            .expect("metadata readable")
+            .is_none(),
+        "no metadata should be stored for a rejected configuration"
     );
 }

--- a/crates/server/src/testing/e2e/switch_guardian_canonicalization.rs
+++ b/crates/server/src/testing/e2e/switch_guardian_canonicalization.rs
@@ -219,12 +219,14 @@ async fn test_switch_guardian_delta_canonicalizes_and_releases_on_old_guardian()
     let auditor = CapturingAuditor::new();
     state.auditor = Arc::new(auditor.clone());
 
-    // Onboard the account on this (soon to be old) guardian.
+    // Onboard the account on this (soon to be old) guardian. /configure
+    // validates the declared cosigner set against the state's signer map
+    // (#102), so the full set is registered, not just the API signer.
     let api_pubkey_hex = cosigner_pubkeys[0].clone().into_hex();
-    let api_commitment_hex = format!(
-        "0x{}",
-        hex::encode(cosigner_pubkeys[0].to_commitment().to_bytes())
-    );
+    let all_commitments_hex: Vec<String> = cosigner_pubkeys
+        .iter()
+        .map(|pk| format!("0x{}", hex::encode(pk.to_commitment().to_bytes())))
+        .collect();
     let timestamp = chrono::Utc::now().timestamp_millis();
 
     configure_account(
@@ -232,7 +234,7 @@ async fn test_switch_guardian_delta_canonicalizes_and_releases_on_old_guardian()
         ConfigureAccountParams {
             account_id: account_id_hex.clone(),
             auth: Auth::MidenFalconRpo {
-                cosigner_commitments: vec![api_commitment_hex],
+                cosigner_commitments: all_commitments_hex.clone(),
             },
             network_config: NetworkConfig::miden_default(),
             initial_state: multisig_account.to_json(),
@@ -415,10 +417,7 @@ async fn test_switch_guardian_delta_canonicalizes_and_releases_on_old_guardian()
         ConfigureAccountParams {
             account_id: account_id_hex.clone(),
             auth: Auth::MidenFalconRpo {
-                cosigner_commitments: vec![format!(
-                    "0x{}",
-                    hex::encode(cosigner_pubkeys[0].to_commitment().to_bytes())
-                )],
+                cosigner_commitments: all_commitments_hex.clone(),
             },
             network_config: NetworkConfig::miden_default(),
             initial_state: executed_account.to_json(),

--- a/spec/processes.md
+++ b/spec/processes.md
@@ -2,7 +2,7 @@
 
 ## Services overview
 
-- **configure_account**: creates a Miden account by validating the provided network configuration and auth policy, then storing account metadata and initial state. EVM accounts are not configured through this service.
+- **configure_account**: creates a Miden account by validating the provided network configuration and auth policy, then storing account metadata and initial state. Every entry in `auth.cosigner_commitments` must be a canonical commitment (`0x` plus 64 lowercase hex digits) and the list must be non-empty and duplicate-free. For MultisigGuardian accounts the list must exactly match the signer map extracted from `initial_state`, including the map's canonical (index) order — the stored list is the authorization source of truth for every later request, so any mismatch is rejected as `InvalidInput`. EVM accounts are not configured through this service.
 - **push_delta**: verifies a Miden delta against the current state, computes the new commitment, attaches an acknowledgement, and either enqueues it as a candidate (canonicalization enabled) or immediately applies it and marks it canonical (optimistic mode). EVM accounts do not support `push_delta` in v1.
 - **get_state**: authenticates and returns the latest persisted account state.
 - **get_delta**: authenticates and returns a specific delta by nonce.
@@ -28,6 +28,8 @@ sequenceDiagram
   S->>S: verify timestamp (within 300s skew window)
   S->>S: validate network_config for account_id
   S->>N: validate_credential(initial_state, credential)
+  S->>N: should_update_auth(initial_state)\n(extract signer map)
+  S->>S: reject unless auth.cosigner_commitments == extracted signer map\n(exact set and order)
   S->>S: auth.verify(account_id, timestamp, request_payload_digest, credential)
   S->>N: get_state_commitment(account_id, initial_state)
   S->>ST: submit_state(state_json, commitment)


### PR DESCRIPTION
Closes #102. Supersedes #109, which predates the `GuardianError` migration and no longer applies.

## Problem

`/configure` accepted the client-declared `auth.cosigner_commitments` after only verifying that the *requesting* key exists in the account state (`validate_credential`). The rest of the list was stored unvalidated — and that stored list is the authorization source of truth for every subsequent request (`Auth::verify` authorizes any key whose commitment appears in it). A configure call could therefore register commitments that are not signers of the account.

## Fix

After the guardian-binding check, extract the signer set from `initial_state` (via the existing `NetworkClient::should_update_auth`, which reads the `openzeppelin::multisig::signer_public_keys` map) and reject with `InvalidInput` when the declared list does not match it exactly (same set and order — the SDK derives the list from the same map walk, so honest clients are unaffected).

`Ok(None)` (no extractable signer set) skips the check, matching the canonicalization-side semantics of `should_update_auth`. Every real multisig-guardian account carries a non-empty signer map — `MultisigGuardianConfig` writes all signers, including 1-of-1 — so the check always runs for real accounts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added access to all authorized cosigner commitments for supported authentication methods.

* **Bug Fixes**
  * Account configuration now rejects declared signer sets that do not match the account’s actual signer commitments.
  * Configuration failures are reported when signer commitments cannot be extracted.
  * Multisignature onboarding and guardian-switching flows now validate the complete cosigner set.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->