### PR TITLE
chore: Fix failing unit test - npm multisig package

### DIFF
--- a/packages/miden-multisig-client/src/client.test.ts
+++ b/packages/miden-multisig-client/src/client.test.ts
@@ -239,12 +239,18 @@ describe('MultisigClient', () => {
         ok: false,
         status: 404,
         statusText: 'Not Found',
-        text: async () => 'Account not found',
+        headers: new Headers(),
+        text: async () =>
+          JSON.stringify({
+            code: 'GUARDIAN_ACCOUNT_NOT_FOUND',
+            message: 'Account not found',
+            meta: { retryable: false },
+          }),
       });
 
       await expect(
         client.load('0xnonexistent', mockSigner)
-      ).rejects.toThrow();
+      ).rejects.toThrow('Account not found');
     });
 
     it('should allow registerOnGuardian after load without explicit initial state', async () => {

--- a/packages/miden-multisig-client/src/multisig.test.ts
+++ b/packages/miden-multisig-client/src/multisig.test.ts
@@ -2293,6 +2293,7 @@ describe('Multisig', () => {
         ok: false,
         status: 404,
         statusText: 'Not Found',
+        headers: new Headers(),
         // Feature 009: only a conforming { code, message, meta } envelope is
         // folded into the error message; raw text bodies are dropped.
         text: async () =>


### PR DESCRIPTION
Fix failing test in multisig package.

Issue for adding package related tests to CI has been created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for missing-account load failures, including structured guardian error details and retryability information.
  * Updated proposal export error handling tests to reflect responses with HTTP headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->