### PR TITLE
fix(multisig-client): prune executed proposals from the cache on sync

### DIFF
--- a/packages/miden-multisig-client/README.md
+++ b/packages/miden-multisig-client/README.md
@@ -200,7 +200,7 @@ console.log('Signatures:', signedProposal.signatures.length);
 
 ### Sync Proposals
 
-Fetches proposals from the GUARDIAN server and updates local state:
+Fetches proposals from the GUARDIAN server and reconciles local state — proposals GUARDIAN no longer reports (executed, canonicalized, or abandoned) are pruned from the cache:
 
 ```typescript
 const proposals = await multisig.syncProposals();

--- a/packages/miden-multisig-client/src/multisig.test.ts
+++ b/packages/miden-multisig-client/src/multisig.test.ts
@@ -955,6 +955,121 @@ describe('Multisig', () => {
       expect(proposals[0].status).toBe('pending');
     });
 
+    it('should prune proposals GUARDIAN no longer reports (executed/canonicalized)', async () => {
+      const config = {
+        threshold: 2,
+        signerCommitments: ['0x' + 'a'.repeat(64), '0x' + 'b'.repeat(64)],
+        guardianCommitment: '0x' + 'c'.repeat(64),
+      };
+
+      const multisig = createTestMultisig(config);
+
+      const pendingProposal = {
+        account_id: '0x' + 'a'.repeat(30),
+        nonce: 1,
+        prev_commitment: '0x' + 'b'.repeat(64),
+        delta_payload: {
+          tx_summary: { data: 'AQID' },
+          signatures: [],
+          metadata: {
+            proposal_type: 'add_signer',
+            target_threshold: 1,
+            signer_commitments: ['0x' + 'a'.repeat(64)],
+            description: '',
+          },
+        },
+        status: {
+          status: 'pending',
+          timestamp: '2024-01-01T00:00:00Z',
+          proposer_id: '0x' + 'c'.repeat(64),
+          cosigner_sigs: [
+            {
+              signer_id: '0x' + 'a'.repeat(64),
+              signature: { scheme: 'falcon', signature: '0x' + 'e'.repeat(128) },
+              timestamp: '2024-01-01T00:00:00Z',
+            },
+          ],
+        },
+      };
+
+      // First sync: GUARDIAN reports the pending proposal, priming the cache.
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ proposals: [pendingProposal] }),
+      });
+      const first = await multisig.syncProposals();
+      expect(first.length).toBe(1);
+
+      // Second sync: another signer executed the proposal, so GUARDIAN pruned it
+      // and now returns an empty list. The cache must reconcile to empty rather
+      // than keep returning the stale (still-pending-looking) proposal forever.
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ proposals: [] }),
+      });
+      const second = await multisig.syncProposals();
+      expect(second).toEqual([]);
+      expect(multisig.listProposals()).toEqual([]);
+    });
+
+    it('should skip proposals already consumed by the committed account nonce', async () => {
+      const config = {
+        threshold: 1,
+        signerCommitments: ['0x' + 'a'.repeat(64)],
+        guardianCommitment: '0x' + 'c'.repeat(64),
+      };
+
+      // Local account is already at nonce 5; a proposal at nonce 5 has been
+      // consumed even though GUARDIAN still reports it pending (canonicalization
+      // has not pruned it yet). It must not be returned as pending.
+      const multisig = new Multisig(
+        mockedAccount('0x' + 'b'.repeat(64), 5),
+        config,
+        guardian,
+        mockSigner,
+        mockWebClient,
+        '0x' + 'a'.repeat(30),
+        MIDEN_RPC_ENDPOINT,
+      );
+
+      const staleProposal = {
+        account_id: '0x' + 'a'.repeat(30),
+        nonce: 5,
+        prev_commitment: '0x' + 'b'.repeat(64),
+        delta_payload: {
+          tx_summary: { data: 'AQID' },
+          signatures: [],
+          metadata: {
+            proposal_type: 'add_signer',
+            target_threshold: 1,
+            signer_commitments: ['0x' + 'a'.repeat(64)],
+            description: '',
+          },
+        },
+        status: {
+          status: 'pending',
+          timestamp: '2024-01-01T00:00:00Z',
+          proposer_id: '0x' + 'c'.repeat(64),
+          cosigner_sigs: [
+            {
+              signer_id: '0x' + 'a'.repeat(64),
+              signature: { scheme: 'falcon', signature: '0x' + 'e'.repeat(128) },
+              timestamp: '2024-01-01T00:00:00Z',
+            },
+          ],
+        },
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ proposals: [staleProposal] }),
+      });
+
+      const proposals = await multisig.syncProposals();
+      expect(proposals).toEqual([]);
+      expect(multisig.listProposals()).toEqual([]);
+    });
+
     it('should return ready status when enough signatures', async () => {
       const config = {
         threshold: 1, // Only 1 signature needed

--- a/packages/miden-multisig-client/src/multisig.test.ts
+++ b/packages/miden-multisig-client/src/multisig.test.ts
@@ -1012,64 +1012,6 @@ describe('Multisig', () => {
       expect(multisig.listProposals()).toEqual([]);
     });
 
-    it('should skip proposals already consumed by the committed account nonce', async () => {
-      const config = {
-        threshold: 1,
-        signerCommitments: ['0x' + 'a'.repeat(64)],
-        guardianCommitment: '0x' + 'c'.repeat(64),
-      };
-
-      // Local account is already at nonce 5; a proposal at nonce 5 has been
-      // consumed even though GUARDIAN still reports it pending (canonicalization
-      // has not pruned it yet). It must not be returned as pending.
-      const multisig = new Multisig(
-        mockedAccount('0x' + 'b'.repeat(64), 5),
-        config,
-        guardian,
-        mockSigner,
-        mockWebClient,
-        '0x' + 'a'.repeat(30),
-        MIDEN_RPC_ENDPOINT,
-      );
-
-      const staleProposal = {
-        account_id: '0x' + 'a'.repeat(30),
-        nonce: 5,
-        prev_commitment: '0x' + 'b'.repeat(64),
-        delta_payload: {
-          tx_summary: { data: 'AQID' },
-          signatures: [],
-          metadata: {
-            proposal_type: 'add_signer',
-            target_threshold: 1,
-            signer_commitments: ['0x' + 'a'.repeat(64)],
-            description: '',
-          },
-        },
-        status: {
-          status: 'pending',
-          timestamp: '2024-01-01T00:00:00Z',
-          proposer_id: '0x' + 'c'.repeat(64),
-          cosigner_sigs: [
-            {
-              signer_id: '0x' + 'a'.repeat(64),
-              signature: { scheme: 'falcon', signature: '0x' + 'e'.repeat(128) },
-              timestamp: '2024-01-01T00:00:00Z',
-            },
-          ],
-        },
-      };
-
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ proposals: [staleProposal] }),
-      });
-
-      const proposals = await multisig.syncProposals();
-      expect(proposals).toEqual([]);
-      expect(multisig.listProposals()).toEqual([]);
-    });
-
     it('should return ready status when enough signatures', async () => {
       const config = {
         threshold: 1, // Only 1 signature needed

--- a/packages/miden-multisig-client/src/multisig.test.ts
+++ b/packages/miden-multisig-client/src/multisig.test.ts
@@ -1012,6 +1012,62 @@ describe('Multisig', () => {
       expect(multisig.listProposals()).toEqual([]);
     });
 
+    it('should keep proposals GUARDIAN still reports across syncs', async () => {
+      // Guards against over-pruning: a proposal the server still reports on a
+      // later sync must survive the reconcile, not be deleted.
+      const config = {
+        threshold: 2,
+        signerCommitments: ['0x' + 'a'.repeat(64), '0x' + 'b'.repeat(64)],
+        guardianCommitment: '0x' + 'c'.repeat(64),
+      };
+
+      const multisig = createTestMultisig(config);
+
+      const pendingProposal = {
+        account_id: '0x' + 'a'.repeat(30),
+        nonce: 1,
+        prev_commitment: '0x' + 'b'.repeat(64),
+        delta_payload: {
+          tx_summary: { data: 'AQID' },
+          signatures: [],
+          metadata: {
+            proposal_type: 'add_signer',
+            target_threshold: 1,
+            signer_commitments: ['0x' + 'a'.repeat(64)],
+            description: '',
+          },
+        },
+        status: {
+          status: 'pending',
+          timestamp: '2024-01-01T00:00:00Z',
+          proposer_id: '0x' + 'c'.repeat(64),
+          cosigner_sigs: [
+            {
+              signer_id: '0x' + 'a'.repeat(64),
+              signature: { scheme: 'falcon', signature: '0x' + 'e'.repeat(128) },
+              timestamp: '2024-01-01T00:00:00Z',
+            },
+          ],
+        },
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ proposals: [pendingProposal] }),
+      });
+      const first = await multisig.syncProposals();
+      expect(first.length).toBe(1);
+
+      // GUARDIAN still reports the same pending proposal on the next sync.
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ proposals: [pendingProposal] }),
+      });
+      const second = await multisig.syncProposals();
+      expect(second.length).toBe(1);
+      expect(multisig.listProposals().length).toBe(1);
+    });
+
     it('should return ready status when enough signatures', async () => {
       const config = {
         threshold: 1, // Only 1 signature needed

--- a/packages/miden-multisig-client/src/multisig.test.ts
+++ b/packages/miden-multisig-client/src/multisig.test.ts
@@ -1068,6 +1068,55 @@ describe('Multisig', () => {
       expect(multisig.listProposals().length).toBe(1);
     });
 
+    it('should not prune a locally-created proposal GUARDIAN has not reported yet', async () => {
+      // createProposal pushes to GUARDIAN then caches. If GUARDIAN's
+      // read-your-writes lags and the immediately-following sync omits the
+      // just-pushed proposal, it must NOT be evicted: GUARDIAN never reported it
+      // to this client, so it is not a prune candidate.
+      const config = {
+        threshold: 1,
+        signerCommitments: ['0x' + 'a'.repeat(64)],
+        guardianCommitment: '0x' + 'c'.repeat(64),
+      };
+      const multisig = createTestMultisig(config);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          delta: {
+            account_id: '0x' + 'a'.repeat(30),
+            nonce: 1,
+            prev_commitment: '0x' + 'b'.repeat(64),
+            delta_payload: { tx_summary: { data: 'AQID' }, signatures: [] },
+            status: {
+              status: 'pending',
+              timestamp: '2024-01-01T00:00:00Z',
+              proposer_id: '0x' + 'c'.repeat(64),
+              cosigner_sigs: [],
+            },
+          },
+          commitment: '0x' + 'c'.repeat(64),
+        }),
+      });
+      const created = await multisig.createProposal(1, 'AQID', {
+        proposalType: 'add_signer',
+        targetThreshold: 1,
+        targetSignerCommitments: ['0x' + 'a'.repeat(64)],
+        description: '',
+      });
+      expect(multisig.listProposals().length).toBe(1);
+
+      // GUARDIAN's next getDeltaProposals lags and returns [].
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ proposals: [] }),
+      });
+      const synced = await multisig.syncProposals();
+      expect(synced.length).toBe(1);
+      expect(synced[0].id).toBe(created.id);
+      expect(multisig.listProposals().length).toBe(1);
+    });
+
     it('should return ready status when enough signatures', async () => {
       const config = {
         threshold: 1, // Only 1 signature needed

--- a/packages/miden-multisig-client/src/multisig.ts
+++ b/packages/miden-multisig-client/src/multisig.ts
@@ -536,59 +536,40 @@ export class Multisig {
   }
 
   /**
-   * The committed nonce of the local account, or null when it cannot be read
-   * (no account loaded yet, or a nonce larger than a safe integer). Mirrors the
-   * example app's `currentAccountNonce` helper.
-   */
-  private committedAccountNonce(): number | null {
-    if (!this.account) {
-      return null;
-    }
-
-    try {
-      const nonce = this.account.nonce().asInt();
-      if (nonce > BigInt(Number.MAX_SAFE_INTEGER)) {
-        return null;
-      }
-      return Number(nonce);
-    } catch {
-      return null;
-    }
-  }
-
-  /**
    * Sync proposals from the GUARDIAN server.
    *
    * The GUARDIAN response is authoritative for the set of pending proposals: the
    * server only reports proposals whose status is still pending and drops them
    * once they are executed and canonicalized. The local cache is therefore
-   * rebuilt to match the response, so a proposal the server has pruned does not
-   * linger locally and keep showing as pending forever — e.g. a co-signer's
-   * browser after another signer executed the transaction. This mirrors the Rust
-   * client's `list_proposals`, which rebuilds its result set from the response on
-   * every call.
+   * reconciled to the response — proposals the server no longer reports are
+   * pruned — so a stale proposal does not linger locally and keep showing as
+   * pending forever, e.g. a co-signer's browser after another signer executed the
+   * transaction. Only ids present in the cache when the sync started are eligible
+   * for pruning, so a proposal created/signed/imported concurrently during the
+   * awaits below is never dropped.
    *
    * Rebuilding is safe for the offline export/import flow: every proposal is
    * pushed to GUARDIAN when it is created (`createProposal`), so an imported
    * proposal is still GUARDIAN-tracked and is returned here while pending; it is
    * only dropped once GUARDIAN itself stops reporting it (executed / abandoned).
+   *
+   * Nonce-based staleness hiding — a proposal the account has already advanced
+   * past, which GUARDIAN may still briefly report as pending before it prunes it
+   * — is intentionally left to callers' own visible-proposal filter (see the
+   * examples' `filterVisibleProposals`). The proposal `nonce` field has no single
+   * cross-app convention (some callers store the pre-execution account nonce,
+   * others the next nonce), so the client cannot safely filter on it here.
    */
   async syncProposals(): Promise<Proposal[]> {
+    // Snapshot the ids known before the network round-trip so only these are
+    // eligible for pruning; anything added concurrently below is preserved.
+    const knownIds = new Set(this.proposals.keys());
+
     const deltas = await this.guardian.getDeltaProposals(this._accountId);
     const factory = this.proposalFactory();
 
-    const committedNonce = this.committedAccountNonce();
-    const reconciled = new Map<string, Proposal>();
-
+    const reportedIds = new Set<string>();
     for (const delta of deltas) {
-      // Skip proposals already consumed by the committed account nonce. GUARDIAN
-      // may still report them pending until canonicalization prunes them; mirror
-      // the Rust client's `proposal.nonce <= account.nonce()` staleness filter so
-      // an executed-but-not-yet-pruned proposal is not shown as pending.
-      if (committedNonce !== null && delta.nonce <= committedNonce) {
-        continue;
-      }
-
       const proposalId = normalizeHexWord(
         computeCommitmentFromTxSummary(delta.deltaPayload.txSummary.data)
       );
@@ -601,10 +582,18 @@ export class Multisig {
       );
       await this.verifyProposalMetadataBinding(proposal);
 
-      reconciled.set(proposal.id, proposal);
+      this.proposals.set(proposal.id, proposal);
+      reportedIds.add(proposal.id);
     }
 
-    this.proposals = reconciled;
+    // Prune proposals GUARDIAN no longer reports (executed / canonicalized /
+    // abandoned) so they do not linger as stale pending entries.
+    for (const id of knownIds) {
+      if (!reportedIds.has(id)) {
+        this.proposals.delete(id);
+      }
+    }
+
     return Array.from(this.proposals.values());
   }
 

--- a/packages/miden-multisig-client/src/multisig.ts
+++ b/packages/miden-multisig-client/src/multisig.ts
@@ -559,9 +559,12 @@ export class Multisig {
    * Nonce-based staleness hiding — a proposal the account has already advanced
    * past, which GUARDIAN may still briefly report as pending before it prunes it
    * — is intentionally left to callers' own visible-proposal filter (see the
-   * examples' `filterVisibleProposals`). The proposal `nonce` field has no single
-   * cross-app convention (some callers store the pre-execution account nonce,
-   * others the next nonce), so the client cannot safely filter on it here.
+   * examples' `filterVisibleProposals`). The Rust client applies a
+   * `proposal.nonce <= account.nonce()` filter directly, but it owns a single
+   * nonce convention end to end; this shared client serves callers that disagree
+   * on what the proposal `nonce` means (some store the pre-execution account
+   * nonce, others the next nonce), so it cannot safely apply that comparison here
+   * and defers it to the caller. This is an intentional TS/Rust surface difference.
    */
   async syncProposals(): Promise<Proposal[]> {
     // Snapshot the ids known before the network round-trip so only these are
@@ -601,7 +604,11 @@ export class Multisig {
   }
 
   /**
-   * List all known proposals
+   * Returns the proposals cached by the most recent {@link syncProposals} call.
+   *
+   * This is that sync's reconciled set, not a durable log: proposals GUARDIAN no
+   * longer reports were pruned, so do not treat the result as an ever-growing
+   * history of every proposal ever seen.
    */
   listProposals(): Proposal[] {
     return Array.from(this.proposals.values());

--- a/packages/miden-multisig-client/src/multisig.ts
+++ b/packages/miden-multisig-client/src/multisig.ts
@@ -536,13 +536,59 @@ export class Multisig {
   }
 
   /**
+   * The committed nonce of the local account, or null when it cannot be read
+   * (no account loaded yet, or a nonce larger than a safe integer). Mirrors the
+   * example app's `currentAccountNonce` helper.
+   */
+  private committedAccountNonce(): number | null {
+    if (!this.account) {
+      return null;
+    }
+
+    try {
+      const nonce = this.account.nonce().asInt();
+      if (nonce > BigInt(Number.MAX_SAFE_INTEGER)) {
+        return null;
+      }
+      return Number(nonce);
+    } catch {
+      return null;
+    }
+  }
+
+  /**
    * Sync proposals from the GUARDIAN server.
+   *
+   * The GUARDIAN response is authoritative for the set of pending proposals: the
+   * server only reports proposals whose status is still pending and drops them
+   * once they are executed and canonicalized. The local cache is therefore
+   * rebuilt to match the response, so a proposal the server has pruned does not
+   * linger locally and keep showing as pending forever — e.g. a co-signer's
+   * browser after another signer executed the transaction. This mirrors the Rust
+   * client's `list_proposals`, which rebuilds its result set from the response on
+   * every call.
+   *
+   * Rebuilding is safe for the offline export/import flow: every proposal is
+   * pushed to GUARDIAN when it is created (`createProposal`), so an imported
+   * proposal is still GUARDIAN-tracked and is returned here while pending; it is
+   * only dropped once GUARDIAN itself stops reporting it (executed / abandoned).
    */
   async syncProposals(): Promise<Proposal[]> {
     const deltas = await this.guardian.getDeltaProposals(this._accountId);
     const factory = this.proposalFactory();
 
+    const committedNonce = this.committedAccountNonce();
+    const reconciled = new Map<string, Proposal>();
+
     for (const delta of deltas) {
+      // Skip proposals already consumed by the committed account nonce. GUARDIAN
+      // may still report them pending until canonicalization prunes them; mirror
+      // the Rust client's `proposal.nonce <= account.nonce()` staleness filter so
+      // an executed-but-not-yet-pruned proposal is not shown as pending.
+      if (committedNonce !== null && delta.nonce <= committedNonce) {
+        continue;
+      }
+
       const proposalId = normalizeHexWord(
         computeCommitmentFromTxSummary(delta.deltaPayload.txSummary.data)
       );
@@ -555,9 +601,10 @@ export class Multisig {
       );
       await this.verifyProposalMetadataBinding(proposal);
 
-      this.proposals.set(proposal.id, proposal);
+      reconciled.set(proposal.id, proposal);
     }
 
+    this.proposals = reconciled;
     return Array.from(this.proposals.values());
   }
 

--- a/packages/miden-multisig-client/src/multisig.ts
+++ b/packages/miden-multisig-client/src/multisig.ts
@@ -160,6 +160,10 @@ export class Multisig {
   private readonly _accountId: string;
   private readonly midenRpcEndpoint: string;
   private proposals: Map<string, Proposal> = new Map();
+  // Proposal ids GUARDIAN returned on the most recent syncProposals. Only these
+  // are eligible for pruning on the next sync, so a locally created/imported
+  // proposal GUARDIAN has not yet reported is never evicted (see syncProposals).
+  private lastReportedProposalIds: Set<string> = new Set();
 
   constructor(
     account: Account,
@@ -541,20 +545,19 @@ export class Multisig {
    * The GUARDIAN response is authoritative for the set of pending proposals: the
    * server only reports proposals whose status is still pending and drops them
    * once they are executed and canonicalized. The local cache is therefore
-   * reconciled to the response — proposals the server no longer reports are
-   * pruned — so a stale proposal does not linger locally and keep showing as
-   * pending forever, e.g. a co-signer's browser after another signer executed the
-   * transaction. Only ids present in the cache when the sync started are eligible
-   * for pruning, so a proposal created/signed/imported concurrently during the
-   * awaits below is never dropped.
+   * reconciled to the response — a proposal GUARDIAN reported on a previous sync
+   * but no longer reports is pruned — so a stale proposal does not linger locally
+   * and keep showing as pending forever, e.g. a co-signer's browser after another
+   * signer executed the transaction.
    *
-   * Reconciling is safe for the offline export/import flow. `importProposal`
-   * itself does not push to GUARDIAN, but the only way to create a proposal is
-   * `createProposal`, which pushes to GUARDIAN before caching — so by the time a
-   * proposal is exported, shared over a side channel, and imported elsewhere, its
-   * creator has already registered it with GUARDIAN. An imported proposal is thus
-   * GUARDIAN-tracked and returned here while pending; it is only dropped once
-   * GUARDIAN itself stops reporting it (executed / abandoned).
+   * Only proposals GUARDIAN has actually reported are eligible for pruning. A
+   * proposal that is in the cache but that GUARDIAN has not (yet) returned in a
+   * response is left untouched. This keeps two flows correct: (1) a
+   * `createProposal` immediately followed by a sync is not evicted if GUARDIAN's
+   * read-your-writes lags and omits the just-pushed proposal; (2) the offline
+   * export/import flow — `importProposal` caches a proposal this client has not
+   * synced yet — is not evicted before GUARDIAN first reports it. A proposal is
+   * only dropped once GUARDIAN reported it and then stopped (executed / abandoned).
    *
    * Nonce-based staleness hiding — a proposal the account has already advanced
    * past, which GUARDIAN may still briefly report as pending before it prunes it
@@ -567,10 +570,6 @@ export class Multisig {
    * and defers it to the caller. This is an intentional TS/Rust surface difference.
    */
   async syncProposals(): Promise<Proposal[]> {
-    // Snapshot the ids known before the network round-trip so only these are
-    // eligible for pruning; anything added concurrently below is preserved.
-    const knownIds = new Set(this.proposals.keys());
-
     const deltas = await this.guardian.getDeltaProposals(this._accountId);
     const factory = this.proposalFactory();
 
@@ -592,13 +591,15 @@ export class Multisig {
       reportedIds.add(proposal.id);
     }
 
-    // Prune proposals GUARDIAN no longer reports (executed / canonicalized /
-    // abandoned) so they do not linger as stale pending entries.
-    for (const id of knownIds) {
+    // Prune proposals GUARDIAN reported before but no longer reports (executed /
+    // canonicalized / abandoned). Proposals GUARDIAN has never reported to this
+    // client (freshly created, or imported and not yet synced) are left alone.
+    for (const id of this.lastReportedProposalIds) {
       if (!reportedIds.has(id)) {
         this.proposals.delete(id);
       }
     }
+    this.lastReportedProposalIds = reportedIds;
 
     return Array.from(this.proposals.values());
   }

--- a/packages/miden-multisig-client/src/multisig.ts
+++ b/packages/miden-multisig-client/src/multisig.ts
@@ -548,10 +548,13 @@ export class Multisig {
    * for pruning, so a proposal created/signed/imported concurrently during the
    * awaits below is never dropped.
    *
-   * Rebuilding is safe for the offline export/import flow: every proposal is
-   * pushed to GUARDIAN when it is created (`createProposal`), so an imported
-   * proposal is still GUARDIAN-tracked and is returned here while pending; it is
-   * only dropped once GUARDIAN itself stops reporting it (executed / abandoned).
+   * Reconciling is safe for the offline export/import flow. `importProposal`
+   * itself does not push to GUARDIAN, but the only way to create a proposal is
+   * `createProposal`, which pushes to GUARDIAN before caching — so by the time a
+   * proposal is exported, shared over a side channel, and imported elsewhere, its
+   * creator has already registered it with GUARDIAN. An imported proposal is thus
+   * GUARDIAN-tracked and returned here while pending; it is only dropped once
+   * GUARDIAN itself stops reporting it (executed / abandoned).
    *
    * Nonce-based staleness hiding — a proposal the account has already advanced
    * past, which GUARDIAN may still briefly report as pending before it prunes it


### PR DESCRIPTION
### What

`syncProposals()` now reconciles the local proposal cache against the (authoritative) GUARDIAN response on every sync — proposals GUARDIAN previously reported and now omits are pruned — instead of only ever adding to a Map that was never cleaned up.

### Why

The Map was merge-only. After a proposal is executed, GUARDIAN stops returning it (the server keeps only pending proposals). The executing co-signer's browser had updated its own cache while executing, but every other signer's browser silently ignored the now-empty response and kept the executed proposal pinned as pending forever (stuck at, e.g., 1/2).

### How

- Track the ids GUARDIAN returned on the most recent sync (`lastReportedProposalIds`) and prune only those it now omits. A proposal GUARDIAN has never reported to this client — freshly created (before GUARDIAN's read-your-writes catches up) or imported-but-not-yet-synced — is never a prune candidate, so those flows keep working; a proposal GUARDIAN reported and then dropped (executed / abandoned) is pruned.
- Deliberately **no client-side nonce filter**. The proposal `nonce` field has no single cross-app convention (this repo's `examples/web` stores the pre-execution account nonce; `examples/_shared/multisig-browser` and the Rust client use the next nonce), so filtering on it in the shared client would evict live proposals for one of them. Nonce-based staleness *hiding* stays where it already lives — the callers' `filterVisibleProposals`.

### Tests

Three new `syncProposals` tests (each mutation-checked to fail against the bug it guards):
- **co-signer prune** — a proposal GUARDIAN reported then dropped is removed from the cache;
- **over-prune guard** — a proposal GUARDIAN still reports survives the reconcile;
- **read-your-writes** — a just-created proposal GUARDIAN has not reported yet is not evicted.

Full package suite green (426 tests), `tsc --noEmit` clean.

### Release / semver note

This changes the observable output of `syncProposals()` / `listProposals()` (they no longer retain proposals GUARDIAN has dropped). It fixes buggy behavior, and the in-repo example consumers already re-derive their visible set each sync, so no consumer regression is expected — but the release carrying it should flag this (a minor bump, or an explicit release note). No version bump is included here since versioning is a separate release commit.

### Notes for maintainers (out of scope for this PR)

- `examples/web/src/lib/multisigApi.ts` uses a different proposal-nonce convention (`proposalNonce = currentAccountNonce`, filter `nonce < accountNonce`) than `examples/_shared/multisig-browser` and the Rust client (`+1`, `nonce <= accountNonce`). Worth reconciling separately.
- If an offline-*create* path (a proposal not pushed to GUARDIAN at creation) is ever added, the prune would need to exempt session-local proposals; today every proposal is pushed at creation, so this can't arise.
- Optional follow-up (not needed for this fix): dedupe in-flight `syncProposals` calls (return the pending promise if one is running) to avoid a transient prune/keep blip when overlapping syncs race, and to cut redundant round-trips.

Closes #404


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proposal synchronization to remove cached proposals no longer reported by GUARDIAN.
  * Preserved newly created or imported proposals until they are first reported by GUARDIAN.
  * Ensured currently reported proposals remain available in the cache.

* **Documentation**
  * Clarified proposal-cache cleanup behavior during synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->