### PR TITLE
refactor(multisig-client): move nonce into the options object of proposal-creation APIs

### DIFF
--- a/docs/MULTISIG_SDK.md
+++ b/docs/MULTISIG_SDK.md
@@ -539,6 +539,12 @@ one implicitly.
 
 ### Proposal Operations
 
+Every `create*Proposal` method takes a single trailing options object (issue
+#387). All of them accept an optional `nonce` that identifies the proposal
+(defaults to `Date.now()`); method-specific options are listed with each
+method below. Passing a legacy positional `nonce` number where the options
+object is expected throws instead of silently applying defaults.
+
 #### P2ID Transfer (Send Funds)
 
 ```typescript
@@ -731,10 +737,12 @@ await multisig.executeProposal(signedProposal.id);
 | `exportNoteToFile(noteId, filename?)` | Browser-only: download the note file |
 | `importNoteFromBytes(noteBytes)` | Import a note file received out-of-band |
 | `importNoteFromFile(file)` | Import a note file from a browser `File`/`Blob` |
-| `createAddSignerProposal(commitment, { nonce, newThreshold }?)` | Create add signer proposal |
-| `createRemoveSignerProposal(commitment, { nonce, newThreshold }?)` | Create remove signer proposal |
+| `createAddSignerProposal(commitment, { nonce, newThreshold }?)` | Create add signer proposal (`newThreshold` defaults to the current threshold) |
+| `createRemoveSignerProposal(commitment, { nonce, newThreshold }?)` | Create remove signer proposal (`newThreshold` defaults to min of current threshold and remaining signer count) |
 | `createChangeThresholdProposal(threshold, { nonce }?)` | Create threshold change proposal |
+| `createUpdateProcedureThresholdProposal(procedure, threshold, { nonce }?)` | Create per-procedure threshold override proposal (`threshold: 0` clears the override) |
 | `createSwitchGuardianProposal(endpoint, pubkey, { nonce }?)` | Create GUARDIAN switch proposal |
+| `createCustomProposal(requestBytes, label, { nonce }?)` | Create a producer-built custom proposal (issue #266) |
 | `signProposal(id)` | Sign a proposal |
 | `executeProposal(id)` | Execute ready proposal |
 | `exportProposalToJson(id)` | Export for offline signing |

--- a/docs/MULTISIG_SDK.md
+++ b/docs/MULTISIG_SDK.md
@@ -556,7 +556,6 @@ const privateProposal = await multisig.createP2idProposal(
   recipientAccountId,
   faucetAccountId,
   1000n,
-  undefined,                       // nonce (defaults to Date.now())
   { noteType: NoteType.Private },  // note visibility; defaults to NoteType.Public
 );
 
@@ -569,7 +568,6 @@ const reclaimableProposal = await multisig.createP2idProposal(
   recipientAccountId,
   faucetAccountId,
   1000n,
-  undefined,
   { reclaimHeight: 500_000 },
 );
 ```
@@ -631,9 +629,8 @@ any public note.
 
 ```typescript
 const proposal = await multisig.createAddSignerProposal(
-  newSignerCommitment,   // New signer's public key commitment
-  undefined,             // Optional nonce
-  newThreshold           // Optional new threshold
+  newSignerCommitment,     // New signer's public key commitment
+  { newThreshold },        // Options: nonce, newThreshold (defaults to current)
 );
 ```
 
@@ -641,9 +638,9 @@ const proposal = await multisig.createAddSignerProposal(
 
 ```typescript
 const proposal = await multisig.createRemoveSignerProposal(
-  signerToRemove,        // Signer's commitment to remove
-  undefined,             // Optional nonce
-  newThreshold           // Optional new threshold
+  signerToRemove,          // Signer's commitment to remove
+  { newThreshold },        // Options: nonce, newThreshold (defaults to
+                           // min(current threshold, remaining signer count))
 );
 ```
 
@@ -727,17 +724,17 @@ await multisig.executeProposal(signedProposal.id);
 | `abandonCandidate(nonce)` | Record an abandon intent for a stuck candidate (worker resolves after a short quarantine) |
 | `abandonStatus(nonce)` | Poll the abandon resolution: `waiting` / `landed` / `abandoned` / `unexpected` |
 | `listProposals()` | Get cached proposals |
-| `createP2idProposal(recipient, faucet, amount, nonce?, { noteType, reclaimHeight, timelockHeight }?)` | Create transfer proposal (`noteType`: `NoteType.Public` (default) or `NoteType.Private`; presence of `reclaimHeight`/`timelockHeight` creates a P2IDE note, issue #366) |
-| `createConsumeNotesProposal(noteIds, nonce?)` | Create note consumption proposal |
+| `createP2idProposal(recipient, faucet, amount, { nonce, noteType, reclaimHeight, timelockHeight }?)` | Create transfer proposal (`noteType`: `NoteType.Public` (default) or `NoteType.Private`; presence of `reclaimHeight`/`timelockHeight` creates a P2IDE note, issue #366) |
+| `createConsumeNotesProposal(noteIds, { nonce }?)` | Create note consumption proposal |
 | `getP2idNoteId(proposal)` | Compute the note ID a P2ID proposal creates (call before executing) |
 | `exportNoteToBytes(noteId)` | Export a created note as note-file bytes for out-of-band delivery |
 | `exportNoteToFile(noteId, filename?)` | Browser-only: download the note file |
 | `importNoteFromBytes(noteBytes)` | Import a note file received out-of-band |
 | `importNoteFromFile(file)` | Import a note file from a browser `File`/`Blob` |
-| `createAddSignerProposal(commitment, nonce?, threshold?)` | Create add signer proposal |
-| `createRemoveSignerProposal(commitment, nonce?, threshold?)` | Create remove signer proposal |
-| `createChangeThresholdProposal(threshold, nonce?)` | Create threshold change proposal |
-| `createSwitchGuardianProposal(endpoint, pubkey, nonce?)` | Create GUARDIAN switch proposal |
+| `createAddSignerProposal(commitment, { nonce, newThreshold }?)` | Create add signer proposal |
+| `createRemoveSignerProposal(commitment, { nonce, newThreshold }?)` | Create remove signer proposal |
+| `createChangeThresholdProposal(threshold, { nonce }?)` | Create threshold change proposal |
+| `createSwitchGuardianProposal(endpoint, pubkey, { nonce }?)` | Create GUARDIAN switch proposal |
 | `signProposal(id)` | Sign a proposal |
 | `executeProposal(id)` | Execute ready proposal |
 | `exportProposalToJson(id)` | Export for offline signing |

--- a/examples/_shared/multisig-browser/src/multisigApi.ts
+++ b/examples/_shared/multisig-browser/src/multisigApi.ts
@@ -274,7 +274,10 @@ export async function createAddSignerProposal(
 ): Promise<{ proposal: Proposal; proposals: Proposal[] }> {
   return createProposalResult(multisig, () => {
     const newThreshold = increaseThreshold ? multisig.threshold + 1 : undefined;
-    return multisig.createAddSignerProposal(commitment, proposalNonce(multisig), newThreshold);
+    return multisig.createAddSignerProposal(commitment, {
+      nonce: proposalNonce(multisig),
+      newThreshold,
+    });
   });
 }
 
@@ -284,11 +287,10 @@ export async function createRemoveSignerProposal(
   newThreshold?: number,
 ): Promise<{ proposal: Proposal; proposals: Proposal[] }> {
   return createProposalResult(multisig, () =>
-    multisig.createRemoveSignerProposal(
-      signerToRemove,
-      proposalNonce(multisig),
+    multisig.createRemoveSignerProposal(signerToRemove, {
+      nonce: proposalNonce(multisig),
       newThreshold,
-    ));
+    }));
 }
 
 export async function createChangeThresholdProposal(
@@ -296,7 +298,7 @@ export async function createChangeThresholdProposal(
   newThreshold: number,
 ): Promise<{ proposal: Proposal; proposals: Proposal[] }> {
   return createProposalResult(multisig, () =>
-    multisig.createChangeThresholdProposal(newThreshold, proposalNonce(multisig)));
+    multisig.createChangeThresholdProposal(newThreshold, { nonce: proposalNonce(multisig) }));
 }
 
 export async function createUpdateProcedureThresholdProposal(
@@ -308,7 +310,7 @@ export async function createUpdateProcedureThresholdProposal(
     multisig.createUpdateProcedureThresholdProposal(
       procedure,
       threshold,
-      proposalNonce(multisig),
+      { nonce: proposalNonce(multisig) },
     ));
 }
 
@@ -317,7 +319,7 @@ export async function createConsumeNotesProposal(
   noteIds: string[],
 ): Promise<{ proposal: Proposal; proposals: Proposal[] }> {
   return createProposalResult(multisig, () =>
-    multisig.createConsumeNotesProposal(noteIds, proposalNonce(multisig)));
+    multisig.createConsumeNotesProposal(noteIds, { nonce: proposalNonce(multisig) }));
 }
 
 export async function createP2idProposal(
@@ -329,13 +331,11 @@ export async function createP2idProposal(
   heights?: { reclaimHeight?: number; timelockHeight?: number },
 ): Promise<{ proposal: Proposal; proposals: Proposal[] }> {
   return createProposalResult(multisig, () =>
-    multisig.createP2idProposal(
-      recipientId,
-      faucetId,
-      amount,
-      proposalNonce(multisig),
-      { noteType, ...heights },
-    ));
+    multisig.createP2idProposal(recipientId, faucetId, amount, {
+      nonce: proposalNonce(multisig),
+      noteType,
+      ...heights,
+    }));
 }
 
 export async function createSwitchGuardianProposal(
@@ -349,7 +349,7 @@ export async function createSwitchGuardianProposal(
       multisig.createSwitchGuardianProposal(
         newGuardianEndpoint,
         newGuardianPubkey,
-        proposalNonce(multisig),
+        { nonce: proposalNonce(multisig) },
       ),
     async (currentMultisig) => listVisibleProposals(currentMultisig),
   );

--- a/examples/_shared/multisig-browser/src/multisigApi.ts
+++ b/examples/_shared/multisig-browser/src/multisigApi.ts
@@ -332,9 +332,9 @@ export async function createP2idProposal(
 ): Promise<{ proposal: Proposal; proposals: Proposal[] }> {
   return createProposalResult(multisig, () =>
     multisig.createP2idProposal(recipientId, faucetId, amount, {
+      ...heights,
       nonce: proposalNonce(multisig),
       noteType,
-      ...heights,
     }));
 }
 
@@ -437,7 +437,7 @@ export async function createCustomP2idProposal(
   );
 
   const created = await createProposalResult(multisig, () =>
-    multisig.createCustomProposal(request.serialize(), label, proposalNonce(multisig)));
+    multisig.createCustomProposal(request.serialize(), label, { nonce: proposalNonce(multisig) }));
 
   const recipe: CustomProposalRecipe = {
     proposalId: created.proposal.id,

--- a/examples/web/src/lib/multisigApi.ts
+++ b/examples/web/src/lib/multisigApi.ts
@@ -368,9 +368,9 @@ export async function createP2idProposal(
 ): Promise<{ proposal: Proposal; proposals: Proposal[] }> {
   return createProposalResult(multisig, () =>
     multisig.createP2idProposal(recipientId, faucetId, amount, {
+      ...heights,
       nonce: proposalNonce(multisig),
       noteType,
-      ...heights,
     }));
 }
 

--- a/examples/web/src/lib/multisigApi.ts
+++ b/examples/web/src/lib/multisigApi.ts
@@ -298,7 +298,10 @@ export async function createAddSignerProposal(
 ): Promise<{ proposal: Proposal; proposals: Proposal[] }> {
   return createProposalResult(multisig, () => {
     const newThreshold = increaseThreshold ? multisig.threshold + 1 : undefined;
-    return multisig.createAddSignerProposal(commitment, proposalNonce(multisig), newThreshold);
+    return multisig.createAddSignerProposal(commitment, {
+      nonce: proposalNonce(multisig),
+      newThreshold,
+    });
   });
 }
 
@@ -311,11 +314,10 @@ export async function createRemoveSignerProposal(
   newThreshold?: number,
 ): Promise<{ proposal: Proposal; proposals: Proposal[] }> {
   return createProposalResult(multisig, () =>
-    multisig.createRemoveSignerProposal(
-      signerToRemove,
-      proposalNonce(multisig),
+    multisig.createRemoveSignerProposal(signerToRemove, {
+      nonce: proposalNonce(multisig),
       newThreshold,
-    ));
+    }));
 }
 
 /**
@@ -326,7 +328,7 @@ export async function createChangeThresholdProposal(
   newThreshold: number,
 ): Promise<{ proposal: Proposal; proposals: Proposal[] }> {
   return createProposalResult(multisig, () =>
-    multisig.createChangeThresholdProposal(newThreshold, proposalNonce(multisig)));
+    multisig.createChangeThresholdProposal(newThreshold, { nonce: proposalNonce(multisig) }));
 }
 
 export async function createUpdateProcedureThresholdProposal(
@@ -338,7 +340,7 @@ export async function createUpdateProcedureThresholdProposal(
     multisig.createUpdateProcedureThresholdProposal(
       procedure,
       threshold,
-      proposalNonce(multisig),
+      { nonce: proposalNonce(multisig) },
     ));
 }
 
@@ -350,7 +352,7 @@ export async function createConsumeNotesProposal(
   noteIds: string[],
 ): Promise<{ proposal: Proposal; proposals: Proposal[] }> {
   return createProposalResult(multisig, () =>
-    multisig.createConsumeNotesProposal(noteIds, proposalNonce(multisig)));
+    multisig.createConsumeNotesProposal(noteIds, { nonce: proposalNonce(multisig) }));
 }
 
 /**
@@ -365,13 +367,11 @@ export async function createP2idProposal(
   heights?: { reclaimHeight?: number; timelockHeight?: number },
 ): Promise<{ proposal: Proposal; proposals: Proposal[] }> {
   return createProposalResult(multisig, () =>
-    multisig.createP2idProposal(
-      recipientId,
-      faucetId,
-      amount,
-      proposalNonce(multisig),
-      { noteType, ...heights },
-    ));
+    multisig.createP2idProposal(recipientId, faucetId, amount, {
+      nonce: proposalNonce(multisig),
+      noteType,
+      ...heights,
+    }));
 }
 
 /**
@@ -389,7 +389,7 @@ export async function createSwitchGuardianProposal(
       multisig.createSwitchGuardianProposal(
         newGuardianEndpoint,
         newGuardianPubkey,
-        proposalNonce(multisig),
+        { nonce: proposalNonce(multisig) },
       ),
     async (currentMultisig) => listVisibleProposals(currentMultisig),
   );

--- a/packages/miden-multisig-client/README.md
+++ b/packages/miden-multisig-client/README.md
@@ -185,8 +185,7 @@ console.log('Created:', state.createdAt);
 // Create a proposal to add a new signer
 const proposal = await multisig.createAddSignerProposal(
   newSignerCommitment, // Commitment of signer to add
-  undefined,
-  3,
+  { newThreshold: 3 }, // Options: nonce, newThreshold
 );
 console.log('Proposal ID:', proposal.id);
 ```
@@ -294,9 +293,9 @@ import { buildP2idTransactionRequest } from '@openzeppelin/miden-multisig-client
 // only its hash on chain, so the recipient needs the note shared out-of-band.
 // It also accepts `reclaimHeight`/`timelockHeight` (absolute block heights,
 // issue #366); presence of either builds a P2IDE note instead of plain P2ID.
-// The typed path is `createP2idProposal(recipient, faucet, amount, nonce?,
-// { noteType, reclaimHeight, timelockHeight })`, which persists the choices
-// in signed metadata.
+// The typed path is `createP2idProposal(recipient, faucet, amount,
+// { nonce, noteType, reclaimHeight, timelockHeight })`, which persists the
+// choices in signed metadata.
 const { request, salt } = buildP2idTransactionRequest(senderId, recipientId, faucetId, amount);
 const proposal = await multisig.createCustomProposal(request.serialize(), 'b2agg');
 

--- a/packages/miden-multisig-client/README.md
+++ b/packages/miden-multisig-client/README.md
@@ -179,6 +179,33 @@ console.log('Commitment:', state.commitment);
 console.log('Created:', state.createdAt);
 ```
 
+### Creating Proposals
+
+Every `create*Proposal` method takes its required arguments followed by a
+single optional options object (issue #387) — there are no positional
+optional parameters:
+
+```typescript
+createP2idProposal(recipientId, faucetId, amount, { nonce, noteType, reclaimHeight, timelockHeight }?)
+createConsumeNotesProposal(noteIds, { nonce }?)
+createAddSignerProposal(commitment, { nonce, newThreshold }?)
+createRemoveSignerProposal(commitment, { nonce, newThreshold }?)
+createChangeThresholdProposal(threshold, { nonce }?)
+createUpdateProcedureThresholdProposal(procedure, threshold, { nonce }?)
+createSwitchGuardianProposal(endpoint, pubkey, { nonce }?)
+createCustomProposal(requestBytes, label, { nonce }?)
+```
+
+All methods accept `nonce` (identifies the proposal; defaults to
+`Date.now()`). `newThreshold` defaults to the current threshold on add and to
+the min of the current threshold and the remaining signer count on remove.
+The option shapes are exported as `CreateProposalOptions`,
+`CreateSignerProposalOptions`, and `CreateP2idProposalOptions`.
+
+> **Breaking change (issue #387):** these methods previously took `nonce` (and
+> `newThreshold`) as positional parameters. Passing the old positional form
+> now throws at runtime instead of silently applying defaults.
+
 ### Create a Proposal (Add Signer)
 
 ```typescript

--- a/packages/miden-multisig-client/src/index.ts
+++ b/packages/miden-multisig-client/src/index.ts
@@ -52,7 +52,14 @@ export {
 export type { ProverConfig, ProverRetryPolicy } from './prover/config.js';
 export type { RpcConfig, RpcRetryPolicy } from './rpc/config.js';
 export { lookupAuthDigest } from './lookupAuth.js';
-export { Multisig, type AccountState } from './multisig.js';
+export {
+  Multisig,
+  type AccountState,
+  type CreateProposalOptions,
+  type CreateAddSignerProposalOptions,
+  type CreateRemoveSignerProposalOptions,
+  type CreateP2idProposalOptions,
+} from './multisig.js';
 export { AccountInspector, type DetectedMultisigConfig, type VaultBalance } from './inspector.js';
 export {
   executeForSummary,

--- a/packages/miden-multisig-client/src/index.ts
+++ b/packages/miden-multisig-client/src/index.ts
@@ -56,8 +56,7 @@ export {
   Multisig,
   type AccountState,
   type CreateProposalOptions,
-  type CreateAddSignerProposalOptions,
-  type CreateRemoveSignerProposalOptions,
+  type CreateSignerProposalOptions,
   type CreateP2idProposalOptions,
 } from './multisig.js';
 export { AccountInspector, type DetectedMultisigConfig, type VaultBalance } from './inspector.js';

--- a/packages/miden-multisig-client/src/multisig.test.ts
+++ b/packages/miden-multisig-client/src/multisig.test.ts
@@ -1355,7 +1355,7 @@ describe('Multisig', () => {
         }),
       });
 
-      const proposal = await multisig.createP2idProposal('0xrecipient', '0xfaucet', 100n, 1);
+      const proposal = await multisig.createP2idProposal('0xrecipient', '0xfaucet', 100n, { nonce: 1 });
 
       expect(proposal.metadata.description).toBe('Send 100 of asset 0xfaucet... to 0xrecipien...');
     });
@@ -1410,7 +1410,8 @@ describe('Multisig', () => {
         }),
       });
 
-      const proposal = await multisig.createP2idProposal('0xrecipient', '0xfaucet', 100n, 1, {
+      const proposal = await multisig.createP2idProposal('0xrecipient', '0xfaucet', 100n, {
+        nonce: 1,
         noteType: NoteType.Private,
       });
 
@@ -1486,7 +1487,8 @@ describe('Multisig', () => {
         }),
       });
 
-      const proposal = await multisig.createP2idProposal('0xrecipient', '0xfaucet', 100n, 1, {
+      const proposal = await multisig.createP2idProposal('0xrecipient', '0xfaucet', 100n, {
+        nonce: 1,
         reclaimHeight: 12345,
         timelockHeight: 700,
       });
@@ -1553,7 +1555,7 @@ describe('Multisig', () => {
         }),
       });
 
-      await multisig.createP2idProposal('0xrecipient', '0xfaucet', 100n, 1);
+      await multisig.createP2idProposal('0xrecipient', '0xfaucet', 100n, { nonce: 1 });
 
       const pushBody = JSON.parse(mockFetch.mock.calls.at(-1)![1].body as string);
       expect('reclaim_height' in pushBody.delta_payload.metadata).toBe(false);
@@ -1761,7 +1763,7 @@ describe('Multisig', () => {
       });
 
       const multisig = createTestMultisig(config, ecdsaSigner);
-      await multisig.createChangeThresholdProposal(2, 1);
+      await multisig.createChangeThresholdProposal(2, { nonce: 1 });
 
       expect(buildUpdateSignersTransactionRequest).toHaveBeenCalledWith(
         mockWebClient,
@@ -1950,7 +1952,7 @@ describe('Multisig', () => {
         }),
       });
 
-      const proposal = await multisig.createUpdateProcedureThresholdProposal('send_asset', 1, 1);
+      const proposal = await multisig.createUpdateProcedureThresholdProposal('send_asset', 1, { nonce: 1 });
 
       expect(buildUpdateProcedureThresholdTransactionRequest).toHaveBeenCalledWith(
         mockWebClient,
@@ -2018,7 +2020,7 @@ describe('Multisig', () => {
         }),
       });
 
-      await multisig.createUpdateProcedureThresholdProposal('send_asset', 1, 1);
+      await multisig.createUpdateProcedureThresholdProposal('send_asset', 1, { nonce: 1 });
 
       expect(buildUpdateProcedureThresholdTransactionRequest).toHaveBeenCalledWith(
         mockWebClient,

--- a/packages/miden-multisig-client/src/multisig.test.ts
+++ b/packages/miden-multisig-client/src/multisig.test.ts
@@ -1774,6 +1774,143 @@ describe('Multisig', () => {
     });
   });
 
+  describe('createAddSignerProposal / createRemoveSignerProposal', () => {
+    const config = {
+      threshold: 2,
+      signerCommitments: ['0x' + 'a'.repeat(64), '0x' + 'b'.repeat(64), '0x' + 'd'.repeat(64)],
+      guardianCommitment: '0x' + 'c'.repeat(64),
+    };
+
+    const mockPushResponse = (proposalType: string) => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          delta: {
+            account_id: '0x' + 'a'.repeat(30),
+            nonce: 1,
+            prev_commitment: '0x' + 'b'.repeat(64),
+            delta_payload: {
+              tx_summary: { data: 'AQID' },
+              signatures: [],
+              metadata: { proposal_type: proposalType, description: '' },
+            },
+            status: {
+              status: 'pending',
+              timestamp: '2024-01-01T00:00:00Z',
+              proposer_id: '0x' + 'c'.repeat(64),
+              cosigner_sigs: [],
+            },
+          },
+          commitment: '0x' + 'c'.repeat(64),
+        }),
+      });
+    };
+
+    beforeEach(() => {
+      vi.mocked(executeForSummary).mockResolvedValue({
+        toCommitment: () => ({ toHex: () => '0x' + 'c'.repeat(64) }),
+        serialize: () => new Uint8Array([1, 2, 3]),
+      } as any);
+    });
+
+    it('add: passes newThreshold from the options bag and appends the commitment', async () => {
+      mockPushResponse('add_signer');
+      const newCommitment = '0x' + 'e'.repeat(64);
+
+      const multisig = createTestMultisig(config);
+      await multisig.createAddSignerProposal(newCommitment, { nonce: 1, newThreshold: 3 });
+
+      expect(buildUpdateSignersTransactionRequest).toHaveBeenCalledWith(
+        mockWebClient,
+        3,
+        [...config.signerCommitments, newCommitment],
+        { signatureScheme: mockSigner.scheme },
+      );
+    });
+
+    it('add: defaults to the current threshold when newThreshold is omitted', async () => {
+      mockPushResponse('add_signer');
+
+      const multisig = createTestMultisig(config);
+      await multisig.createAddSignerProposal('0x' + 'e'.repeat(64), { nonce: 1 });
+
+      expect(buildUpdateSignersTransactionRequest).toHaveBeenCalledWith(
+        mockWebClient,
+        config.threshold,
+        expect.any(Array),
+        { signatureScheme: mockSigner.scheme },
+      );
+    });
+
+    it('remove: passes newThreshold from the options bag and drops the commitment', async () => {
+      mockPushResponse('remove_signer');
+
+      const multisig = createTestMultisig(config);
+      await multisig.createRemoveSignerProposal('0x' + 'd'.repeat(64), { nonce: 1, newThreshold: 1 });
+
+      expect(buildUpdateSignersTransactionRequest).toHaveBeenCalledWith(
+        mockWebClient,
+        1,
+        [config.signerCommitments[0], config.signerCommitments[1]],
+        { signatureScheme: mockSigner.scheme },
+      );
+    });
+
+    it('remove: defaults to min(current threshold, remaining signers) when newThreshold is omitted', async () => {
+      mockPushResponse('remove_signer');
+
+      const multisig = createTestMultisig(config);
+      await multisig.createRemoveSignerProposal('0x' + 'd'.repeat(64), { nonce: 1 });
+
+      expect(buildUpdateSignersTransactionRequest).toHaveBeenCalledWith(
+        mockWebClient,
+        2,
+        expect.any(Array),
+        { signatureScheme: mockSigner.scheme },
+      );
+    });
+  });
+
+  describe('legacy positional-caller guard (issue #387)', () => {
+    const config = {
+      threshold: 1,
+      signerCommitments: ['0x' + 'a'.repeat(64)],
+      guardianCommitment: '0x' + 'c'.repeat(64),
+    };
+
+    it('rejects a legacy positional nonce where the options bag is expected', async () => {
+      const multisig = createTestMultisig(config);
+
+      await expect(
+        multisig.createP2idProposal('0xrecipient', '0xfaucet', 100n, 1 as any),
+      ).rejects.toThrow(/issue #387/);
+      await expect(
+        multisig.createConsumeNotesProposal(['0x1'], 1 as any),
+      ).rejects.toThrow(/issue #387/);
+      await expect(
+        multisig.createAddSignerProposal('0x' + 'e'.repeat(64), 1 as any),
+      ).rejects.toThrow(/issue #387/);
+      await expect(
+        multisig.createCustomProposal(new Uint8Array([1]), 'label', 1 as any),
+      ).rejects.toThrow(/issue #387/);
+    });
+
+    it('rejects a legacy trailing argument after the options slot', async () => {
+      const multisig = createTestMultisig(config);
+
+      // Pre-#387 pattern: createP2idProposal(r, f, amount, nonceHole, { noteType })
+      await expect(
+        (multisig.createP2idProposal as any)('0xrecipient', '0xfaucet', 100n, undefined, {
+          noteType: 'private',
+        }),
+      ).rejects.toThrow(/issue #387/);
+      // Pre-#387 pattern: createAddSignerProposal(commitment, nonceHole, newThreshold)
+      await expect(
+        (multisig.createAddSignerProposal as any)('0x' + 'e'.repeat(64), undefined, 3),
+      ).rejects.toThrow(/issue #387/);
+    });
+  });
+
   describe('createSwitchGuardianProposal', () => {
     it('should verify new endpoint commitment before creating proposal', async () => {
       vi.mocked(executeForSummary).mockResolvedValue({

--- a/packages/miden-multisig-client/src/multisig.ts
+++ b/packages/miden-multisig-client/src/multisig.ts
@@ -125,15 +125,10 @@ export interface CreateProposalOptions {
   nonce?: number;
 }
 
-export interface CreateAddSignerProposalOptions extends CreateProposalOptions {
-  /** New signing threshold; defaults to the current threshold. */
-  newThreshold?: number;
-}
-
-export interface CreateRemoveSignerProposalOptions extends CreateProposalOptions {
+export interface CreateSignerProposalOptions extends CreateProposalOptions {
   /**
-   * New signing threshold; defaults to
-   * `min(current threshold, remaining signer count)`.
+   * New signing threshold. Defaults to the current threshold on add, and to
+   * `min(current threshold, remaining signer count)` on remove.
    */
   newThreshold?: number;
 }
@@ -170,6 +165,27 @@ function deserializeTransactionRequest(bytes: Uint8Array): TransactionRequest {
     const detail = err instanceof Error ? err.message : String(err);
     throw new Error(`failed to decode transaction request: ${detail}`);
   }
+}
+
+/**
+ * Single home for the proposal-nonce default, plus a runtime guard for
+ * pre-#387 positional callers. Untyped JS passing the old `nonce` number (or
+ * a legacy trailing argument) would otherwise bind it as the options bag and
+ * silently fall back to every default — a public note instead of a private
+ * one, or the current threshold instead of the requested one — so it must
+ * fail loudly instead.
+ */
+function resolveProposalNonce(
+  method: string,
+  options: CreateProposalOptions,
+  legacyArgs: readonly unknown[] = [],
+): number {
+  if (typeof options !== 'object' || options === null || legacyArgs.length > 0) {
+    throw new Error(
+      `${method}: positional optional parameters were replaced by a trailing options object (issue #387); pass { nonce, ... } instead`,
+    );
+  }
+  return options.nonce ?? Date.now();
 }
 
 export class Multisig {
@@ -633,8 +649,10 @@ export class Multisig {
    */
   async createAddSignerProposal(
     newCommitment: string,
-    options: CreateAddSignerProposalOptions = {},
+    options: CreateSignerProposalOptions = {},
+    ...legacyArgs: never[]
   ): Promise<Proposal> {
+    const proposalNonce = resolveProposalNonce('createAddSignerProposal', options, legacyArgs);
     const webClient = await this.getRawClient();
     const targetThreshold = options.newThreshold ?? this.threshold;
     const targetSignerCommitments = [...this.signerCommitments, newCommitment];
@@ -648,7 +666,6 @@ export class Multisig {
 
     const summary = await executeForSummary(webClient, this._accountId, request);
     const summaryBase64 = uint8ArrayToBase64(summary.serialize());
-    const proposalNonce = options.nonce ?? Date.now();
 
     const metadata: ProposalMetadata = {
       proposalType: 'add_signer',
@@ -671,8 +688,10 @@ export class Multisig {
    */
   async createRemoveSignerProposal(
     signerToRemove: string,
-    options: CreateRemoveSignerProposalOptions = {},
+    options: CreateSignerProposalOptions = {},
+    ...legacyArgs: never[]
   ): Promise<Proposal> {
+    const proposalNonce = resolveProposalNonce('createRemoveSignerProposal', options, legacyArgs);
     const webClient = await this.getRawClient();
     const normalizedRemove = signerToRemove.toLowerCase();
     const targetSignerCommitments = this.signerCommitments.filter(
@@ -703,7 +722,6 @@ export class Multisig {
 
     const summary = await executeForSummary(webClient, this._accountId, request);
     const summaryBase64 = uint8ArrayToBase64(summary.serialize());
-    const proposalNonce = options.nonce ?? Date.now();
 
     const metadata: ProposalMetadata = {
       proposalType: 'remove_signer',
@@ -727,6 +745,7 @@ export class Multisig {
     newThreshold: number,
     options: CreateProposalOptions = {},
   ): Promise<Proposal> {
+    const proposalNonce = resolveProposalNonce('createChangeThresholdProposal', options);
     const webClient = await this.getRawClient();
     if (newThreshold < 1 || newThreshold > this.signerCommitments.length) {
       throw new Error(
@@ -747,7 +766,6 @@ export class Multisig {
 
     const summary = await executeForSummary(webClient, this._accountId, request);
     const summaryBase64 = uint8ArrayToBase64(summary.serialize());
-    const proposalNonce = options.nonce ?? Date.now();
 
     const metadata: ProposalMetadata = {
       proposalType: 'change_threshold',
@@ -766,6 +784,7 @@ export class Multisig {
     targetThreshold: number,
     options: CreateProposalOptions = {},
   ): Promise<Proposal> {
+    const proposalNonce = resolveProposalNonce('createUpdateProcedureThresholdProposal', options);
     const webClient = await this.getRawClient();
     if (targetThreshold < 0 || targetThreshold > this.signerCommitments.length) {
       throw new Error(
@@ -793,7 +812,6 @@ export class Multisig {
 
     const summary = await executeForSummary(webClient, this._accountId, request);
     const summaryBase64 = uint8ArrayToBase64(summary.serialize());
-    const proposalNonce = options.nonce ?? Date.now();
     const action = targetThreshold === 0
       ? `Clear threshold override for ${targetProcedure}`
       : `Set ${targetProcedure} threshold override to ${targetThreshold}`;
@@ -822,6 +840,7 @@ export class Multisig {
     newGuardianPubkey: string,
     options: CreateProposalOptions = {},
   ): Promise<Proposal> {
+    const proposalNonce = resolveProposalNonce('createSwitchGuardianProposal', options);
     const webClient = await this.getRawClient();
     await this.verifyGuardianEndpointCommitment(newGuardianEndpoint, newGuardianPubkey);
 
@@ -833,7 +852,6 @@ export class Multisig {
 
     const summary = await executeForSummary(webClient, this._accountId, request);
     const summaryBase64 = uint8ArrayToBase64(summary.serialize());
-    const proposalNonce = options.nonce ?? Date.now();
 
     const metadata: ProposalMetadata = {
       proposalType: 'switch_guardian',
@@ -859,6 +877,7 @@ export class Multisig {
     noteIds: string[],
     options: CreateProposalOptions = {},
   ): Promise<Proposal> {
+    const proposalNonce = resolveProposalNonce('createConsumeNotesProposal', options);
     const webClient = await this.getRawClient();
     if (noteIds.length === 0) {
       throw new Error('At least one note ID is required');
@@ -880,7 +899,6 @@ export class Multisig {
 
     const summary = await executeForSummary(webClient, this._accountId, request);
     const summaryBase64 = uint8ArrayToBase64(summary.serialize());
-    const proposalNonce = options.nonce ?? Date.now();
 
     const metadata: ProposalMetadata = {
       proposalType: 'consume_notes',
@@ -920,7 +938,9 @@ export class Multisig {
     faucetId: string,
     amount: bigint,
     options: CreateP2idProposalOptions = {},
+    ...legacyArgs: never[]
   ): Promise<Proposal> {
+    const proposalNonce = resolveProposalNonce('createP2idProposal', options, legacyArgs);
     const webClient = await this.getRawClient();
     if (amount <= 0n) {
       throw new Error('Amount must be greater than 0');
@@ -928,22 +948,20 @@ export class Multisig {
 
     const account = await this.getStoreAccount();
 
+    // Forward everything but the nonce, so a note option added to
+    // CreateP2idProposalOptions can't be silently dropped before the builder.
+    const { nonce: _nonce, ...noteOptions } = options;
     const { request, salt } = buildP2idTransactionRequest(
       this._accountId,
       recipientId,
       faucetId,
       amount,
       account,
-      {
-        noteType: options.noteType,
-        reclaimHeight: options.reclaimHeight,
-        timelockHeight: options.timelockHeight,
-      },
+      noteOptions,
     );
 
     const summary = await executeForSummary(webClient, this._accountId, request);
     const summaryBase64 = uint8ArrayToBase64(summary.serialize());
-    const proposalNonce = options.nonce ?? Date.now();
 
     const metadata: ProposalMetadata = {
       proposalType: 'p2id',
@@ -1344,8 +1362,9 @@ export class Multisig {
   async createCustomProposal(
     transactionRequestBytes: Uint8Array,
     proposalType: string,
-    nonce?: number,
+    options: CreateProposalOptions = {},
   ): Promise<Proposal> {
+    const proposalNonce = resolveProposalNonce('createCustomProposal', options);
     const label = proposalType.trim().toLowerCase();
     if (label.length === 0) {
       throw new Error('proposalType must not be empty');
@@ -1365,7 +1384,6 @@ export class Multisig {
     const request = deserializeTransactionRequest(transactionRequestBytes);
     const summary = await executeForSummary(webClient, this._accountId, request);
     const summaryBase64 = uint8ArrayToBase64(summary.serialize());
-    const proposalNonce = nonce ?? Date.now();
 
     const metadata: ProposalMetadata = {
       proposalType: 'custom',

--- a/packages/miden-multisig-client/src/multisig.ts
+++ b/packages/miden-multisig-client/src/multisig.ts
@@ -47,6 +47,7 @@ import {
   buildP2idTransactionRequest,
   parseP2idNoteType,
   p2idNoteTypeToMetadata,
+  type P2ideHeightOptions,
 } from './transaction.js';
 import { buildConsumeNotesTransactionRequestFromNotes } from './transaction/consumeNotes.js';
 import {
@@ -112,6 +113,34 @@ export interface AccountStateVerificationResult {
   accountId: string;
   localCommitment: string;
   onChainCommitment: string;
+}
+
+/**
+ * Options shared by the `create*Proposal` family (issue #387). Every optional
+ * knob lives in a single trailing options bag, so call sites never need
+ * positional `undefined` holes to reach a later option.
+ */
+export interface CreateProposalOptions {
+  /** Proposal nonce; defaults to `Date.now()`. */
+  nonce?: number;
+}
+
+export interface CreateAddSignerProposalOptions extends CreateProposalOptions {
+  /** New signing threshold; defaults to the current threshold. */
+  newThreshold?: number;
+}
+
+export interface CreateRemoveSignerProposalOptions extends CreateProposalOptions {
+  /**
+   * New signing threshold; defaults to
+   * `min(current threshold, remaining signer count)`.
+   */
+  newThreshold?: number;
+}
+
+export interface CreateP2idProposalOptions extends CreateProposalOptions, P2ideHeightOptions {
+  /** Visibility of the created note. Defaults to `NoteType.Public` (issue #322). */
+  noteType?: NoteType;
 }
 
 /**
@@ -599,16 +628,15 @@ export class Multisig {
    * Create an "add signer" proposal.
    *
    * @param newCommitment - Commitment of the new signer (hex)
-   * @param nonce - Optional proposal nonce (defaults to Date.now())
-   * @param newThreshold - Optional new threshold (defaults to current threshold)
+   * @param options - Optional settings: `nonce`, `newThreshold` (defaults to
+   *   current threshold)
    */
   async createAddSignerProposal(
     newCommitment: string,
-    nonce?: number,
-    newThreshold?: number,
+    options: CreateAddSignerProposalOptions = {},
   ): Promise<Proposal> {
     const webClient = await this.getRawClient();
-    const targetThreshold = newThreshold ?? this.threshold;
+    const targetThreshold = options.newThreshold ?? this.threshold;
     const targetSignerCommitments = [...this.signerCommitments, newCommitment];
 
     const { request, salt } = await buildUpdateSignersTransactionRequest(
@@ -620,7 +648,7 @@ export class Multisig {
 
     const summary = await executeForSummary(webClient, this._accountId, request);
     const summaryBase64 = uint8ArrayToBase64(summary.serialize());
-    const proposalNonce = nonce ?? Date.now();
+    const proposalNonce = options.nonce ?? Date.now();
 
     const metadata: ProposalMetadata = {
       proposalType: 'add_signer',
@@ -638,13 +666,12 @@ export class Multisig {
    * Create a "remove signer" proposal by executing the update_signers script to summary.
    *
    * @param signerToRemove - Commitment of the signer to remove (hex)
-   * @param nonce - Optional proposal nonce (defaults to Date.now())
-   * @param newThreshold - Optional new threshold (defaults to min of current threshold and new signer count)
+   * @param options - Optional settings: `nonce`, `newThreshold` (defaults to
+   *   min of current threshold and new signer count)
    */
   async createRemoveSignerProposal(
     signerToRemove: string,
-    nonce?: number,
-    newThreshold?: number,
+    options: CreateRemoveSignerProposalOptions = {},
   ): Promise<Proposal> {
     const webClient = await this.getRawClient();
     const normalizedRemove = signerToRemove.toLowerCase();
@@ -659,7 +686,7 @@ export class Multisig {
       throw new Error('Cannot remove the last signer');
     }
 
-    const targetThreshold = newThreshold ?? Math.min(this.threshold, targetSignerCommitments.length);
+    const targetThreshold = options.newThreshold ?? Math.min(this.threshold, targetSignerCommitments.length);
 
     if (targetThreshold < 1 || targetThreshold > targetSignerCommitments.length) {
       throw new Error(
@@ -676,7 +703,7 @@ export class Multisig {
 
     const summary = await executeForSummary(webClient, this._accountId, request);
     const summaryBase64 = uint8ArrayToBase64(summary.serialize());
-    const proposalNonce = nonce ?? Date.now();
+    const proposalNonce = options.nonce ?? Date.now();
 
     const metadata: ProposalMetadata = {
       proposalType: 'remove_signer',
@@ -694,11 +721,11 @@ export class Multisig {
    * Create a "change threshold" proposal.
    *
    * @param newThreshold - The new threshold value
-   * @param nonce - Optional proposal nonce (defaults to Date.now())
+   * @param options - Optional settings: `nonce`
    */
   async createChangeThresholdProposal(
     newThreshold: number,
-    nonce?: number,
+    options: CreateProposalOptions = {},
   ): Promise<Proposal> {
     const webClient = await this.getRawClient();
     if (newThreshold < 1 || newThreshold > this.signerCommitments.length) {
@@ -720,7 +747,7 @@ export class Multisig {
 
     const summary = await executeForSummary(webClient, this._accountId, request);
     const summaryBase64 = uint8ArrayToBase64(summary.serialize());
-    const proposalNonce = nonce ?? Date.now();
+    const proposalNonce = options.nonce ?? Date.now();
 
     const metadata: ProposalMetadata = {
       proposalType: 'change_threshold',
@@ -737,7 +764,7 @@ export class Multisig {
   async createUpdateProcedureThresholdProposal(
     targetProcedure: ProcedureName,
     targetThreshold: number,
-    nonce?: number,
+    options: CreateProposalOptions = {},
   ): Promise<Proposal> {
     const webClient = await this.getRawClient();
     if (targetThreshold < 0 || targetThreshold > this.signerCommitments.length) {
@@ -766,7 +793,7 @@ export class Multisig {
 
     const summary = await executeForSummary(webClient, this._accountId, request);
     const summaryBase64 = uint8ArrayToBase64(summary.serialize());
-    const proposalNonce = nonce ?? Date.now();
+    const proposalNonce = options.nonce ?? Date.now();
     const action = targetThreshold === 0
       ? `Clear threshold override for ${targetProcedure}`
       : `Set ${targetProcedure} threshold override to ${targetThreshold}`;
@@ -788,12 +815,12 @@ export class Multisig {
    * 
    * @param newGuardianEndpoint - The new GUARDIAN server endpoint URL
    * @param newGuardianPubkey - The new GUARDIAN server's public key commitment (hex)
-   * @param nonce - Optional proposal nonce (defaults to Date.now())
+   * @param options - Optional settings: `nonce`
    */
   async createSwitchGuardianProposal(
     newGuardianEndpoint: string,
     newGuardianPubkey: string,
-    nonce?: number,
+    options: CreateProposalOptions = {},
   ): Promise<Proposal> {
     const webClient = await this.getRawClient();
     await this.verifyGuardianEndpointCommitment(newGuardianEndpoint, newGuardianPubkey);
@@ -806,7 +833,7 @@ export class Multisig {
 
     const summary = await executeForSummary(webClient, this._accountId, request);
     const summaryBase64 = uint8ArrayToBase64(summary.serialize());
-    const proposalNonce = nonce ?? Date.now();
+    const proposalNonce = options.nonce ?? Date.now();
 
     const metadata: ProposalMetadata = {
       proposalType: 'switch_guardian',
@@ -826,11 +853,11 @@ export class Multisig {
    * Create a "consume notes" proposal to consume notes sent to the multisig account.
    *
    * @param noteIds - IDs of the notes to consume (hex strings)
-   * @param nonce - Optional proposal nonce (defaults to Date.now())
+   * @param options - Optional settings: `nonce`
    */
   async createConsumeNotesProposal(
     noteIds: string[],
-    nonce?: number,
+    options: CreateProposalOptions = {},
   ): Promise<Proposal> {
     const webClient = await this.getRawClient();
     if (noteIds.length === 0) {
@@ -853,7 +880,7 @@ export class Multisig {
 
     const summary = await executeForSummary(webClient, this._accountId, request);
     const summaryBase64 = uint8ArrayToBase64(summary.serialize());
-    const proposalNonce = nonce ?? Date.now();
+    const proposalNonce = options.nonce ?? Date.now();
 
     const metadata: ProposalMetadata = {
       proposalType: 'consume_notes',
@@ -884,16 +911,15 @@ export class Multisig {
    * @param recipientId - Account ID of the recipient (hex string)
    * @param faucetId - Faucet/token account ID (hex string)
    * @param amount - Amount to send
-   * @param nonce - Optional proposal nonce (defaults to Date.now())
-   * @param options - Optional settings; `noteType` selects the created note's
-   *   visibility (defaults to `NoteType.Public`, issue #322)
+   * @param options - Optional settings: `nonce`; `noteType` selects the created
+   *   note's visibility (defaults to `NoteType.Public`, issue #322);
+   *   `reclaimHeight`/`timelockHeight` build a P2IDE note (issue #366)
    */
   async createP2idProposal(
     recipientId: string,
     faucetId: string,
     amount: bigint,
-    nonce?: number,
-    options: { noteType?: NoteType; reclaimHeight?: number; timelockHeight?: number } = {},
+    options: CreateP2idProposalOptions = {},
   ): Promise<Proposal> {
     const webClient = await this.getRawClient();
     if (amount <= 0n) {
@@ -917,7 +943,7 @@ export class Multisig {
 
     const summary = await executeForSummary(webClient, this._accountId, request);
     const summaryBase64 = uint8ArrayToBase64(summary.serialize());
-    const proposalNonce = nonce ?? Date.now();
+    const proposalNonce = options.nonce ?? Date.now();
 
     const metadata: ProposalMetadata = {
       proposalType: 'p2id',

--- a/speckit/features/008-custom-proposal-producer/contracts/sdk-api.md
+++ b/speckit/features/008-custom-proposal-producer/contracts/sdk-api.md
@@ -35,7 +35,7 @@ Integration execute flow (Rust): `let advice = client.prepare_custom_execution(i
 ## TypeScript — `Multisig` (`packages/miden-multisig-client/src/multisig.ts`)
 
 ```ts
-createCustomProposal(transactionRequestBytes: Uint8Array, proposalType: string, nonce?: number): Promise<Proposal>;
+createCustomProposal(transactionRequestBytes: Uint8Array, proposalType: string, options?: { nonce?: number }): Promise<Proposal>; // nonce moved into options by issue #387
 
 // Binding-check, fetch ack, return advice. Does NOT submit.
 prepareCustomExecution(proposalId: string, transactionRequestBytes: Uint8Array): Promise<AdviceMap>;


### PR DESCRIPTION
Closes #387. Based on #381 (`366-p2ide-heights`), riding the same breaking window.

Folds the positional optional `nonce` — and `newThreshold` for add/remove signer — into a single trailing options object across all eight `create*Proposal` methods (including `createCustomProposal`, so the family shares one convention):

```ts
await multisig.createP2idProposal(recipientAccountId, faucetAccountId, 1000n, {
  nonce: 42,                // optional, defaults to Date.now() as before
  noteType: NoteType.Private,
  reclaimHeight: 500_000,
});
