### PR TITLE
fix(contracts): read auth flags from element 0 after the little-endian migration

### DIFF
--- a/crates/contracts/masm/auth/guardian.masm
+++ b/crates/contracts/masm/auth/guardian.masm
@@ -179,7 +179,7 @@ end
 pub proc verify_guardian_signature(msg: word)
     push.GUARDIAN_SELECTOR_SLOT[0..2]
     exec.active_account::get_item
-    drop drop drop
+    movdn.3 drop drop drop
     # => [selector, MSG]
 
     push.1 eq

--- a/crates/contracts/masm/auth/guardian_ecdsa.masm
+++ b/crates/contracts/masm/auth/guardian_ecdsa.masm
@@ -175,7 +175,7 @@ end
 pub proc verify_guardian_signature(msg: word)
     push.GUARDIAN_SELECTOR_SLOT[0..2]
     exec.active_account::get_item
-    drop drop drop
+    movdn.3 drop drop drop
     # => [selector, MSG]
 
     push.1 eq

--- a/crates/contracts/masm/auth/multisig.masm
+++ b/crates/contracts/masm/auth/multisig.masm
@@ -82,9 +82,9 @@ pub proc assert_new_tx(msg: word)
 
     # Set the key value pair in the map to mark transaction as executed
     exec.native_account::set_map_item
-    # => [[0, 0, 0, is_executed]]
+    # => [[is_executed, 0, 0, 0]]
 
-    drop drop drop
+    movdn.3 drop drop drop
     # => [is_executed]
 
     assertz.err=ERR_TX_ALREADY_EXECUTED

--- a/crates/contracts/masm/auth/multisig_ecdsa.masm
+++ b/crates/contracts/masm/auth/multisig_ecdsa.masm
@@ -82,9 +82,9 @@ pub proc assert_new_tx(msg: word)
 
     # Set the key value pair in the map to mark transaction as executed
     exec.native_account::set_map_item
-    # => [[0, 0, 0, is_executed]]
+    # => [[is_executed, 0, 0, 0]]
 
-    drop drop drop
+    movdn.3 drop drop drop
     # => [is_executed]
 
     assertz.err=ERR_TX_ALREADY_EXECUTED

--- a/crates/contracts/src/multisig_guardian.rs
+++ b/crates/contracts/src/multisig_guardian.rs
@@ -474,11 +474,12 @@ mod tests {
 
         // Cross-SDK parity contract: the TypeScript builder must produce these
         // same identity values for the same inputs. Re-verify it against these
-        // when validating smoke-web.
-        assert_eq!(account.id().to_hex(), "0xc42d3ebf2d6ac86103906b4a71b642");
+        // when validating smoke-web. Updated here because the auth MASM changed,
+        // which changes the account code commitment and therefore the derived id.
+        assert_eq!(account.id().to_hex(), "0x7d17c59e6dbfa98162326cfad0a312");
         assert_eq!(
             account.to_commitment().into_hex(),
-            "0xf3e34ccf284ed0d9defc573d8ae7ab2d136f11dc65937939294b6155f62588c2"
+            "0x56a5cfb496800eaa45530ad8af37025ff9fbbfb0caae8b046dbb7b36b9824df6"
         );
     }
 }

--- a/crates/contracts/tests/auth/multisig.rs
+++ b/crates/contracts/tests/auth/multisig.rs
@@ -1476,3 +1476,148 @@ async fn repro_add_signer_fresh_undeployed_account() -> anyhow::Result<()> {
         Err(err) => anyhow::bail!("expected Unauthorized, got abort: {err:?}"),
     }
 }
+
+/// Tests that a GUARDIAN-enabled multisig rejects a transaction carrying the full
+/// cosigner threshold but no GUARDIAN signature.
+#[tokio::test]
+async fn test_multisig_rejects_missing_guardian_signature() -> anyhow::Result<()> {
+    let (
+        _secret_keys,
+        public_keys,
+        authenticators,
+        _guardian_secret_key,
+        guardian_public_key,
+        _guardian_authenticator,
+    ) = setup_keys_and_authenticators_with_guardian(2, 2)?;
+
+    let multisig_account =
+        create_multisig_account_with_guardian(2, &public_keys, guardian_public_key.clone(), true)?;
+
+    let output_note_asset = FungibleAsset::mock(0);
+    let mut mock_chain_builder =
+        MockChainBuilder::with_accounts([multisig_account.clone()]).unwrap();
+
+    let output_note = mock_chain_builder.add_p2id_note(
+        multisig_account.id(),
+        ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE
+            .try_into()
+            .unwrap(),
+        &[output_note_asset],
+        NoteType::Public,
+    )?;
+    let input_note = mock_chain_builder.add_spawn_note([&output_note])?;
+    let mock_chain = mock_chain_builder.build().unwrap();
+
+    let salt = Word::from([Felt::new_unchecked(1); 4]);
+
+    let tx_context_init = mock_chain
+        .build_tx_context(multisig_account.id(), &[input_note.id()], &[])?
+        .authenticator(None)
+        .extend_expected_output_notes(vec![RawOutputNote::Full(output_note.clone())])
+        .auth_args(salt)
+        .build()?;
+
+    let tx_summary = match tx_context_init.execute().await.unwrap_err() {
+        TransactionExecutorError::Unauthorized(tx_effects) => tx_effects,
+        error => panic!("expected abort with tx effects: {error:?}"),
+    };
+
+    let msg = tx_summary.as_ref().to_commitment();
+    let tx_summary = SigningInputs::TransactionSummary(tx_summary);
+
+    let sig_1 = authenticators[0]
+        .get_signature(public_keys[0].to_commitment().into(), &tx_summary)
+        .await?;
+    let sig_2 = authenticators[1]
+        .get_signature(public_keys[1].to_commitment().into(), &tx_summary)
+        .await?;
+
+    // The GUARDIAN signature is deliberately omitted.
+    let result = mock_chain
+        .build_tx_context(multisig_account.id(), &[input_note.id()], &[])?
+        .authenticator(None)
+        .extend_expected_output_notes(vec![RawOutputNote::Full(output_note)])
+        .add_signature(public_keys[0].clone().into(), msg, sig_1)
+        .add_signature(public_keys[1].clone().into(), msg, sig_2)
+        .auth_args(salt)
+        .build()?
+        .execute()
+        .await;
+
+    match result {
+        Err(TransactionExecutorError::Unauthorized(_)) => Ok(()),
+        Ok(_) => anyhow::bail!(
+            "transaction was executed with the GUARDIAN enabled and no GUARDIAN signature"
+        ),
+        Err(err) => anyhow::bail!("expected Unauthorized, got abort: {err:?}"),
+    }
+}
+
+/// Tests that `assert_new_tx` rejects a transaction whose summary has already been
+/// executed and committed.
+#[tokio::test]
+async fn test_multisig_rejects_replayed_transaction() -> anyhow::Result<()> {
+    let (_secret_keys, public_keys, authenticators, _, guardian_public_key, guardian_authenticator) =
+        setup_keys_and_authenticators_with_guardian(2, 1)?;
+
+    let signer_commitments: Vec<Word> = public_keys.iter().map(|pk| pk.to_commitment()).collect();
+    let config =
+        MultisigGuardianConfig::new(1, signer_commitments, guardian_public_key.to_commitment())
+            .with_account_type(AccountType::Public);
+    let multisig_account = MultisigGuardianBuilder::new(config).build_existing()?;
+
+    let mut mock_chain = MockChainBuilder::with_accounts([multisig_account.clone()])?.build()?;
+    let salt = Word::from([Felt::new_unchecked(5); 4]);
+
+    let tx_context_init = mock_chain
+        .build_tx_context(multisig_account.id(), &[], &[])?
+        .authenticator(None)
+        .auth_args(salt)
+        .build()?;
+
+    let tx_summary = match tx_context_init.execute().await.unwrap_err() {
+        TransactionExecutorError::Unauthorized(tx_effects) => tx_effects,
+        error => panic!("expected abort with tx effects: {error:?}"),
+    };
+
+    let msg = tx_summary.as_ref().to_commitment();
+    let tx_summary = SigningInputs::TransactionSummary(tx_summary);
+
+    let signer_sig = authenticators[0]
+        .get_signature(public_keys[0].to_commitment().into(), &tx_summary)
+        .await?;
+    let guardian_sig = guardian_authenticator
+        .get_signature(guardian_public_key.to_commitment().into(), &tx_summary)
+        .await?;
+
+    let first_tx = mock_chain
+        .build_tx_context(multisig_account.id(), &[], &[])?
+        .authenticator(None)
+        .add_signature(public_keys[0].to_commitment().into(), msg, signer_sig.clone())
+        .add_signature(guardian_public_key.to_commitment().into(), msg, guardian_sig.clone())
+        .auth_args(salt)
+        .build()?
+        .execute()
+        .await?;
+
+    mock_chain.add_pending_executed_transaction(&first_tx)?;
+    mock_chain.prove_next_block()?;
+
+    let replay = mock_chain
+        .build_tx_context(multisig_account.id(), &[], &[])?
+        .authenticator(None)
+        .add_signature(public_keys[0].to_commitment().into(), msg, signer_sig)
+        .add_signature(guardian_public_key.to_commitment().into(), msg, guardian_sig)
+        .auth_args(salt)
+        .build()?
+        .execute()
+        .await;
+
+    match replay {
+        Err(_) => Ok(()),
+        Ok(tx) => anyhow::bail!(
+            "replay of an already-executed transaction was accepted (nonce_delta = {})",
+            tx.account_delta().nonce_delta()
+        ),
+    }
+}

--- a/crates/contracts/tests/auth/multisig.rs
+++ b/crates/contracts/tests/auth/multisig.rs
@@ -1593,8 +1593,16 @@ async fn test_multisig_rejects_replayed_transaction() -> anyhow::Result<()> {
     let first_tx = mock_chain
         .build_tx_context(multisig_account.id(), &[], &[])?
         .authenticator(None)
-        .add_signature(public_keys[0].to_commitment().into(), msg, signer_sig.clone())
-        .add_signature(guardian_public_key.to_commitment().into(), msg, guardian_sig.clone())
+        .add_signature(
+            public_keys[0].to_commitment().into(),
+            msg,
+            signer_sig.clone(),
+        )
+        .add_signature(
+            guardian_public_key.to_commitment().into(),
+            msg,
+            guardian_sig.clone(),
+        )
         .auth_args(salt)
         .build()?
         .execute()
@@ -1607,7 +1615,11 @@ async fn test_multisig_rejects_replayed_transaction() -> anyhow::Result<()> {
         .build_tx_context(multisig_account.id(), &[], &[])?
         .authenticator(None)
         .add_signature(public_keys[0].to_commitment().into(), msg, signer_sig)
-        .add_signature(guardian_public_key.to_commitment().into(), msg, guardian_sig)
+        .add_signature(
+            guardian_public_key.to_commitment().into(),
+            msg,
+            guardian_sig,
+        )
         .auth_args(salt)
         .build()?
         .execute()

--- a/crates/miden-multisig-client/src/procedures.rs
+++ b/crates/miden-multisig-client/src/procedures.rs
@@ -23,7 +23,7 @@ impl ProcedureName {
     pub fn root(&self) -> Word {
         match self {
             ProcedureName::UpdateSigners => procedure_root_word(
-                "0x34963b067dbba634e57b416bc2f2a9a8d4ac24147f40b2900148c9ba44774274",
+                "0x3a5c07142f2501edd45b93db0d5c97d88093d92defc4c5d01f09840db7951cd8",
             ),
             ProcedureName::UpdateProcedureThreshold => procedure_root_word(
                 "0xec74c4b96ce593c11017ae54dec9c0ae5e0d242e8b3074eb3908d961300aed67",
@@ -35,7 +35,7 @@ impl ProcedureName {
                 "0xeceb1f2c2d7d20312dbaf091e9a27a2b63f9fcba120948043069793a5715bc96",
             ),
             ProcedureName::VerifyGuardian => procedure_root_word(
-                "0xe6a8a62d37117f55a79b5345aa3d263ab16e973d486bac9a1612663dfdecf82d",
+                "0xff45881bc28ced66a55102c5410d6b2253ca3ac757daf308fb72d1b0af76fcf9",
             ),
             ProcedureName::SendAsset => procedure_root_word(
                 "0xfb1c73d10de1954e9e8948964e3e77cf4e33759d2e012cb00eb10c50f2974eb4",

--- a/packages/miden-multisig-client/masm/auth/guardian.masm
+++ b/packages/miden-multisig-client/masm/auth/guardian.masm
@@ -179,7 +179,7 @@ end
 pub proc verify_guardian_signature(msg: word)
     push.GUARDIAN_SELECTOR_SLOT[0..2]
     exec.active_account::get_item
-    drop drop drop
+    movdn.3 drop drop drop
     # => [selector, MSG]
 
     push.1 eq

--- a/packages/miden-multisig-client/masm/auth/guardian_ecdsa.masm
+++ b/packages/miden-multisig-client/masm/auth/guardian_ecdsa.masm
@@ -175,7 +175,7 @@ end
 pub proc verify_guardian_signature(msg: word)
     push.GUARDIAN_SELECTOR_SLOT[0..2]
     exec.active_account::get_item
-    drop drop drop
+    movdn.3 drop drop drop
     # => [selector, MSG]
 
     push.1 eq

--- a/packages/miden-multisig-client/masm/auth/multisig.masm
+++ b/packages/miden-multisig-client/masm/auth/multisig.masm
@@ -82,9 +82,9 @@ pub proc assert_new_tx(msg: word)
 
     # Set the key value pair in the map to mark transaction as executed
     exec.native_account::set_map_item
-    # => [[0, 0, 0, is_executed]]
+    # => [[is_executed, 0, 0, 0]]
 
-    drop drop drop
+    movdn.3 drop drop drop
     # => [is_executed]
 
     assertz.err=ERR_TX_ALREADY_EXECUTED

--- a/packages/miden-multisig-client/masm/auth/multisig_ecdsa.masm
+++ b/packages/miden-multisig-client/masm/auth/multisig_ecdsa.masm
@@ -82,9 +82,9 @@ pub proc assert_new_tx(msg: word)
 
     # Set the key value pair in the map to mark transaction as executed
     exec.native_account::set_map_item
-    # => [[0, 0, 0, is_executed]]
+    # => [[is_executed, 0, 0, 0]]
 
-    drop drop drop
+    movdn.3 drop drop drop
     # => [is_executed]
 
     assertz.err=ERR_TX_ALREADY_EXECUTED

--- a/packages/miden-multisig-client/src/account/masm/auth.ts
+++ b/packages/miden-multisig-client/src/account/masm/auth.ts
@@ -85,9 +85,9 @@ pub proc assert_new_tx(msg: word)
 
     # Set the key value pair in the map to mark transaction as executed
     exec.native_account::set_map_item
-    # => [[0, 0, 0, is_executed]]
+    # => [[is_executed, 0, 0, 0]]
 
-    drop drop drop
+    movdn.3 drop drop drop
     # => [is_executed]
 
     assertz.err=ERR_TX_ALREADY_EXECUTED
@@ -641,9 +641,9 @@ pub proc assert_new_tx(msg: word)
 
     # Set the key value pair in the map to mark transaction as executed
     exec.native_account::set_map_item
-    # => [[0, 0, 0, is_executed]]
+    # => [[is_executed, 0, 0, 0]]
 
-    drop drop drop
+    movdn.3 drop drop drop
     # => [is_executed]
 
     assertz.err=ERR_TX_ALREADY_EXECUTED
@@ -1294,7 +1294,7 @@ end
 pub proc verify_guardian_signature(msg: word)
     push.GUARDIAN_SELECTOR_SLOT[0..2]
     exec.active_account::get_item
-    drop drop drop
+    movdn.3 drop drop drop
     # => [selector, MSG]
 
     push.1 eq
@@ -1491,7 +1491,7 @@ end
 pub proc verify_guardian_signature(msg: word)
     push.GUARDIAN_SELECTOR_SLOT[0..2]
     exec.active_account::get_item
-    drop drop drop
+    movdn.3 drop drop drop
     # => [selector, MSG]
 
     push.1 eq


### PR DESCRIPTION
Closes #382

The v0.14 upgrade (#185) moved these components to Miden's little-endian operand-stack convention and updated twelve word reads to `movdn.3 drop drop drop`. Four reads were missed, so both `verify_guardian_signature` and `assert_new_tx` inspect the padding felt at element 3 instead of the flag at element 0, which is always zero.

As a result the guardian branch in `verify_guardian_signature` is never entered, and `ERR_TX_ALREADY_EXECUTED` in `assert_new_tx` is unreachable.

Applies `movdn.3` at the four sites:

- `crates/contracts/masm/auth/guardian.masm:182`
- `crates/contracts/masm/auth/guardian_ecdsa.masm:178`
- `crates/contracts/masm/auth/multisig.masm:87`
- `crates/contracts/masm/auth/multisig_ecdsa.masm:87`

Also corrects two stale stack comments that described the pre-migration layout, and regenerates the packaged MASM and TS copies.

Adds regression tests for both rejection paths. Neither was previously covered: the existing tests always attach a valid guardian signature and submit each transaction once, so both branches were unreachable in the suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multisignature transaction validation and guardian authentication handling.
  * Prevented valid guardian signatures from being misread during authorization.
  * Strengthened replay protection by correctly preserving transaction execution status.
  * Applied fixes consistently across supported Falcon and ECDSA authentication flows.

* **Tests**
  * Added regression coverage for missing guardian signatures.
  * Added coverage ensuring previously executed transactions cannot be replayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->