### PR TITLE
feat(multisig-client): expose signer public-key commitment accessors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,6 +310,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-npm-multisig-
 
+      # rust-toolchain.toml pins a toolchain with components that rustup syncs
+      # on first cargo use. Two test files shell out to `cargo run`
+      # concurrently (procedure-roots, account-roundtrip), and concurrent
+      # first-use syncs race each other ("detected conflict: 'bin/cargo'").
+      # Building both example fixtures here syncs once, serially, and turns
+      # the in-test cargo runs into cache hits.
+      - name: Sync pinned toolchain and prebuild example fixtures
+        if: matrix.package == 'miden-multisig-client'
+        working-directory: .
+        run: cargo build --quiet --example procedure_roots --example serialized_account -p miden-multisig-client
+
       - name: Install dependencies
         run: npm ci
 

--- a/crates/miden-multisig-client/examples/serialized_account.rs
+++ b/crates/miden-multisig-client/examples/serialized_account.rs
@@ -1,0 +1,68 @@
+//! Emit a deterministic serialized guarded-multisig account for the TS SDK's
+//! round-trip tests (`packages/miden-multisig-client/tests/account-roundtrip.test.ts`).
+//!
+//! The TS test deserializes the account with the real WASM SDK and asserts the
+//! `AccountInspector` accessors return the exact configuration written here,
+//! proving the Rust writer and TS reader agree on the storage layout and that
+//! the readers work against real SDK storage semantics.
+//!
+//! Run with:
+//! ```sh
+//! cargo run --example serialized_account -p miden-multisig-client
+//! ```
+
+use miden_confidential_contracts::multisig_guardian::{
+    MultisigGuardianBuilder, MultisigGuardianConfig,
+};
+use miden_protocol::utils::serde::Serializable;
+use miden_protocol::{Felt, Word};
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+struct SerializedAccountOutput {
+    account_hex: String,
+    threshold: u32,
+    signer_commitments: Vec<String>,
+    guardian_commitment: String,
+}
+
+fn mock_commitment(seed: u64) -> Word {
+    Word::from([
+        Felt::new_unchecked(seed),
+        Felt::new_unchecked(seed + 1),
+        Felt::new_unchecked(seed + 2),
+        Felt::new_unchecked(seed + 3),
+    ])
+}
+
+/// Hex in the SDK's `Word::toHex` format: little-endian bytes per felt.
+fn word_to_sdk_hex(word: &Word) -> String {
+    format!("0x{}", hex::encode(word.to_bytes()))
+}
+
+fn main() {
+    let signers = vec![
+        mock_commitment(1),
+        mock_commitment(100),
+        mock_commitment(200),
+    ];
+    let guardian = mock_commitment(1000);
+
+    let config = MultisigGuardianConfig::new(2, signers.clone(), guardian);
+    let account = MultisigGuardianBuilder::new(config)
+        .with_seed([42u8; 32])
+        .build()
+        .expect("failed to build account");
+
+    let output = SerializedAccountOutput {
+        account_hex: format!("0x{}", hex::encode(account.to_bytes())),
+        threshold: 2,
+        signer_commitments: signers.iter().map(word_to_sdk_hex).collect(),
+        guardian_commitment: word_to_sdk_hex(&guardian),
+    };
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&output).expect("serialized account json serialization")
+    );
+}

--- a/docs/MULTISIG_SDK.md
+++ b/docs/MULTISIG_SDK.md
@@ -824,6 +824,8 @@ await multisig.executeProposal(signedProposal.id);
 | `importProposal(json)` | Import offline proposal |
 | `signProposalOffline(id)` | Sign imported proposal offline |
 | `getConsumableNotes()` | Get notes that can be consumed |
+| `getSignerPublicKeyCommitments()` | Read the current signer public-key commitments from account storage, ordered by signer index (strict; throws on partial reads) |
+| `getGuardianPublicKeyCommitment()` | Read the current guardian commitment from account storage (strict; throws when the entry is missing — the guarded-multisig always includes a guardian) |
 
 #### FalconSigner
 
@@ -841,13 +843,30 @@ await multisig.executeProposal(signedProposal.id);
 |--------|-------------|
 | `fromBase64(data)` | Inspect base64-encoded account |
 | `fromAccount(account)` | Inspect Account object |
+| `getSignerPublicKeyCommitments(account)` | Read the signer public-key commitments ordered by signer index (strict; throws on a foreign contract version or any absent entry) |
+| `getGuardianPublicKeyCommitment(account)` | Read the guardian commitment (strict; throws on a foreign contract version or a missing entry) |
 
-Returns `DetectedMultisigConfig`:
+`fromBase64` / `fromAccount` return `DetectedMultisigConfig`:
 - `threshold`: number
 - `numSigners`: number
 - `signerCommitments`: string[]
-- `guardianCommitment`: string
+- `guardianCommitment`: string | null
 - `vaultBalances`: { faucetId, amount }[]
+
+> **Reading an account's keys:** since the account uses the upstream
+> `AuthGuardedMultisig` component, the Miden SDK's
+> `Account.getPublicKeyCommitments()` returns the approver commitments
+> natively. The accessors above are the strict, layout-insulated
+> alternative (issue #306): they validate the complete set against the
+> configured signer count and throw instead of silently omitting
+> unreadable entries, and they shield consumers from storage-layout
+> changes across contract versions (both are gated on the pinned contract
+> version — see [Contract version pinning](#contract-version-pinning)).
+> Commitments are ordered by signer index as currently stored (indices
+> re-pack when signers are removed); hot/cold roles are a consumer-side
+> convention. The `Account` must come from the same copy of
+> `@miden-sdk/miden-sdk` that this package links — a separately bundled
+> SDK copy is rejected by the SDK's instance checks.
 
 ---
 

--- a/packages/miden-multisig-client/README.md
+++ b/packages/miden-multisig-client/README.md
@@ -160,6 +160,47 @@ The configuration is automatically detected from the account's on-chain storage:
 const multisig = await client.load(accountId, signer);
 ```
 
+### Read Signer Public-Key Commitments
+
+Since accounts use the upstream `AuthGuardedMultisig` component, the Miden
+SDK's `Account.getPublicKeyCommitments()` returns the approver commitments
+natively. The `AccountInspector` accessors are the strict, layout-insulated
+alternative (issue #306): they validate the complete set against the
+configured signer count and throw instead of silently omitting unreadable
+entries, and they shield consumers from storage-layout changes across
+contract versions.
+
+Holding only a fetched Miden SDK `Account` (e.g. a wallet or dApp):
+
+```typescript
+import { AccountInspector } from '@openzeppelin/miden-multisig-client';
+
+const commitments = AccountInspector.getSignerPublicKeyCommitments(account);
+const guardianKey = AccountInspector.getGuardianPublicKeyCommitment(account);
+```
+
+Or from a loaded `Multisig` instance (reads current store-backed state):
+
+```typescript
+const signerKeys = await multisig.getSignerPublicKeyCommitments();
+```
+
+Commitments are ordered by signer index as currently stored; indices re-pack
+when signers are removed, so index 0 is the key listed first at creation (by
+convention the creating client's own key) only until the first membership
+change. Hot/cold roles are a consumer-side convention, not part of on-chain
+state. `getSignerPublicKeyCommitments` throws rather than silently returning
+a truncated list when any signer entry is absent; `getGuardianPublicKeyCommitment`
+throws when the guardian entry is missing (the guarded-multisig always
+includes a guardian). Both are gated on this SDK's pinned contract version
+and reject accounts built from a different miden-standards release.
+
+The `Account` passed to `AccountInspector` must come from the same copy of
+`@miden-sdk/miden-sdk` that this package links. An application bundling its
+own SDK copy (common in wallets) will get a descriptive error from the SDK's
+instance checks; construct the account with this package's SDK instance
+instead.
+
 ### Recover An Account By Key
 
 When the wallet only holds a signing key from the account's authorization

--- a/packages/miden-multisig-client/src/account/layout.ts
+++ b/packages/miden-multisig-client/src/account/layout.ts
@@ -1,0 +1,33 @@
+/**
+ * `AuthGuardedMultisig` storage slot names (`miden::standards::auth::*`),
+ * shared by the writer (`account/storage.ts`) and the readers
+ * (`inspector.ts`). Single source of truth so the two cannot drift. These
+ * must match the Rust `miden-standards` component exactly: account ID and
+ * commitment derive from the storage layout, so any divergence breaks
+ * cross-SDK determinism (guarded by the parity test).
+ *
+ * Deliberately not re-exported from the package index: consumers should use
+ * the `AccountInspector` accessors rather than reading storage directly
+ * (issue #306).
+ */
+
+export const MULTISIG_SLOT_NAMES = {
+  THRESHOLD_CONFIG: 'miden::standards::auth::multisig::threshold_config',
+  SIGNER_PUBLIC_KEYS: 'miden::standards::auth::multisig::approver_public_keys',
+  SIGNER_SCHEME_IDS: 'miden::standards::auth::multisig::approver_schemes',
+  EXECUTED_TRANSACTIONS: 'miden::standards::auth::multisig::executed_transactions',
+  PROCEDURE_THRESHOLDS: 'miden::standards::auth::multisig::procedure_thresholds',
+} as const;
+
+export const GUARDIAN_SLOT_NAMES = {
+  PUBLIC_KEY: 'miden::standards::auth::guardian::pub_key',
+  SCHEME_ID: 'miden::standards::auth::guardian::scheme',
+} as const;
+
+/**
+ * Sanity ceiling for the signer count read from `threshold_config`. The
+ * contract has no on-chain maximum (the felt is only asserted to be a u32),
+ * so a corrupt or adversarial account could report an arbitrarily large
+ * count; readers bound their loops with this instead of trusting it.
+ */
+export const MAX_SIGNERS = 1000;

--- a/packages/miden-multisig-client/src/account/storage.ts
+++ b/packages/miden-multisig-client/src/account/storage.ts
@@ -2,24 +2,7 @@ import type { MultisigConfig } from '../types.js';
 import { StorageSlot, StorageMap, Word } from '@miden-sdk/miden-sdk';
 import { ensureHexPrefix } from '../utils/encoding.js';
 import { getProcedureRoot } from '../procedures.js';
-
-/**
- * `AuthGuardedMultisig` storage slot names (`miden::standards::auth::*`). These must match the
- * Rust `miden-standards` component exactly: account ID and commitment derive from the storage
- * layout, so any divergence breaks cross-SDK determinism (guarded by the parity test).
- */
-const MULTISIG_SLOT_NAMES = {
-  THRESHOLD_CONFIG: 'miden::standards::auth::multisig::threshold_config',
-  SIGNER_PUBLIC_KEYS: 'miden::standards::auth::multisig::approver_public_keys',
-  SIGNER_SCHEME_IDS: 'miden::standards::auth::multisig::approver_schemes',
-  EXECUTED_TRANSACTIONS: 'miden::standards::auth::multisig::executed_transactions',
-  PROCEDURE_THRESHOLDS: 'miden::standards::auth::multisig::procedure_thresholds',
-} as const;
-
-const GUARDIAN_SLOT_NAMES = {
-  PUBLIC_KEY: 'miden::standards::auth::guardian::pub_key',
-  SCHEME_ID: 'miden::standards::auth::guardian::scheme',
-} as const;
+import { MULTISIG_SLOT_NAMES, GUARDIAN_SLOT_NAMES } from './layout.js';
 
 function signerMapKey(index: bigint): Word {
   return new Word(new BigUint64Array([index, 0n, 0n, 0n]));

--- a/packages/miden-multisig-client/src/client.test.ts
+++ b/packages/miden-multisig-client/src/client.test.ts
@@ -19,21 +19,27 @@ vi.mock('@miden-sdk/miden-sdk', () => ({
       vault: vi.fn(),
     })),
   },
+  Word: vi.fn(),
 }));
 
-// Mock the AccountInspector
-vi.mock('./inspector.js', () => ({
-  AccountInspector: {
-    fromAccount: vi.fn(() => ({
-      threshold: 2,
-      numSigners: 2,
-      signerCommitments: ['0x' + 'a'.repeat(64), '0x' + 'b'.repeat(64)],
-      guardianCommitment: '0x' + 'c'.repeat(64),
-      vaultBalances: [],
-      procedureThresholds: new Map(),
-    })),
-  },
-}));
+// Mock the AccountInspector, keeping the real assertCompleteDetectedConfig
+// so load()'s fail-closed validation is exercised.
+vi.mock('./inspector.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./inspector.js')>();
+  return {
+    ...actual,
+    AccountInspector: {
+      fromAccount: vi.fn(() => ({
+        threshold: 2,
+        numSigners: 2,
+        signerCommitments: ['0x' + 'a'.repeat(64), '0x' + 'b'.repeat(64)],
+        guardianCommitment: '0x' + 'c'.repeat(64),
+        vaultBalances: [],
+        procedureThresholds: new Map(),
+      })),
+    },
+  };
+});
 
 // Mock the account creation module
 vi.mock('./account/index.js', () => ({
@@ -229,6 +235,66 @@ describe('MultisigClient', () => {
       expect(multisig.account).not.toBeNull();
       expect(webClient.accounts.get).toHaveBeenCalledTimes(1);
       expect(webClient.accounts.insert).toHaveBeenCalledTimes(1);
+    });
+
+    it('fails closed when the detected signer set is incomplete (issue #306 review)', async () => {
+      const client = new MultisigClient(webClient, CLIENT_CONFIG);
+
+      const { AccountInspector } = await import('./inspector.js');
+      // Storage reports 3 signers but only 2 entries were readable — adopting
+      // this config would let membership proposals drop the missing key.
+      vi.mocked(AccountInspector.fromAccount).mockReturnValueOnce({
+        threshold: 2,
+        numSigners: 3,
+        signerCommitments: ['0x' + 'a'.repeat(64), '0x' + 'b'.repeat(64)],
+        guardianCommitment: '0x' + 'c'.repeat(64),
+        vaultBalances: [],
+        procedureThresholds: new Map(),
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          account_id: '0x' + 'd'.repeat(30),
+          commitment: '0x' + 'e'.repeat(64),
+          state_json: { data: 'base64state' },
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-02T00:00:00Z',
+        }),
+      });
+
+      await expect(client.load('0x' + 'd'.repeat(30), mockSigner)).rejects.toThrow(
+        /incomplete signer set: storage reports 3 signers, read 2/,
+      );
+    });
+
+    it('fails closed when the guardian commitment is missing', async () => {
+      const client = new MultisigClient(webClient, CLIENT_CONFIG);
+
+      const { AccountInspector } = await import('./inspector.js');
+      vi.mocked(AccountInspector.fromAccount).mockReturnValueOnce({
+        threshold: 1,
+        numSigners: 1,
+        signerCommitments: ['0x' + 'a'.repeat(64)],
+        guardianCommitment: null,
+        vaultBalances: [],
+        procedureThresholds: new Map(),
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          account_id: '0x' + 'd'.repeat(30),
+          commitment: '0x' + 'e'.repeat(64),
+          state_json: { data: 'base64state' },
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-02T00:00:00Z',
+        }),
+      });
+
+      await expect(client.load('0x' + 'd'.repeat(30), mockSigner)).rejects.toThrow(
+        /missing guardian commitment/,
+      );
     });
 
     it('should throw if account not found on GUARDIAN', async () => {

--- a/packages/miden-multisig-client/src/client.ts
+++ b/packages/miden-multisig-client/src/client.ts
@@ -10,7 +10,7 @@ import { GuardianHttpClient } from '@openzeppelin/guardian-client';
 import type { StateObject } from '@openzeppelin/guardian-client';
 import { Multisig } from './multisig.js';
 import { createMultisigAccount } from './account/index.js';
-import { AccountInspector } from './inspector.js';
+import { AccountInspector, assertCompleteDetectedConfig } from './inspector.js';
 import { getRawMidenClient, requireConfigValue, requireMidenRpcEndpoint } from './raw-client.js';
 import type { MultisigConfig, Signer } from './types.js';
 import {
@@ -214,10 +214,13 @@ export class MultisigClient {
     const account = Account.deserialize(accountBytes);
 
     const detected = AccountInspector.fromAccount(account);
+    // Fail closed on a partial read: the detected signer set becomes the
+    // authoritative config that membership proposals rewrite on-chain.
+    assertCompleteDetectedConfig(detected);
     const config: MultisigConfig = {
       threshold: detected.threshold,
       signerCommitments: detected.signerCommitments,
-      guardianCommitment: detected.guardianCommitment ?? '',
+      guardianCommitment: detected.guardianCommitment,
       procedureThresholds: Array.from(detected.procedureThresholds.entries()).map(
         ([procedure, threshold]) => ({ procedure, threshold })
       ),

--- a/packages/miden-multisig-client/src/inspector.test.ts
+++ b/packages/miden-multisig-client/src/inspector.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { AccountInspector } from './inspector.js';
+import { AccountInspector, assertCompleteDetectedConfig } from './inspector.js';
+import type { DetectedMultisigConfig } from './inspector.js';
 
 // Mock the Miden SDK
 vi.mock('@miden-sdk/miden-sdk', () => {
@@ -494,5 +495,48 @@ describe('AccountInspector.getGuardianPublicKeyCommitment', () => {
     expect(() => AccountInspector.getGuardianPublicKeyCommitment(account)).toThrow(
       'storage backend exploded'
     );
+  });
+});
+
+describe('assertCompleteDetectedConfig', () => {
+  const complete: DetectedMultisigConfig = {
+    threshold: 2,
+    numSigners: 2,
+    signerCommitments: ['0x' + 'a'.repeat(64), '0x' + 'b'.repeat(64)],
+    guardianCommitment: '0x' + 'c'.repeat(64),
+    vaultBalances: [],
+    procedureThresholds: new Map(),
+  };
+
+  it('accepts a complete config', () => {
+    expect(() => assertCompleteDetectedConfig(complete)).not.toThrow();
+  });
+
+  it('rejects a signer set shorter than the reported count', () => {
+    expect(() =>
+      assertCompleteDetectedConfig({
+        ...complete,
+        numSigners: 3,
+      }),
+    ).toThrow(/incomplete signer set: storage reports 3 signers, read 2/);
+  });
+
+  it('rejects a zero signer count', () => {
+    expect(() =>
+      assertCompleteDetectedConfig({
+        ...complete,
+        numSigners: 0,
+        signerCommitments: [],
+      }),
+    ).toThrow(/incomplete signer set/);
+  });
+
+  it('rejects a missing guardian commitment', () => {
+    expect(() =>
+      assertCompleteDetectedConfig({
+        ...complete,
+        guardianCommitment: null,
+      }),
+    ).toThrow(/missing guardian commitment/);
   });
 });

--- a/packages/miden-multisig-client/src/inspector.test.ts
+++ b/packages/miden-multisig-client/src/inspector.test.ts
@@ -8,15 +8,18 @@ vi.mock('@miden-sdk/miden-sdk', () => {
     toHex: () => '0x' + values.map(v => v.toString(16).padStart(16, '0')).join(''),
   });
 
+  // Faithful to the real SDK's read semantics (verified against the wasm
+  // glue and miden-protocol): getItem returns undefined for an absent slot;
+  // getMapItem returns undefined only when the slot is absent or not a map,
+  // and the EMPTY word for a missing key in an existing map
+  // (StorageMap::get is unwrap_or_default). Neither throws for "not found".
   const createMockStorage = (slots: Map<string, any>, maps: Map<string, Map<string, any>>) => ({
-    getItem: (slotName: string) => slots.get(slotName) ?? createMockWord([0n, 0n, 0n, 0n]),
+    getItem: (slotName: string) => slots.get(slotName),
     getMapItem: (slotName: string, key: any) => {
       const map = maps.get(slotName);
-      if (!map) throw new Error('Map not found');
+      if (!map) return undefined;
       const keyStr = key.toU64s?.()[0]?.toString() ?? '0';
-      const value = map.get(keyStr);
-      if (!value) throw new Error('Key not found');
-      return value;
+      return map.get(keyStr) ?? createMockWord([0n, 0n, 0n, 0n]);
     },
   });
 
@@ -256,5 +259,240 @@ describe('AccountInspector edge cases', () => {
     const config = AccountInspector.fromAccount(account);
 
     expect(config.vaultBalances).toEqual([]);
+  });
+});
+
+describe('AccountInspector.getSignerPublicKeyCommitments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns all signer commitments ordered by signer index', async () => {
+    const { Account } = await import('@miden-sdk/miden-sdk');
+    const account = Account.deserialize(new Uint8Array([1, 2, 3]));
+
+    const commitments = AccountInspector.getSignerPublicKeyCommitments(account);
+
+    expect(commitments).toEqual([
+      '0x1111111111111111222222222222222233333333333333334444444444444444',
+      '0x5555555555555555666666666666666677777777777777778888888888888888',
+      '0xaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbccccccccccccccccdddddddddddddddd',
+    ]);
+  });
+
+  it('rejects accounts built from a different contract version', async () => {
+    const { Account } = await import('@miden-sdk/miden-sdk');
+    const account = Account.deserialize(new Uint8Array([1, 2, 3]));
+    const foreign = {
+      ...account,
+      code: () => ({ hasProcedure: () => false }),
+    };
+
+    expect(() => AccountInspector.getSignerPublicKeyCommitments(foreign as never)).toThrow(
+      /unsupported contract version/,
+    );
+  });
+
+  it('throws when a signer map entry is the empty word instead of truncating', async () => {
+    const { Account } = await import('@miden-sdk/miden-sdk');
+
+    // Real SDK semantics: entries 0 and 1 exist, entries 2..4 come back as
+    // the empty word (StorageMap::get is unwrap_or_default) — NOT undefined
+    // and NOT a throw.
+    const entries = new Map<string, any>([
+      ['0', { toU64s: () => [1n, 2n, 3n, 4n], toHex: () => '0x' + 'a'.repeat(64) }],
+      ['1', { toU64s: () => [5n, 6n, 7n, 8n], toHex: () => '0x' + 'b'.repeat(64) }],
+    ]);
+    vi.mocked(Account.deserialize).mockReturnValueOnce({
+      code: () => ({ hasProcedure: () => true }),
+      storage: () => ({
+        getItem: (slotName: string) => {
+          if (slotName === 'miden::standards::auth::multisig::threshold_config') return { toU64s: () => [2n, 5n, 0n, 0n] };
+          return undefined;
+        },
+        getMapItem: (slotName: string, key: any) => {
+          if (slotName !== 'miden::standards::auth::multisig::approver_public_keys') return undefined;
+          const keyStr = key.toU64s?.()[0]?.toString() ?? '0';
+          return entries.get(keyStr) ?? { toU64s: () => [0n, 0n, 0n, 0n] };
+        },
+      }),
+    } as any);
+
+    const account = Account.deserialize(new Uint8Array([1, 2, 3]));
+
+    expect(() => AccountInspector.getSignerPublicKeyCommitments(account)).toThrow(
+      /missing signer public key at index 2/
+    );
+  });
+
+  it('throws when the signer map slot itself is absent', async () => {
+    const { Account } = await import('@miden-sdk/miden-sdk');
+
+    vi.mocked(Account.deserialize).mockReturnValueOnce({
+      code: () => ({ hasProcedure: () => true }),
+      storage: () => ({
+        getItem: (slotName: string) => {
+          if (slotName === 'miden::standards::auth::multisig::threshold_config') return { toU64s: () => [2n, 3n, 0n, 0n] };
+          return undefined;
+        },
+        getMapItem: () => undefined,
+      }),
+    } as any);
+
+    const account = Account.deserialize(new Uint8Array([1, 2, 3]));
+
+    expect(() => AccountInspector.getSignerPublicKeyCommitments(account)).toThrow(
+      /missing signer public key at index 0/
+    );
+  });
+
+  it('throws when the threshold config slot is absent', async () => {
+    const { Account } = await import('@miden-sdk/miden-sdk');
+
+    vi.mocked(Account.deserialize).mockReturnValueOnce({
+      code: () => ({ hasProcedure: () => true }),
+      storage: () => ({
+        getItem: () => undefined,
+        getMapItem: () => undefined,
+      }),
+    } as any);
+
+    const account = Account.deserialize(new Uint8Array([1, 2, 3]));
+
+    expect(() => AccountInspector.getSignerPublicKeyCommitments(account)).toThrow(
+      /not a guarded-multisig account/
+    );
+  });
+
+  it('throws when the threshold config reports zero signers', async () => {
+    const { Account } = await import('@miden-sdk/miden-sdk');
+
+    vi.mocked(Account.deserialize).mockReturnValueOnce({
+      code: () => ({ hasProcedure: () => true }),
+      storage: () => ({
+        getItem: () => ({ toU64s: () => [0n, 0n, 0n, 0n] }),
+        getMapItem: () => undefined,
+      }),
+    } as any);
+
+    const account = Account.deserialize(new Uint8Array([1, 2, 3]));
+
+    expect(() => AccountInspector.getSignerPublicKeyCommitments(account)).toThrow(
+      /zero signers/
+    );
+  });
+
+  // 2n ** 53n is the smallest count whose Number() conversion is no longer a
+  // safe integer (i++ would stop advancing without the ceiling guard).
+  it.each([4294967295n, 2n ** 53n])(
+    'throws on an absurd signer count (%s) instead of looping',
+    async (count) => {
+      const { Account } = await import('@miden-sdk/miden-sdk');
+
+      vi.mocked(Account.deserialize).mockReturnValueOnce({
+        code: () => ({ hasProcedure: () => true }),
+        storage: () => ({
+          getItem: () => ({ toU64s: () => [2n, count, 0n, 0n] }),
+          getMapItem: () => ({ toU64s: () => [1n, 2n, 3n, 4n], toHex: () => '0x' + 'a'.repeat(64) }),
+        }),
+      } as any);
+
+      const account = Account.deserialize(new Uint8Array([1, 2, 3]));
+
+      expect(() => AccountInspector.getSignerPublicKeyCommitments(account)).toThrow(
+        /sanity limit/
+      );
+    },
+  );
+
+  it('surfaces a descriptive error for an account from a different SDK copy', async () => {
+    const { Account } = await import('@miden-sdk/miden-sdk');
+
+    // wasm-bindgen's _assertClass rejects Word instances from another
+    // bundled SDK copy with this exact message.
+    vi.mocked(Account.deserialize).mockReturnValueOnce({
+      code: () => ({ hasProcedure: () => true }),
+      storage: () => ({
+        getItem: (slotName: string) => {
+          if (slotName === 'miden::standards::auth::multisig::threshold_config') return { toU64s: () => [1n, 1n, 0n, 0n] };
+          return undefined;
+        },
+        getMapItem: () => {
+          throw new Error('expected instance of Word');
+        },
+      }),
+    } as any);
+
+    const account = Account.deserialize(new Uint8Array([1, 2, 3]));
+
+    expect(() => AccountInspector.getSignerPublicKeyCommitments(account)).toThrow(
+      /different copy of @miden-sdk\/miden-sdk/
+    );
+  });
+});
+
+describe('AccountInspector.getGuardianPublicKeyCommitment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the guardian commitment', async () => {
+    const { Account } = await import('@miden-sdk/miden-sdk');
+    const account = Account.deserialize(new Uint8Array([1, 2, 3]));
+
+    const commitment = AccountInspector.getGuardianPublicKeyCommitment(account);
+
+    expect(commitment).toBe('0xeeeeeeeeeeeeeeeeffffffffffffffff00000000000000010000000000000002');
+  });
+
+  it('rejects accounts built from a different contract version', async () => {
+    const { Account } = await import('@miden-sdk/miden-sdk');
+    const account = Account.deserialize(new Uint8Array([1, 2, 3]));
+    const foreign = {
+      ...account,
+      code: () => ({ hasProcedure: () => false }),
+    };
+
+    expect(() => AccountInspector.getGuardianPublicKeyCommitment(foreign as never)).toThrow(
+      /unsupported contract version/,
+    );
+  });
+
+  it('throws when the guardian key entry is the empty word', async () => {
+    const { Account } = await import('@miden-sdk/miden-sdk');
+
+    vi.mocked(Account.deserialize).mockReturnValueOnce({
+      code: () => ({ hasProcedure: () => true }),
+      storage: () => ({
+        getItem: () => ({ toU64s: () => [1n, 1n, 0n, 0n] }),
+        getMapItem: () => ({ toU64s: () => [0n, 0n, 0n, 0n] }),
+      }),
+    } as any);
+
+    const account = Account.deserialize(new Uint8Array([1, 2, 3]));
+
+    expect(() => AccountInspector.getGuardianPublicKeyCommitment(account)).toThrow(
+      /inconsistent account state/
+    );
+  });
+
+  it('propagates genuine storage read failures', async () => {
+    const { Account } = await import('@miden-sdk/miden-sdk');
+
+    vi.mocked(Account.deserialize).mockReturnValueOnce({
+      code: () => ({ hasProcedure: () => true }),
+      storage: () => ({
+        getItem: () => ({ toU64s: () => [1n, 1n, 0n, 0n] }),
+        getMapItem: () => {
+          throw new Error('storage backend exploded');
+        },
+      }),
+    } as any);
+
+    const account = Account.deserialize(new Uint8Array([1, 2, 3]));
+
+    expect(() => AccountInspector.getGuardianPublicKeyCommitment(account)).toThrow(
+      'storage backend exploded'
+    );
   });
 });

--- a/packages/miden-multisig-client/src/inspector.ts
+++ b/packages/miden-multisig-client/src/inspector.ts
@@ -4,20 +4,11 @@
 
 import { Account, Word } from '@miden-sdk/miden-sdk';
 import { base64ToUint8Array } from './utils/encoding.js';
-import { wordElementToBigInt, wordToHex } from './utils/word.js';
+import { isEmptyWord, wordElementToBigInt, wordToHex } from './utils/word.js';
 import { getProcedureRoot, getProcedureNames, type ProcedureName } from './procedures.js';
+import { MULTISIG_SLOT_NAMES, GUARDIAN_SLOT_NAMES, MAX_SIGNERS } from './account/layout.js';
 
-// `AuthGuardedMultisig` storage slot names (miden::standards::auth::*).
-const MULTISIG_SLOT_NAMES = {
-  THRESHOLD_CONFIG: 'miden::standards::auth::multisig::threshold_config',
-  SIGNER_PUBLIC_KEYS: 'miden::standards::auth::multisig::approver_public_keys',
-  EXECUTED_TRANSACTIONS: 'miden::standards::auth::multisig::executed_transactions',
-  PROCEDURE_THRESHOLDS: 'miden::standards::auth::multisig::procedure_thresholds',
-} as const;
-
-const GUARDIAN_SLOT_NAMES = {
-  PUBLIC_KEY: 'miden::standards::auth::guardian::pub_key',
-} as const;
+type AccountStorageLike = ReturnType<Account['storage']>;
 
 export interface VaultBalance {
   faucetId: string;
@@ -31,6 +22,62 @@ export interface DetectedMultisigConfig {
   guardianCommitment: string | null;
   vaultBalances: VaultBalance[];
   procedureThresholds: Map<ProcedureName, number>;
+}
+
+/**
+ * Rejects accounts built from a different contract version before any
+ * layout-dependent read: against such an account the slot names and
+ * procedure-root-keyed maps below describe a different component, so reads
+ * would silently miss its state.
+ */
+function assertPinnedContractVersion(account: Account): void {
+  if (!account.code().hasProcedure(Word.fromHex(getProcedureRoot('auth_tx')))) {
+    throw new Error(
+      'unsupported contract version: the account\'s code does not carry this ' +
+      "SDK's pinned guarded-multisig auth procedure; use the SDK release " +
+      'matching the contract version the account was created with ' +
+      '(see docs/MULTISIG_SDK.md, "Contract version pinning")',
+    );
+  }
+}
+
+function indexMapKey(index: number): Word {
+  return new Word(new BigUint64Array([BigInt(index), 0n, 0n, 0n]));
+}
+
+/**
+ * Read one entry from a storage map, treating "no entry" uniformly.
+ *
+ * The SDK returns `undefined` only when the slot itself is absent or not a
+ * map; a key with no entry in an existing map comes back as `Word::empty()`
+ * (`StorageMap::get` is `unwrap_or_default()` in miden-protocol). The
+ * contract also zeroes removed approver entries, so an empty word always
+ * means "no entry" and is mapped to `undefined` here — matching the Rust
+ * readers.
+ */
+function readMapWord(
+  storage: AccountStorageLike,
+  slotName: string,
+  key: Word,
+): Word | undefined {
+  let value: Word | undefined;
+  try {
+    value = storage.getMapItem(slotName, key) as Word | undefined;
+  } catch (error) {
+    // The SDK's storage rejects Word instances constructed by a different
+    // bundled copy of @miden-sdk/miden-sdk (wasm-bindgen instance check).
+    if (error instanceof Error && error.message.includes('expected instance of Word')) {
+      throw new Error(
+        `cannot read ${slotName}: the account object comes from a different copy of @miden-sdk/miden-sdk than the one this package links; pass an Account created by the same SDK instance`,
+        { cause: error },
+      );
+    }
+    throw error;
+  }
+  if (value === undefined || isEmptyWord(value)) {
+    return undefined;
+  }
+  return value;
 }
 
 /**
@@ -50,6 +97,98 @@ export class AccountInspector {
   private constructor() {}
 
   /**
+   * Read the ordered approver (signer) public-key commitments of a
+   * guarded-multisig account from its
+   * `miden::standards::auth::multisig::approver_public_keys` storage map.
+   *
+   * Since the account uses the upstream `AuthGuardedMultisig` component,
+   * `Account.getPublicKeyCommitments()` also returns these commitments;
+   * this accessor is the strict, layout-insulated alternative: it validates
+   * the complete set against the configured signer count and throws instead
+   * of silently omitting unreadable entries, and it shields consumers from
+   * storage-layout changes across contract versions.
+   *
+   * The returned array is ordered by signer index as currently stored.
+   * Index 0 is the key listed first at creation only until the first
+   * membership change: removing a signer re-packs the indices. Hot/cold
+   * roles are a consumer-side convention, not part of on-chain state.
+   *
+   * Unlike `fromAccount()`, which tolerates partial reads, this throws if
+   * the account was built from a different contract version or any signer
+   * entry is absent — it never silently returns a truncated or empty list.
+   *
+   * The `account` must come from the same copy of `@miden-sdk/miden-sdk`
+   * that this package links; an account from a separately bundled SDK is
+   * rejected by the SDK's own instance checks (a descriptive error is
+   * thrown).
+   *
+   * @param account - The Account object from the Miden SDK
+   * @returns Signer public-key commitments as 0x-prefixed hex, ordered by signer index
+   */
+  static getSignerPublicKeyCommitments(account: Account): string[] {
+    assertPinnedContractVersion(account);
+    const storage = account.storage();
+
+    const thresholdConfig = storage.getItem(MULTISIG_SLOT_NAMES.THRESHOLD_CONFIG) as
+      | Word
+      | undefined;
+    if (!thresholdConfig) {
+      throw new Error(
+        `account has no ${MULTISIG_SLOT_NAMES.THRESHOLD_CONFIG} storage slot: not a guarded-multisig account`,
+      );
+    }
+
+    const numSigners = Number(wordElementToBigInt(thresholdConfig, 1));
+    if (numSigners === 0) {
+      throw new Error(
+        `${MULTISIG_SLOT_NAMES.THRESHOLD_CONFIG} reports zero signers: not a guarded-multisig account`,
+      );
+    }
+    if (numSigners > MAX_SIGNERS) {
+      throw new Error(
+        `${MULTISIG_SLOT_NAMES.THRESHOLD_CONFIG} reports ${numSigners} signers, exceeding the sanity limit of ${MAX_SIGNERS}: account storage is corrupt`,
+      );
+    }
+
+    const commitments: string[] = [];
+    for (let i = 0; i < numSigners; i++) {
+      const commitment = readMapWord(storage, MULTISIG_SLOT_NAMES.SIGNER_PUBLIC_KEYS, indexMapKey(i));
+      if (!commitment) {
+        throw new Error(
+          `missing signer public key at index ${i} in ${MULTISIG_SLOT_NAMES.SIGNER_PUBLIC_KEYS} (expected ${numSigners} signers)`,
+        );
+      }
+      commitments.push(wordToHex(commitment));
+    }
+    return commitments;
+  }
+
+  /**
+   * Read the guardian public-key commitment of a guarded-multisig account
+   * from its `miden::standards::auth::guardian::pub_key` storage map.
+   *
+   * The guarded-multisig component always includes a guardian, so this
+   * returns the commitment or throws: on an account from a different
+   * contract version, or when the guardian key entry is missing
+   * (inconsistent account state). Genuine storage read failures propagate.
+   *
+   * @param account - The Account object from the Miden SDK
+   * @returns The guardian commitment as 0x-prefixed hex
+   */
+  static getGuardianPublicKeyCommitment(account: Account): string {
+    assertPinnedContractVersion(account);
+    const storage = account.storage();
+
+    const commitment = readMapWord(storage, GUARDIAN_SLOT_NAMES.PUBLIC_KEY, indexMapKey(0));
+    if (!commitment) {
+      throw new Error(
+        `${GUARDIAN_SLOT_NAMES.PUBLIC_KEY} has no entry: inconsistent account state (the guarded-multisig always includes a guardian)`,
+      );
+    }
+    return wordToHex(commitment);
+  }
+
+  /**
    * Inspect a base64-encoded serialized account.
    *
    * @param base64Data - Base64-encoded Account bytes
@@ -64,6 +203,11 @@ export class AccountInspector {
   /**
    * Inspect a Miden SDK Account object.
    *
+   * Lenient by design (skips unreadable parts): `MultisigClient.load` uses
+   * it to reconstruct config from accounts it already trusts. Consumers that
+   * need a guarantee should use `getSignerPublicKeyCommitments` /
+   * `getGuardianPublicKeyCommitment`, which throw instead of degrading.
+   *
    * @param account - The Account object from Miden SDK
    * @returns Detected multisig configuration
    */
@@ -73,26 +217,18 @@ export class AccountInspector {
     // procedure-root-keyed read: against such an account the reads below would
     // silently miss its stored overrides (its `procedure_thresholds` map is
     // keyed by *its* roots, not this SDK's) and report wrong thresholds.
-    if (!account.code().hasProcedure(Word.fromHex(getProcedureRoot('auth_tx')))) {
-      throw new Error(
-        'unsupported contract version: the account\'s code does not carry this ' +
-        "SDK's pinned guarded-multisig auth procedure; use the SDK release " +
-        'matching the contract version the account was created with ' +
-        '(see docs/MULTISIG_SDK.md, "Contract version pinning")',
-      );
-    }
+    assertPinnedContractVersion(account);
 
     const storage = account.storage();
 
-    const slot0 = storage.getItem(MULTISIG_SLOT_NAMES.THRESHOLD_CONFIG) as Word;
-    const threshold = Number(wordElementToBigInt(slot0, 0));
-    const numSigners = Number(wordElementToBigInt(slot0, 1));
+    const slot0 = storage.getItem(MULTISIG_SLOT_NAMES.THRESHOLD_CONFIG) as Word | undefined;
+    const threshold = slot0 ? Number(wordElementToBigInt(slot0, 0)) : 0;
+    const numSigners = slot0 ? Number(wordElementToBigInt(slot0, 1)) : 0;
 
     const signerCommitments: string[] = [];
-    for (let i = 0; i < numSigners; i++) {
+    for (let i = 0; i < Math.min(numSigners, MAX_SIGNERS); i++) {
       try {
-        const key = new Word(new BigUint64Array([BigInt(i), 0n, 0n, 0n]));
-        const commitment = storage.getMapItem(MULTISIG_SLOT_NAMES.SIGNER_PUBLIC_KEYS, key) as Word;
+        const commitment = readMapWord(storage, MULTISIG_SLOT_NAMES.SIGNER_PUBLIC_KEYS, indexMapKey(i));
         if (commitment) {
           signerCommitments.push(wordToHex(commitment));
         }
@@ -106,8 +242,7 @@ export class AccountInspector {
     let guardianCommitment: string | null = null;
 
     try {
-      const zeroKey = new Word(new BigUint64Array([0n, 0n, 0n, 0n]));
-      const guardianKey = storage.getMapItem(GUARDIAN_SLOT_NAMES.PUBLIC_KEY, zeroKey) as Word;
+      const guardianKey = readMapWord(storage, GUARDIAN_SLOT_NAMES.PUBLIC_KEY, indexMapKey(0));
       if (guardianKey) {
         guardianCommitment = wordToHex(guardianKey);
       }
@@ -136,7 +271,7 @@ export class AccountInspector {
       try {
         const rootHex = getProcedureRoot(procName);
         const rootWord = Word.fromHex(rootHex);
-        const value = storage.getMapItem(MULTISIG_SLOT_NAMES.PROCEDURE_THRESHOLDS, rootWord) as Word;
+        const value = readMapWord(storage, MULTISIG_SLOT_NAMES.PROCEDURE_THRESHOLDS, rootWord);
         if (value) {
           const procThreshold = Number(wordElementToBigInt(value, 0));
           if (procThreshold > 0) {

--- a/packages/miden-multisig-client/src/inspector.ts
+++ b/packages/miden-multisig-client/src/inspector.ts
@@ -25,6 +25,29 @@ export interface DetectedMultisigConfig {
 }
 
 /**
+ * Fail-closed validation for consuming a lenient `fromAccount()` result on a
+ * mutation path. `fromAccount` tolerates partial reads (absent entries are
+ * skipped), which is fine for inspection but not for callers that store the
+ * result as the authoritative config: membership proposals treat the signer
+ * set as the complete on-chain set, so adopting a truncated read could
+ * rewrite the account without the omitted keys.
+ */
+export function assertCompleteDetectedConfig(
+  detected: DetectedMultisigConfig,
+): asserts detected is DetectedMultisigConfig & { guardianCommitment: string } {
+  if (detected.numSigners === 0 || detected.signerCommitments.length !== detected.numSigners) {
+    throw new Error(
+      `incomplete signer set: storage reports ${detected.numSigners} signers, read ${detected.signerCommitments.length}`,
+    );
+  }
+  if (!detected.guardianCommitment) {
+    throw new Error(
+      'missing guardian commitment: the guarded-multisig always includes a guardian',
+    );
+  }
+}
+
+/**
  * Rejects accounts built from a different contract version before any
  * layout-dependent read: against such an account the slot names and
  * procedure-root-keyed maps below describe a different component, so reads

--- a/packages/miden-multisig-client/src/multisig.test.ts
+++ b/packages/miden-multisig-client/src/multisig.test.ts
@@ -165,13 +165,19 @@ vi.mock('./utils/encoding.js', async () => {
   };
 });
 
-vi.mock('./inspector.js', () => ({
-  AccountInspector: {
-    fromAccount: mockDetectConfig,
-    getSignerPublicKeyCommitments: mockGetSignerCommitments,
-    getGuardianPublicKeyCommitment: mockGetGuardianCommitment,
-  },
-}));
+// Keep the real assertCompleteDetectedConfig so refreshConfigFromAccount's
+// fail-closed validation is exercised.
+vi.mock('./inspector.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./inspector.js')>();
+  return {
+    ...actual,
+    AccountInspector: {
+      fromAccount: mockDetectConfig,
+      getSignerPublicKeyCommitments: mockGetSignerCommitments,
+      getGuardianPublicKeyCommitment: mockGetGuardianCommitment,
+    },
+  };
+});
 
 // Mock fetch for GUARDIAN client
 const mockFetch = vi.fn();
@@ -637,6 +643,44 @@ describe('Multisig', () => {
       ]);
       expect(multisig.guardianCommitment).toBe('0x' + 'd'.repeat(64));
       expect(mockWebClient.newAccount).not.toHaveBeenCalled();
+    });
+
+    it('keeps the previous config when a refresh reads an incomplete signer set (issue #306 review)', async () => {
+      const config = {
+        threshold: 1,
+        signerCommitments: ['0x' + 'a'.repeat(64)],
+        guardianCommitment: '0x' + 'c'.repeat(64),
+      };
+      const multisig = createTestMultisig(config, mockSigner, '0x' + 'a'.repeat(30));
+
+      mockWebClient.getAccount.mockResolvedValueOnce(mockedAccount('0x' + 'b'.repeat(64), 0));
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          account_id: multisig.accountId,
+          commitment: '0x' + 'b'.repeat(64),
+          state_json: { data: 'AQID' },
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-02T00:00:00Z',
+        }),
+      });
+      // Storage reports 3 signers but only 1 entry was readable: adopting
+      // this would let membership proposals rewrite the on-chain set without
+      // the omitted keys. The refresh must keep the previous config instead.
+      mockDetectConfig.mockReturnValueOnce({
+        threshold: 2,
+        numSigners: 3,
+        signerCommitments: ['0x' + '1'.repeat(64)],
+        guardianCommitment: '0x' + 'd'.repeat(64),
+        vaultBalances: [],
+        procedureThresholds: new Map(),
+      });
+
+      await multisig.syncState();
+
+      expect(multisig.threshold).toBe(1);
+      expect(multisig.signerCommitments).toEqual(['0x' + 'a'.repeat(64)]);
+      expect(multisig.guardianCommitment).toBe('0x' + 'c'.repeat(64));
     });
 
     it('should overwrite local state when account is not found on-chain', async () => {

--- a/packages/miden-multisig-client/src/multisig.test.ts
+++ b/packages/miden-multisig-client/src/multisig.test.ts
@@ -10,11 +10,20 @@ import {
   executeForSummaryAt,
 } from './transaction.js';
 
-const { mockRpcGetAccountDetails, mockAccountDeserialize, mockDetectConfig, mockNoteFileDeserialize } = vi.hoisted(() => ({
+const {
+  mockRpcGetAccountDetails,
+  mockAccountDeserialize,
+  mockDetectConfig,
+  mockNoteFileDeserialize,
+  mockGetSignerCommitments,
+  mockGetGuardianCommitment,
+} = vi.hoisted(() => ({
   mockRpcGetAccountDetails: vi.fn(),
   mockAccountDeserialize: vi.fn(),
   mockDetectConfig: vi.fn(),
   mockNoteFileDeserialize: vi.fn(),
+  mockGetSignerCommitments: vi.fn(),
+  mockGetGuardianCommitment: vi.fn(),
 }));
 
 const { MOCK_CHAIN_ANCHOR_B64, createMockChainAnchor } = vi.hoisted(() => {
@@ -159,6 +168,8 @@ vi.mock('./utils/encoding.js', async () => {
 vi.mock('./inspector.js', () => ({
   AccountInspector: {
     fromAccount: mockDetectConfig,
+    getSignerPublicKeyCommitments: mockGetSignerCommitments,
+    getGuardianPublicKeyCommitment: mockGetGuardianCommitment,
   },
 }));
 
@@ -423,6 +434,56 @@ describe('Multisig', () => {
 
       const multisig = createTestMultisig(config);
       expect(multisig.signerCommitment).toBe(mockSigner.commitment);
+    });
+  });
+
+  describe('getSignerPublicKeyCommitments (issue #306)', () => {
+    const config = {
+      threshold: 1,
+      signerCommitments: ['0x' + 'a'.repeat(64)],
+      guardianCommitment: '0x' + 'c'.repeat(64),
+    };
+
+    it('reads commitments from the store-backed account', async () => {
+      const storeAccount = mockedAccount('0x' + 'b'.repeat(64), 1);
+      mockWebClient.getAccount.mockResolvedValueOnce(storeAccount);
+      const expected = ['0x' + '1'.repeat(64), '0x' + '2'.repeat(64)];
+      mockGetSignerCommitments.mockReturnValueOnce(expected);
+
+      const multisig = createTestMultisig(config);
+      const commitments = await multisig.getSignerPublicKeyCommitments();
+
+      expect(commitments).toEqual(expected);
+      expect(mockGetSignerCommitments).toHaveBeenCalledWith(storeAccount);
+    });
+
+    it('falls back to the account snapshot when the store has no record', async () => {
+      mockWebClient.getAccount.mockResolvedValueOnce(null);
+      mockGetSignerCommitments.mockReturnValueOnce(['0x' + '3'.repeat(64)]);
+
+      const multisig = createTestMultisig(config);
+      await multisig.getSignerPublicKeyCommitments();
+
+      expect(mockGetSignerCommitments).toHaveBeenCalledWith(mockAccount);
+    });
+  });
+
+  describe('getGuardianPublicKeyCommitment (issue #306)', () => {
+    it('reads the guardian commitment from the store-backed account', async () => {
+      const storeAccount = mockedAccount('0x' + 'b'.repeat(64), 1);
+      mockWebClient.getAccount.mockResolvedValueOnce(storeAccount);
+      mockGetGuardianCommitment.mockReturnValueOnce('0x' + '4'.repeat(64));
+
+      const multisig = createTestMultisig({
+        threshold: 1,
+        signerCommitments: ['0x' + 'a'.repeat(64)],
+        guardianCommitment: '0x' + 'c'.repeat(64),
+      });
+
+      const commitment = await multisig.getGuardianPublicKeyCommitment();
+
+      expect(commitment).toBe('0x' + '4'.repeat(64));
+      expect(mockGetGuardianCommitment).toHaveBeenCalledWith(storeAccount);
     });
   });
 

--- a/packages/miden-multisig-client/src/multisig.ts
+++ b/packages/miden-multisig-client/src/multisig.ts
@@ -81,7 +81,7 @@ import {
 } from './utils/signature.js';
 import { computeCommitmentFromTxSummary, accountIdToHex } from './multisig/helpers.js';
 import { buildGuardianSignatureFromSigner } from './multisig/signing.js';
-import { AccountInspector } from './inspector.js';
+import { AccountInspector, assertCompleteDetectedConfig } from './inspector.js';
 import { ProposalFactory } from './proposal/factory.js';
 import { ProposalMetadataCodec } from './proposal/metadata.js';
 import { ProposalSignatures } from './proposal/signatures.js';
@@ -600,12 +600,14 @@ export class Multisig {
 
     try {
       const detected = AccountInspector.fromAccount(account);
+      // Fail closed on a partial read: adopting a truncated signer set would
+      // let membership proposals rewrite the account without the omitted
+      // keys. The catch below keeps the previously validated config instead.
+      assertCompleteDetectedConfig(detected);
       this.account = account;
       this.threshold = detected.threshold;
       this.signerCommitments = detected.signerCommitments;
-      if (detected.guardianCommitment) {
-        this.guardianCommitment = detected.guardianCommitment;
-      }
+      this.guardianCommitment = detected.guardianCommitment;
       this.procedureThresholds = new Map(detected.procedureThresholds);
     } catch (error) {
       console.warn('Failed to refresh multisig config from account state', error);

--- a/packages/miden-multisig-client/src/multisig.ts
+++ b/packages/miden-multisig-client/src/multisig.ts
@@ -305,6 +305,32 @@ export class Multisig {
   }
 
   /**
+   * Read the current ordered signer public-key commitments from account
+   * storage (store-backed state, falling back to the snapshot).
+   *
+   * Commitments are ordered by signer index as currently stored; indices
+   * re-pack when signers are removed, so index 0 is the creation-time first
+   * key only until the first membership change. Unlike the
+   * `signerCommitments` field, which reflects the config detected at
+   * construction / last sync, this reads the account state directly.
+   * See `AccountInspector.getSignerPublicKeyCommitments` (issue #306).
+   */
+  async getSignerPublicKeyCommitments(): Promise<string[]> {
+    const account = await this.getStoreAccount();
+    return AccountInspector.getSignerPublicKeyCommitments(account);
+  }
+
+  /**
+   * Read the current guardian public-key commitment from account storage.
+   * The guarded-multisig always includes a guardian, so this throws (rather
+   * than returning null) when the entry is missing.
+   */
+  async getGuardianPublicKeyCommitment(): Promise<string> {
+    const account = await this.getStoreAccount();
+    return AccountInspector.getGuardianPublicKeyCommitment(account);
+  }
+
+  /**
    * Maps a proposal type to the procedure that determines its threshold.
    */
   private getProposalProcedure(proposalType: ProposalType): ProcedureName | null {

--- a/packages/miden-multisig-client/src/utils/word.ts
+++ b/packages/miden-multisig-client/src/utils/word.ts
@@ -15,6 +15,23 @@ export function wordElementToBigInt(word: Word, index: number): bigint {
   return index < elements.length ? elements[index] : 0n;
 }
 
+/**
+ * True when every element of the word is zero. The SDK's storage-map reads
+ * return `Word::empty()` for a key with no entry (`StorageMap::get` is
+ * `unwrap_or_default()` in miden-protocol), so readers use this to detect
+ * absent entries.
+ */
+export function isEmptyWord(word: Word): boolean {
+  const elements: BigUint64Array | bigint[] =
+    typeof word.toU64s === 'function' ? word.toU64s() : word.toFelts().map(f => f.asInt());
+  for (const element of elements) {
+    if (element !== 0n) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export function wordToBytes(word: { toFelts: () => Array<{ asInt: () => bigint }> }): Uint8Array {
   const felts = word.toFelts();
   const buf = new Uint8Array(32);

--- a/packages/miden-multisig-client/tests/account-roundtrip.test.ts
+++ b/packages/miden-multisig-client/tests/account-roundtrip.test.ts
@@ -1,0 +1,95 @@
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { Account } from '@miden-sdk/miden-sdk';
+
+import { AccountInspector } from '../src/inspector.js';
+
+interface SerializedAccountFixture {
+  account_hex: string;
+  threshold: number;
+  signer_commitments: string[];
+  guardian_commitment: string;
+}
+
+let cachedFixture: SerializedAccountFixture | null = null;
+
+function loadFixture(): SerializedAccountFixture {
+  if (cachedFixture) {
+    return cachedFixture;
+  }
+
+  const repoRoot = fileURLToPath(new URL('../../../', import.meta.url));
+  const output = execFileSync(
+    'cargo',
+    ['run', '--quiet', '--example', 'serialized_account', '-p', 'miden-multisig-client'],
+    {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    },
+  );
+
+  cachedFixture = JSON.parse(output) as SerializedAccountFixture;
+  return cachedFixture;
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const normalized = hex.replace(/^0x/, '');
+  const bytes = new Uint8Array(normalized.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(normalized.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+// Round-trips a Rust-built account through the real WASM SDK: proves the
+// Rust writer and the TS readers agree on the storage layout, and exercises
+// the accessors against the SDK's actual storage read semantics (empty word
+// for missing map keys, undefined for absent slots) instead of mocks.
+describe('AccountInspector round-trip against a Rust-built account', () => {
+  it('reads the signer commitments in signer-index order', () => {
+    const fixture = loadFixture();
+    const account = Account.deserialize(hexToBytes(fixture.account_hex));
+
+    expect(AccountInspector.getSignerPublicKeyCommitments(account)).toEqual(
+      fixture.signer_commitments,
+    );
+  });
+
+  it('reads the guardian commitment', () => {
+    const fixture = loadFixture();
+    const account = Account.deserialize(hexToBytes(fixture.account_hex));
+
+    expect(AccountInspector.getGuardianPublicKeyCommitment(account)).toBe(
+      fixture.guardian_commitment,
+    );
+  });
+
+  it('detects the full config through the lenient inspector', () => {
+    const fixture = loadFixture();
+    const account = Account.deserialize(hexToBytes(fixture.account_hex));
+
+    const detected = AccountInspector.fromAccount(account);
+    expect(detected.threshold).toBe(fixture.threshold);
+    expect(detected.numSigners).toBe(fixture.signer_commitments.length);
+    expect(detected.signerCommitments).toEqual(fixture.signer_commitments);
+    expect(detected.guardianCommitment).toBe(fixture.guardian_commitment);
+  });
+
+  // The original #306 failure: the SDK's AccountInterface did not recognize
+  // the previous OpenZeppelin auth component, so getPublicKeyCommitments()
+  // returned []. With the upstream AuthGuardedMultisig component it must
+  // return the approver commitments natively.
+  it('getPublicKeyCommitments() works natively on the upstream component (issue #306)', () => {
+    const fixture = loadFixture();
+    const account = Account.deserialize(hexToBytes(fixture.account_hex));
+
+    const native = account.getPublicKeyCommitments().map((word) => word.toHex());
+
+    expect(native.length).toBeGreaterThan(0);
+    for (const signer of fixture.signer_commitments) {
+      expect(native).toContain(signer);
+    }
+  });
+});


### PR DESCRIPTION
Stacked on #340 — merge only after it. Addresses #306.

## Context

#306 reported that `Account.getPublicKeyCommitments()` returned `[]` for Guardian accounts because miden-standards' `AccountInterface` did not recognize the previous OpenZeppelin auth component. With #340's move to the upstream `AuthGuardedMultisig` component, that call now works natively — this PR no longer "fixes" #306's symptom, and instead adds the Guardian-owned inspection API discussed in review: strict, layout-insulated accessors so consumers never read storage layout directly.

## What this adds

- `AccountInspector.getSignerPublicKeyCommitments(account)` — ordered approver commitments, validating the complete set against the configured signer count. Throws instead of silently omitting unreadable entries (upstream public-key extraction can omit them silently).
- `AccountInspector.getGuardianPublicKeyCommitment(account)` — the guardian commitment; throws when the entry is missing (the guarded-multisig always includes a guardian — no selector, no null case).
- `Multisig.getSignerPublicKeyCommitments()` / `getGuardianPublicKeyCommitment()` — instance variants reading current store-backed state.
- Both strict accessors are gated on #340's pinned-contract-version check (shared helper with `fromAccount`), so a foreign contract version is a clear error rather than misread storage.
- Fail-closed mutation path: `load()` and config refresh now validate the lenient `fromAccount()` result (complete signer set + guardian present) before adopting it, so a corrupt account can't be loaded and later rewritten without the omitted keys. `fromAccount()` stays lenient for inspect-only use.

## Robustness details

- Empty-word map reads are treated as "no entry" (`StorageMap::get` is `unwrap_or_default()` in miden-protocol; the contract zeroes removed entries) — never returned as `0x000…0` commitments.
- The untrusted signer count is bounded by a sanity ceiling (guards the ≥2^53 unsafe-integer loop case).
- A cross-SDK-copy `Word` rejection is translated into a descriptive error; the same-SDK requirement is documented.
- Slot names are shared between the storage writer and the readers via one internal module; deliberately not exported — consumers should use the accessors, not the layout.