### PR TITLE
ci: run integration tests, doctests, and npm package tests on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,12 @@ jobs:
         uses: taiki-e/install-action@4a44d353abec8bd780e47de38e5bc5ea77053391 # cargo-llvm-cov
 
       - name: Run tests with coverage
-        run: cargo llvm-cov --lib --workspace --lcov --output-path lcov.info
+        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+
+      # llvm-cov doctest coverage requires nightly, so doctests run as a
+      # separate uninstrumented step.
+      - name: Run doctests
+        run: cargo test --workspace --doc
 
       - name: Run feature-006 authz-test-probe tests
         # The `authz-test-probe` Cargo feature (default-off in release builds —
@@ -81,6 +86,46 @@ jobs:
           files: ./lcov.info
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  npm-test:
+    name: TypeScript Package Tests
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'OpenZeppelin'
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - guardian-client
+          - guardian-evm-client
+          - guardian-operator-client
+          - miden-multisig-client
+    defaults:
+      run:
+        working-directory: packages/${{ matrix.package }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: packages/${{ matrix.package }}/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Run tests
+        run: npm test
 
   clippy:
     name: Clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -65,20 +69,16 @@ jobs:
         uses: taiki-e/install-action@4a44d353abec8bd780e47de38e5bc5ea77053391 # cargo-llvm-cov
 
       - name: Run tests with coverage
-        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+        run: >-
+          cargo llvm-cov
+          --features guardian-server/authz-test-probe
+          --lcov
+          --output-path lcov.info
 
       # llvm-cov doctest coverage requires nightly, so doctests run as a
       # separate uninstrumented step.
       - name: Run doctests
-        run: cargo test --workspace --doc
-
-      - name: Run feature-006 authz-test-probe tests
-        # The `authz-test-probe` Cargo feature (default-off in release builds —
-        # see `crates/server/src/dashboard/probe.rs`) gates a test-only
-        # route that exercises the operator-authorization middleware
-        # end-to-end. Run guardian-server's lib tests with the feature
-        # enabled so the US2 probe integration tests execute in CI.
-        run: cargo test -p guardian-server --lib --features authz-test-probe
+        run: cargo test --doc
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@351f82a4dc29e4159746a068ed925da17341219f # 1.89.0
@@ -71,14 +73,25 @@ jobs:
       - name: Run tests with coverage
         run: >-
           cargo llvm-cov
-          --features guardian-server/authz-test-probe
+          --workspace
+          --exclude guardian-prod-benchmarks
+          --exclude guardian-server-bench-loadgen
+          --exclude guardian-demo
+          --exclude guardian-rust-example
           --lcov
           --output-path lcov.info
 
       # llvm-cov doctest coverage requires nightly, so doctests run as a
       # separate uninstrumented step.
       - name: Run doctests
-        run: cargo test --doc
+        run: >-
+          cargo test
+          --workspace
+          --exclude guardian-prod-benchmarks
+          --exclude guardian-server-bench-loadgen
+          --exclude guardian-demo
+          --exclude guardian-rust-example
+          --doc
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
@@ -86,6 +99,43 @@ jobs:
           files: ./lcov.info
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  authz-test-probe:
+    name: Authz Test Probe
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'OpenZeppelin'
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@351f82a4dc29e4159746a068ed925da17341219f # 1.89.0
+        with:
+          toolchain: 1.93.0
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libpq-dev
+
+      - name: Cache cargo
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-authz-test-probe-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-authz-test-probe-
+
+      - name: Run authz test probe tests
+        run: cargo test -p guardian-server --lib --features authz-test-probe
 
   npm-test:
     name: TypeScript Package Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,25 @@ jobs:
           cache: npm
           cache-dependency-path: packages/${{ matrix.package }}/package-lock.json
 
+      # The procedure-roots test shells out to
+      # `cargo run --example procedure_roots -p miden-multisig-client`,
+      # which builds Rust workspace crates whose build scripts need protoc.
+      - name: Install system dependencies
+        if: matrix.package == 'miden-multisig-client'
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Cache cargo
+        if: matrix.package == 'miden-multisig-client'
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-npm-multisig-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-npm-multisig-
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,12 @@ jobs:
             ${{ runner.os }}-cargo-authz-test-probe-
 
       - name: Run authz test probe tests
-        run: cargo test -p guardian-server --lib --features authz-test-probe
+        run: >-
+          cargo test
+          -p guardian-server
+          --lib
+          --features authz-test-probe
+          api::dashboard::tests::authz_probe::
 
   npm-test:
     name: TypeScript Package Tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,9 +116,10 @@ cd examples/demo && cargo run --release   # Rust TUI multisig flow
 # smoke-web / operator-smoke-web / evm-smoke-web have their own READMEs
 ```
 
-CI enforces the Rust workspace tests and doctests, formatting, clippy, and the
-build and test scripts for all TypeScript packages. Run the matching checks
-locally before pushing when you touch a package or browser example.
+CI enforces tests and doctests for the Rust workspace's default members,
+formatting, clippy, and the build and test scripts for all TypeScript packages.
+Run the matching checks locally before pushing when you touch a package or
+browser example.
 
 For UI / SDK changes you cannot fully verify with `cargo test` alone,
 run the matching smoke example end to end. The

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,9 +116,9 @@ cd examples/demo && cargo run --release   # Rust TUI multisig flow
 # smoke-web / operator-smoke-web / evm-smoke-web have their own READMEs
 ```
 
-CI currently enforces the Rust workspace, formatting, and clippy jobs.
-Run the TypeScript package checks locally when you touch TS packages or
-browser examples.
+CI enforces the Rust workspace tests and doctests, formatting, clippy, and the
+build and test scripts for all TypeScript packages. Run the matching checks
+locally before pushing when you touch a package or browser example.
 
 For UI / SDK changes you cannot fully verify with `cargo test` alone,
 run the matching smoke example end to end. The

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,10 +116,10 @@ cd examples/demo && cargo run --release   # Rust TUI multisig flow
 # smoke-web / operator-smoke-web / evm-smoke-web have their own READMEs
 ```
 
-CI enforces tests and doctests for the Rust workspace's default members,
-formatting, clippy, and the build and test scripts for all TypeScript packages.
-Run the matching checks locally before pushing when you touch a package or
-browser example.
+CI enforces tests and doctests for the core Rust workspace crates, excluding
+benchmark and example members, plus formatting, clippy, and the build and test
+scripts for all TypeScript packages. Run the matching checks locally before
+pushing when you touch a package or browser example.
 
 For UI / SDK changes you cannot fully verify with `cargo test` alone,
 run the matching smoke example end to end. The

--- a/codecov.yml
+++ b/codecov.yml
@@ -19,6 +19,8 @@ comment:
   require_head: true
 
 ignore:
+  - "benchmarks/**"
+  - "crates/server/bench/**"
   - "examples/**"
   - "crates/contracts/**"
   - "tests/**"


### PR DESCRIPTION
Drop --lib from the coverage invocation so integration tests (cross-SDK auth vectors, P2ID serialization vectors, MASM auth suites) run on every PR and count toward coverage. Add a separate uninstrumented doctest step, since llvm-cov doctest coverage requires nightly. Add an npm-test matrix job running install, build, and tests for the four packages in packages/, which previously only ran at publish time.

Closes #388

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded automated Rust validation, including coverage and documentation tests.
  * Added CI testing for four TypeScript packages, including builds and package tests.
  * CI now cancels outdated runs to provide faster feedback.

* **Documentation**
  * Updated contribution guidance with current local validation recommendations.

* **Chores**
  * Refined coverage reporting to exclude benchmark code for more relevant results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->