### PR TITLE
feat(auth): scope replay protection state per signer + retry

### DIFF
--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -18,7 +18,7 @@ serde_json = { workspace = true }
 tonic = { workspace = true }
 tonic-prost = { workspace = true }
 prost = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 thiserror = { workspace = true }
 hex = { workspace = true }
 chrono = { workspace = true }

--- a/crates/client/README.md
+++ b/crates/client/README.md
@@ -55,8 +55,8 @@ class), and `retry_after()` returns the server's hint, preferring the
 `retry-after` status metadata over the envelope value.
 
 Rate-limit rejections happen before the server touches any state, so
-retrying them is always safe. The client does not retry automatically
-(automatic backoff is tracked in
+retrying them is always safe. The client does not retry rate limits
+automatically (automatic backoff is tracked in
 [#360](https://github.com/OpenZeppelin/guardian/issues/360)); a bounded
 loop over the exposed hint is a few lines:
 
@@ -79,6 +79,18 @@ let state = loop {
 Retries are idempotent (the original request timestamp is preserved). The
 server refuses with `GUARDIAN_CANDIDATE_LANDED` when the transaction
 demonstrably landed.
+
+### Replay-protection retries
+
+Signed requests carry a strictly increasing per-instance timestamp
+(`max(now_ms, previous + 1)`). When a correctly signed request still loses
+the server's per-signer replay check (stable code `authentication_replay`,
+typically two in-flight requests landing out of order), the client retries
+automatically, up to 2 times with a 50ms backoff, minting a fresh timestamp
+and signature over the identical payload each attempt.
+`ClientError::is_replay_rejection()` exposes the classification. Terminal
+authentication failures (`authentication_failed`: clock outside the skew
+window, invalid or unauthorized signature) are never retried.
 
 ## Authentication
 

--- a/crates/client/README.md
+++ b/crates/client/README.md
@@ -92,6 +92,12 @@ and signature over the identical payload each attempt.
 authentication failures (`authentication_failed`: clock outside the skew
 window, invalid or unauthorized signature) are never retried.
 
+The client retries only `authentication_replay`; it never retries
+`authentication_failed`. During a mixed server/client rollout, a replay CAS
+reported under the older authentication code—or received by a client without
+replay-specific retry handling—can therefore surface as a terminal error until
+both sides use the same error contract.
+
 ## Authentication
 
 The client uses Falcon Poseidon2 signatures for authenticated requests. Here is how to set it up:

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -509,12 +509,19 @@ impl GuardianClient {
 /// instance; the caller supplies the clock so the arithmetic stays
 /// deterministic under test.
 fn next_monotonic_timestamp(last_timestamp: &AtomicI64, now_ms: i64) -> i64 {
-    let previous = last_timestamp
-        .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |last| {
-            Some(last.max(now_ms - 1) + 1)
-        })
-        .expect("update closure always returns Some");
-    previous.max(now_ms - 1) + 1
+    let mut previous = last_timestamp.load(Ordering::SeqCst);
+    loop {
+        let next = previous.saturating_add(1).max(now_ms);
+        match last_timestamp.compare_exchange_weak(
+            previous,
+            next,
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+        ) {
+            Ok(_) => return next,
+            Err(actual) => previous = actual,
+        }
+    }
 }
 
 fn attach_auth_headers<T: prost::Message>(

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -21,8 +21,18 @@ use guardian_shared::lookup_auth_message::LookupAuthMessage;
 use miden_protocol::Word;
 use miden_protocol::account::AccountId;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::time::Duration;
 use tonic::metadata::MetadataValue;
 use tonic::transport::Channel;
+
+/// Bounded retry policy for replay-classified rejections
+/// (`authentication_replay`): the request was correctly signed but lost the
+/// server's per-signer timestamp CAS to a concurrent request. Each attempt
+/// re-mints the timestamp and re-signs the identical payload. Mirrors the TS
+/// client's policy; terminal authentication failures are never retried.
+const REPLAY_RETRY_LIMIT: u32 = 2;
+const REPLAY_RETRY_BACKOFF: Duration = Duration::from_millis(50);
 
 /// A client for interacting with Guardian servers.
 ///
@@ -36,6 +46,7 @@ pub struct GuardianClient {
     client: GuardianGrpcClient<Channel>,
     auth: Option<Auth>,
     signer: Option<Arc<dyn Signer>>,
+    last_timestamp: AtomicI64,
 }
 
 impl GuardianClient {
@@ -50,7 +61,16 @@ impl GuardianClient {
             client,
             auth: None,
             signer: None,
+            last_timestamp: AtomicI64::new(0),
         })
+    }
+
+    /// Monotonic timestamp for auth metadata: strictly increasing across
+    /// calls within a single client instance so concurrent or rapid-fire
+    /// requests never mint duplicate `x-timestamp` values. Mirrors the TS
+    /// client's `nextTimestamp`.
+    fn next_timestamp(&self) -> i64 {
+        next_monotonic_timestamp(&self.last_timestamp, Utc::now().timestamp_millis())
     }
 
     /// Configures scheme-aware authentication for authenticated GUARDIAN requests.
@@ -87,7 +107,7 @@ impl GuardianClient {
         account_id: &AccountId,
     ) -> ClientResult<()> {
         let request_payload = AuthRequestPayload::from_protobuf_message(request.get_ref());
-        let timestamp = Utc::now().timestamp_millis();
+        let timestamp = self.next_timestamp();
 
         let (pubkey_hex, signature_hex) = if let Some(auth) = &self.auth {
             let pubkey_hex = auth.public_key_hex();
@@ -118,7 +138,7 @@ impl GuardianClient {
         request: &mut tonic::Request<T>,
         key_commitment: Word,
     ) -> ClientResult<()> {
-        let timestamp = Utc::now().timestamp_millis();
+        let timestamp = self.next_timestamp();
         let digest = LookupAuthMessage::new(timestamp, key_commitment).to_word();
 
         let (pubkey_hex, signature_hex) = if let Some(auth) = &self.auth {
@@ -134,6 +154,43 @@ impl GuardianClient {
         attach_auth_headers(request, &pubkey_hex, &signature_hex, timestamp)
     }
 
+    /// Send an authenticated request, retrying only replay-classified
+    /// rejections (`authentication_replay`) up to [`REPLAY_RETRY_LIMIT`]
+    /// times. Every attempt rebuilds the request from the identical message
+    /// with a fresh monotonic timestamp, recomputed digest, and fresh
+    /// signature. Terminal failures (invalid signature, unauthorized signer,
+    /// clock outside the skew window) propagate immediately.
+    async fn send_with_replay_retry<Req, Resp, F>(
+        &mut self,
+        account_id: &AccountId,
+        message: Req,
+        mut send: F,
+    ) -> ClientResult<Resp>
+    where
+        Req: prost::Message + Clone + std::fmt::Debug,
+        F: AsyncFnMut(
+            &mut GuardianGrpcClient<Channel>,
+            tonic::Request<Req>,
+        ) -> Result<tonic::Response<Resp>, tonic::Status>,
+    {
+        let mut retries_left = REPLAY_RETRY_LIMIT;
+        loop {
+            let mut request = tonic::Request::new(message.clone());
+            self.add_auth_metadata(&mut request, account_id)?;
+            match send(&mut self.client, request).await {
+                Ok(response) => return Ok(response.into_inner()),
+                Err(status) => {
+                    let error = ClientError::from(status);
+                    if retries_left == 0 || !error.is_replay_rejection() {
+                        return Err(error);
+                    }
+                    retries_left -= 1;
+                    tokio::time::sleep(REPLAY_RETRY_BACKOFF).await;
+                }
+            }
+        }
+    }
+
     /// Configure a new account
     ///
     /// # Arguments
@@ -145,16 +202,17 @@ impl GuardianClient {
     ) -> ClientResult<ConfigureResponse> {
         let initial_state_json = serde_json::to_string(&initial_state)?;
 
-        let mut request = tonic::Request::new(ConfigureRequest {
+        let message = ConfigureRequest {
             account_id: account_id.to_string(),
             auth: Some(auth),
             initial_state: initial_state_json,
-        });
+        };
 
-        self.add_auth_metadata(&mut request, account_id)?;
-
-        let response = self.client.configure(request).await?;
-        let inner = response.into_inner();
+        let inner = self
+            .send_with_replay_retry(account_id, message, async |client, request| {
+                client.configure(request).await
+            })
+            .await?;
 
         if !inner.success {
             return Err(ClientError::ServerError(inner.message.clone()));
@@ -175,17 +233,18 @@ impl GuardianClient {
     ) -> ClientResult<PushDeltaResponse> {
         let delta_payload_json = serde_json::to_string(&delta_payload)?;
 
-        let mut request = tonic::Request::new(PushDeltaRequest {
+        let message = PushDeltaRequest {
             account_id: account_id.to_string(),
             nonce,
             prev_commitment: prev_commitment.into(),
             delta_payload: delta_payload_json,
-        });
+        };
 
-        self.add_auth_metadata(&mut request, account_id)?;
-
-        let response = self.client.push_delta(request).await?;
-        let inner = response.into_inner();
+        let inner = self
+            .send_with_replay_retry(account_id, message, async |client, request| {
+                client.push_delta(request).await
+            })
+            .await?;
 
         if !inner.success {
             return Err(ClientError::ServerError(inner.message.clone()));
@@ -200,15 +259,16 @@ impl GuardianClient {
         account_id: &AccountId,
         nonce: u64,
     ) -> ClientResult<GetDeltaResponse> {
-        let mut request = tonic::Request::new(GetDeltaRequest {
+        let message = GetDeltaRequest {
             account_id: account_id.to_string(),
             nonce,
-        });
+        };
 
-        self.add_auth_metadata(&mut request, account_id)?;
-
-        let response = self.client.get_delta(request).await?;
-        let inner = response.into_inner();
+        let inner = self
+            .send_with_replay_retry(account_id, message, async |client, request| {
+                client.get_delta(request).await
+            })
+            .await?;
 
         if !inner.success {
             return Err(ClientError::ServerError(inner.message.clone()));
@@ -223,15 +283,16 @@ impl GuardianClient {
         account_id: &AccountId,
         from_nonce: u64,
     ) -> ClientResult<GetDeltaSinceResponse> {
-        let mut request = tonic::Request::new(GetDeltaSinceRequest {
+        let message = GetDeltaSinceRequest {
             account_id: account_id.to_string(),
             from_nonce,
-        });
+        };
 
-        self.add_auth_metadata(&mut request, account_id)?;
-
-        let response = self.client.get_delta_since(request).await?;
-        let inner = response.into_inner();
+        let inner = self
+            .send_with_replay_retry(account_id, message, async |client, request| {
+                client.get_delta_since(request).await
+            })
+            .await?;
 
         if !inner.success {
             return Err(ClientError::ServerError(inner.message.clone()));
@@ -242,14 +303,15 @@ impl GuardianClient {
 
     /// Retrieves the current state for an account.
     pub async fn get_state(&mut self, account_id: &AccountId) -> ClientResult<GetStateResponse> {
-        let mut request = tonic::Request::new(GetStateRequest {
+        let message = GetStateRequest {
             account_id: account_id.to_string(),
-        });
+        };
 
-        self.add_auth_metadata(&mut request, account_id)?;
-
-        let response = self.client.get_state(request).await?;
-        let inner = response.into_inner();
+        let inner = self
+            .send_with_replay_retry(account_id, message, async |client, request| {
+                client.get_state(request).await
+            })
+            .await?;
 
         if !inner.success {
             return Err(ClientError::ServerError(inner.message.clone()));
@@ -310,16 +372,17 @@ impl GuardianClient {
     ) -> ClientResult<PushDeltaProposalResponse> {
         let delta_payload_json = serde_json::to_string(&delta_payload)?;
 
-        let mut request = tonic::Request::new(PushDeltaProposalRequest {
+        let message = PushDeltaProposalRequest {
             account_id: account_id.to_string(),
             nonce,
             delta_payload: delta_payload_json,
-        });
+        };
 
-        self.add_auth_metadata(&mut request, account_id)?;
-
-        let response = self.client.push_delta_proposal(request).await?;
-        let inner = response.into_inner();
+        let inner = self
+            .send_with_replay_retry(account_id, message, async |client, request| {
+                client.push_delta_proposal(request).await
+            })
+            .await?;
 
         if !inner.success {
             return Err(ClientError::ServerError(inner.message.clone()));
@@ -333,14 +396,15 @@ impl GuardianClient {
         &mut self,
         account_id: &AccountId,
     ) -> ClientResult<GetDeltaProposalsResponse> {
-        let mut request = tonic::Request::new(GetDeltaProposalsRequest {
+        let message = GetDeltaProposalsRequest {
             account_id: account_id.to_string(),
-        });
+        };
 
-        self.add_auth_metadata(&mut request, account_id)?;
-
-        let response = self.client.get_delta_proposals(request).await?;
-        let inner = response.into_inner();
+        let inner = self
+            .send_with_replay_retry(account_id, message, async |client, request| {
+                client.get_delta_proposals(request).await
+            })
+            .await?;
 
         if !inner.success {
             return Err(ClientError::ServerError(inner.message.clone()));
@@ -355,15 +419,16 @@ impl GuardianClient {
         account_id: &AccountId,
         commitment: impl Into<String>,
     ) -> ClientResult<GetDeltaProposalResponse> {
-        let mut request = tonic::Request::new(GetDeltaProposalRequest {
+        let message = GetDeltaProposalRequest {
             account_id: account_id.to_string(),
             commitment: commitment.into(),
-        });
+        };
 
-        self.add_auth_metadata(&mut request, account_id)?;
-
-        let response = self.client.get_delta_proposal(request).await?;
-        let inner = response.into_inner();
+        let inner = self
+            .send_with_replay_retry(account_id, message, async |client, request| {
+                client.get_delta_proposal(request).await
+            })
+            .await?;
 
         if !inner.success {
             return Err(ClientError::ServerError(inner.message.clone()));
@@ -381,16 +446,17 @@ impl GuardianClient {
     ) -> ClientResult<SignDeltaProposalResponse> {
         let proto_signature = Some(proto_signature_from_json(&signature));
 
-        let mut request = tonic::Request::new(SignDeltaProposalRequest {
+        let message = SignDeltaProposalRequest {
             account_id: account_id.to_string(),
             commitment: commitment.into(),
             signature: proto_signature,
-        });
+        };
 
-        self.add_auth_metadata(&mut request, account_id)?;
-
-        let response = self.client.sign_delta_proposal(request).await?;
-        let inner = response.into_inner();
+        let inner = self
+            .send_with_replay_retry(account_id, message, async |client, request| {
+                client.sign_delta_proposal(request).await
+            })
+            .await?;
 
         if !inner.success {
             return Err(ClientError::ServerError(inner.message.clone()));
@@ -419,15 +485,16 @@ impl GuardianClient {
         account_id: &AccountId,
         nonce: u64,
     ) -> ClientResult<AbandonDeltaCandidateResponse> {
-        let mut request = tonic::Request::new(AbandonDeltaCandidateRequest {
+        let message = AbandonDeltaCandidateRequest {
             account_id: account_id.to_string(),
             nonce,
-        });
+        };
 
-        self.add_auth_metadata(&mut request, account_id)?;
-
-        let response = self.client.abandon_delta_candidate(request).await?;
-        let inner = response.into_inner();
+        let inner = self
+            .send_with_replay_retry(account_id, message, async |client, request| {
+                client.abandon_delta_candidate(request).await
+            })
+            .await?;
 
         if !inner.success {
             return Err(ClientError::ServerError(inner.message.clone()));
@@ -435,6 +502,19 @@ impl GuardianClient {
 
         Ok(inner)
     }
+}
+
+/// `max(now_ms, last + 1)`: the wall clock when it is ahead, otherwise one
+/// past the previously minted value. Shared by all auth paths of one client
+/// instance; the caller supplies the clock so the arithmetic stays
+/// deterministic under test.
+fn next_monotonic_timestamp(last_timestamp: &AtomicI64, now_ms: i64) -> i64 {
+    let previous = last_timestamp
+        .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |last| {
+            Some(last.max(now_ms - 1) + 1)
+        })
+        .expect("update closure always returns Some");
+    previous.max(now_ms - 1) + 1
 }
 
 fn attach_auth_headers<T: prost::Message>(
@@ -472,5 +552,60 @@ fn proto_signature_from_json(signature: &JsonProposalSignature) -> ProtoProposal
             signature: signature.clone(),
             public_key: public_key.clone(),
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn monotonic_timestamp_follows_the_clock_when_ahead() {
+        let last = AtomicI64::new(0);
+        assert_eq!(next_monotonic_timestamp(&last, 1_000), 1_000);
+        assert_eq!(next_monotonic_timestamp(&last, 2_000), 2_000);
+    }
+
+    #[test]
+    fn monotonic_timestamp_never_repeats_within_one_instance() {
+        let last = AtomicI64::new(0);
+        let first = next_monotonic_timestamp(&last, 1_000);
+        let second = next_monotonic_timestamp(&last, 1_000);
+        let third = next_monotonic_timestamp(&last, 1_000);
+        assert_eq!((first, second, third), (1_000, 1_001, 1_002));
+    }
+
+    #[test]
+    fn monotonic_timestamp_survives_a_clock_step_backwards() {
+        let last = AtomicI64::new(0);
+        assert_eq!(next_monotonic_timestamp(&last, 5_000), 5_000);
+        assert_eq!(next_monotonic_timestamp(&last, 4_000), 5_001);
+    }
+
+    #[test]
+    fn concurrent_timestamps_are_unique() {
+        let last = Arc::new(AtomicI64::new(0));
+        let handles: Vec<_> = (0..8)
+            .map(|_| {
+                let last = last.clone();
+                std::thread::spawn(move || {
+                    (0..100)
+                        .map(|_| next_monotonic_timestamp(&last, 1_000))
+                        .collect::<Vec<_>>()
+                })
+            })
+            .collect();
+        let mut minted: Vec<i64> = handles
+            .into_iter()
+            .flat_map(|handle| handle.join().unwrap())
+            .collect();
+        let count = minted.len();
+        minted.sort_unstable();
+        minted.dedup();
+        assert_eq!(
+            minted.len(),
+            count,
+            "timestamps must be unique across threads"
+        );
     }
 }

--- a/crates/client/src/error.rs
+++ b/crates/client/src/error.rs
@@ -5,6 +5,11 @@ use thiserror::Error;
 /// A Result type alias for GUARDIAN client operations.
 pub type ClientResult<T> = Result<T, ClientError>;
 
+/// Stable code the server attaches to a replay-protection rejection
+/// (`authentication_replay`, issue #367): the request was correctly signed
+/// but its timestamp did not win the per-signer monotonicity check.
+pub const AUTHENTICATION_REPLAY_CODE: &str = "authentication_replay";
+
 /// Errors that can occur when using the GUARDIAN client.
 #[derive(Debug, Error)]
 pub enum ClientError {
@@ -91,6 +96,14 @@ impl ClientError {
         }
     }
 
+    /// Whether the server classified this error as a replay-protection
+    /// rejection ([`AUTHENTICATION_REPLAY_CODE`]). Safe to retry with a
+    /// fresh timestamp and signature over the identical payload; every
+    /// other authentication failure is terminal and must not be retried.
+    pub fn is_replay_rejection(&self) -> bool {
+        self.guardian_code().as_deref() == Some(AUTHENTICATION_REPLAY_CODE)
+    }
+
     /// Whether the server marked this error safe to retry: `meta.retryable`
     /// from the structured details, falling back to the status-code class
     /// (`ResourceExhausted` rejections happen before any handler runs).
@@ -162,6 +175,48 @@ mod tests {
             tonic::Status::new(tonic::Code::Unavailable, "raw internal detail").into();
         assert_eq!(err.guardian_code(), None);
         assert_eq!(err.user_message(), None);
+    }
+
+    #[test]
+    fn replay_rejection_is_classified_only_from_the_stable_code() {
+        let replay_details = serde_json::json!({
+            "code": "authentication_replay",
+            "message": "Guardian received this request out of order. Please try again.",
+            "meta": { "retryable": true }
+        })
+        .to_string()
+        .into_bytes();
+        let replay: ClientError = tonic::Status::with_details(
+            tonic::Code::Unauthenticated,
+            "test",
+            replay_details.into(),
+        )
+        .into();
+        assert!(replay.is_replay_rejection());
+        assert!(replay.is_retryable());
+
+        let terminal_details = serde_json::json!({
+            "code": "authentication_failed",
+            "message": "Guardian could not authenticate this request.",
+            "meta": { "retryable": false }
+        })
+        .to_string()
+        .into_bytes();
+        let terminal: ClientError = tonic::Status::with_details(
+            tonic::Code::Unauthenticated,
+            "test",
+            terminal_details.into(),
+        )
+        .into();
+        assert!(!terminal.is_replay_rejection());
+        assert!(!terminal.is_retryable());
+
+        let bare: ClientError =
+            tonic::Status::new(tonic::Code::Unauthenticated, "Replay attack detected").into();
+        assert!(
+            !bare.is_replay_rejection(),
+            "message text must never classify a replay"
+        );
     }
 
     #[test]

--- a/crates/client/src/testing/client_tests.rs
+++ b/crates/client/src/testing/client_tests.rs
@@ -22,6 +22,17 @@ fn create_test_signer() -> Arc<dyn Signer> {
     Arc::new(FalconKeyStore::new(SecretKey::new()))
 }
 
+fn guardian_auth_status(code: &str, retryable: bool) -> Status {
+    let details = serde_json::json!({
+        "code": code,
+        "message": "test",
+        "meta": { "retryable": retryable }
+    })
+    .to_string()
+    .into_bytes();
+    Status::with_details(tonic::Code::Unauthenticated, "test", details.into())
+}
+
 #[tokio::test]
 async fn test_get_pubkey_success() {
     let service = MockGuardianService::default().with_get_pubkey(Ok("test_pubkey_123".to_string()));
@@ -440,6 +451,96 @@ async fn test_get_state_success() {
     assert!(response.success);
     assert!(response.state.is_some());
     assert!(response.state.unwrap().state_json.contains("balance"));
+}
+
+#[tokio::test]
+async fn replay_rejections_are_retried_with_fresh_timestamp_and_signature_each_attempt() {
+    // Two queued replay errors force the client to use its entire retry
+    // budget; the mock then serves its default success, so a passing result
+    // proves both retries happened.
+    let service = MockGuardianService::default()
+        .with_get_state(Err(guardian_auth_status("authentication_replay", true)))
+        .with_get_state(Err(guardian_auth_status("authentication_replay", true)));
+    let recorded_headers = service.get_state_auth_headers_handle();
+
+    let endpoint = start_mock_server(service).await.unwrap();
+    let mut client = GuardianClient::connect(endpoint)
+        .await
+        .unwrap()
+        .with_signer(create_test_signer());
+
+    let response = client
+        .get_state(&create_test_account_id())
+        .await
+        .expect("replay rejections within the retry budget must be retried to success");
+    assert!(response.success);
+
+    let attempts = recorded_headers.lock().unwrap().clone();
+    assert_eq!(attempts.len(), 3, "one initial attempt plus two retries");
+    assert!(
+        attempts[0].0 < attempts[1].0 && attempts[1].0 < attempts[2].0,
+        "every attempt must mint a strictly increasing timestamp: {attempts:?}"
+    );
+    let signatures: std::collections::HashSet<&String> =
+        attempts.iter().map(|(_, signature)| signature).collect();
+    assert_eq!(
+        signatures.len(),
+        3,
+        "every attempt must carry a fresh signature over the new timestamp"
+    );
+}
+
+#[tokio::test]
+async fn replay_retries_stop_at_the_bounded_budget() {
+    // Three queued replay errors exceed the two-retry budget. If the client
+    // sent a fourth attempt it would hit the mock's default success, so the
+    // surfaced replay error proves the bound is exact.
+    let service = MockGuardianService::default()
+        .with_get_state(Err(guardian_auth_status("authentication_replay", true)))
+        .with_get_state(Err(guardian_auth_status("authentication_replay", true)))
+        .with_get_state(Err(guardian_auth_status("authentication_replay", true)));
+    let recorded_headers = service.get_state_auth_headers_handle();
+
+    let endpoint = start_mock_server(service).await.unwrap();
+    let mut client = GuardianClient::connect(endpoint)
+        .await
+        .unwrap()
+        .with_signer(create_test_signer());
+
+    let error = client
+        .get_state(&create_test_account_id())
+        .await
+        .expect_err("a replay condition outlasting the retry budget must surface");
+    assert!(error.is_replay_rejection());
+    assert_eq!(
+        recorded_headers.lock().unwrap().len(),
+        3,
+        "one initial attempt plus exactly two retries"
+    );
+}
+
+#[tokio::test]
+async fn terminal_authentication_failure_is_not_retried() {
+    // Same mock semantics as above: a retry would hit the default success
+    // response, so the surfaced error proves the client gave up immediately.
+    let service = MockGuardianService::default()
+        .with_get_state(Err(guardian_auth_status("authentication_failed", false)));
+
+    let endpoint = start_mock_server(service).await.unwrap();
+    let mut client = GuardianClient::connect(endpoint)
+        .await
+        .unwrap()
+        .with_signer(create_test_signer());
+
+    let error = client
+        .get_state(&create_test_account_id())
+        .await
+        .expect_err("a terminal authentication failure must not be retried");
+    assert_eq!(
+        error.guardian_code().as_deref(),
+        Some("authentication_failed")
+    );
+    assert!(!error.is_replay_rejection());
 }
 
 #[tokio::test]

--- a/crates/client/src/testing/mocks.rs
+++ b/crates/client/src/testing/mocks.rs
@@ -24,7 +24,8 @@ pub struct MockGuardianService {
     push_delta_response: Arc<StdMutex<Option<Result<PushDeltaResponse, Status>>>>,
     get_delta_response: Arc<StdMutex<Option<Result<GetDeltaResponse, Status>>>>,
     get_delta_since_response: Arc<StdMutex<Option<Result<GetDeltaSinceResponse, Status>>>>,
-    get_state_response: Arc<StdMutex<Option<Result<GetStateResponse, Status>>>>,
+    get_state_responses: Arc<StdMutex<Vec<Result<GetStateResponse, Status>>>>,
+    get_state_auth_headers: Arc<StdMutex<Vec<(i64, String)>>>,
     get_account_by_key_commitment_response:
         Arc<StdMutex<Option<Result<GetAccountByKeyCommitmentResponse, Status>>>>,
     abandon_delta_candidate_response:
@@ -89,9 +90,19 @@ impl MockGuardianService {
         self
     }
 
+    /// Queue a `get_state` response. Responses are served FIFO; once the
+    /// queue is empty the handler falls back to its default success, so
+    /// queueing N errors makes attempt N+1 succeed.
     pub fn with_get_state(self, response: Result<GetStateResponse, Status>) -> Self {
-        *self.get_state_response.lock().unwrap() = Some(response);
+        self.get_state_responses.lock().unwrap().push(response);
         self
+    }
+
+    /// Handle onto the `(x-timestamp, x-signature)` pairs recorded from every
+    /// `get_state` request, in arrival order. Clone before moving the service
+    /// into `start_mock_server` to observe per-attempt auth metadata.
+    pub fn get_state_auth_headers_handle(&self) -> Arc<StdMutex<Vec<(i64, String)>>> {
+        self.get_state_auth_headers.clone()
     }
 
     pub fn with_get_account_by_key_commitment(
@@ -322,20 +333,35 @@ impl Guardian for MockGuardianService {
 
     async fn get_state(
         &self,
-        _request: Request<GetStateRequest>,
+        request: Request<GetStateRequest>,
     ) -> Result<Response<GetStateResponse>, Status> {
-        let response = self
-            .get_state_response
+        let timestamp = request
+            .metadata()
+            .get("x-timestamp")
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.parse::<i64>().ok())
+            .unwrap_or_default();
+        let signature = request
+            .metadata()
+            .get("x-signature")
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default()
+            .to_string();
+        self.get_state_auth_headers
             .lock()
             .unwrap()
-            .take()
-            .unwrap_or_else(|| {
-                Ok(GetStateResponse {
-                    success: true,
-                    message: String::new(),
-                    state: Some(create_mock_account_state()),
-                })
-            });
+            .push((timestamp, signature));
+
+        let mut responses = self.get_state_responses.lock().unwrap();
+        let response = if responses.is_empty() {
+            Ok(GetStateResponse {
+                success: true,
+                message: String::new(),
+                state: Some(create_mock_account_state()),
+            })
+        } else {
+            responses.remove(0)
+        };
 
         response.map(Response::new)
     }

--- a/crates/server/migrations/2026-08-13-000001_auth_state_per_signer/down.sql
+++ b/crates/server/migrations/2026-08-13-000001_auth_state_per_signer/down.sql
@@ -9,7 +9,7 @@ SET LOCAL lock_timeout = '5s';
 
 LOCK TABLE account_auth_state IN ACCESS EXCLUSIVE MODE;
 
-CREATE TABLE account_auth_state_collapsed AS
+CREATE TEMP TABLE account_auth_state_collapsed AS
 SELECT account_id, MAX(last_auth_timestamp) AS last_auth_timestamp
   FROM account_auth_state
  GROUP BY account_id;

--- a/crates/server/migrations/2026-08-13-000001_auth_state_per_signer/down.sql
+++ b/crates/server/migrations/2026-08-13-000001_auth_state_per_signer/down.sql
@@ -1,0 +1,28 @@
+-- Collapse per-(account, signer) replay state back to one per-account row.
+-- MAX over the account's signers is the conservative account-scoped floor:
+-- no request accepted under per-signer scope wins the account-scoped CAS
+-- after the rollback. Same locking rationale as up.sql: post-#367 CAS
+-- writers are blocked so their timestamps land in the aggregate; once the
+-- rebuild commits, queued per-signer writes fail on the missing column,
+-- which is the intended fail-closed behavior.
+SET LOCAL lock_timeout = '5s';
+
+LOCK TABLE account_auth_state IN ACCESS EXCLUSIVE MODE;
+
+CREATE TABLE account_auth_state_collapsed AS
+SELECT account_id, MAX(last_auth_timestamp) AS last_auth_timestamp
+  FROM account_auth_state
+ GROUP BY account_id;
+
+DROP TABLE account_auth_state;
+
+CREATE TABLE account_auth_state (
+    account_id VARCHAR(128) PRIMARY KEY
+        REFERENCES account_metadata(account_id) ON DELETE CASCADE,
+    last_auth_timestamp BIGINT NOT NULL
+) WITH (fillfactor = 50);
+
+INSERT INTO account_auth_state (account_id, last_auth_timestamp)
+SELECT account_id, last_auth_timestamp FROM account_auth_state_collapsed;
+
+DROP TABLE account_auth_state_collapsed;

--- a/crates/server/migrations/2026-08-13-000001_auth_state_per_signer/up.sql
+++ b/crates/server/migrations/2026-08-13-000001_auth_state_per_signer/up.sql
@@ -1,0 +1,128 @@
+-- Re-key replay-protection state from per-account to per-(account, signer)
+-- (issue #367) so independent authorized cosigners never contend on one
+-- timestamp. Each existing account-scoped row is expanded to one row per
+-- currently authorized signer commitment, preserving the replay floor across
+-- the upgrade instead of re-accepting requests seen just before it.
+--
+-- The exclusive lock blocks CAS writers still running the pre-#367 binary:
+-- a timestamp committed between the expansion snapshot and the table swap
+-- would otherwise be silently discarded, regressing replay state. The share
+-- lock holds the authorized signer sets still, so the metadata validated
+-- below is the metadata that is expanded; readers are unaffected.
+-- Once this commits, queued pre-#367 writes fail against the replacement
+-- schema because signer_commitment is required, which is the intended
+-- fail-closed behavior.
+-- Same bounded-wait rationale as 2026-07-31-000001_account_auth_state.
+SET LOCAL lock_timeout = '5s';
+
+LOCK TABLE account_metadata IN SHARE MODE;
+
+LOCK TABLE account_auth_state IN ACCESS EXCLUSIVE MODE;
+
+CREATE TABLE account_auth_state_per_signer (
+    account_id VARCHAR(128) NOT NULL
+        REFERENCES account_metadata(account_id) ON DELETE CASCADE,
+    signer_commitment VARCHAR(128) NOT NULL,
+    last_auth_timestamp BIGINT NOT NULL,
+    PRIMARY KEY (account_id, signer_commitment)
+) WITH (fillfactor = 50);
+
+-- Expand every account-scoped replay row against its authorized signer set
+-- exactly once, so the format check below and the copy that follows cannot
+-- read different metadata or disagree on which JSON paths hold commitments.
+-- Producing a row is not enough on its own: reading these entries as text
+-- also coerces numbers and objects, which would preserve the floor under a
+-- key no real signer can ever present, silently resetting the replay window
+-- once the metadata is repaired. Each element must be a canonical
+-- commitment string: Miden writes 0x + 64 lowercase hex, EVM signers are
+-- lowercased to 0x + 40 hex on ingest. An account whose signer set is empty
+-- or whose auth JSON is not exactly one known variant yields a single row
+-- with a NULL commitment, which fails the same check.
+CREATE TEMP TABLE auth_state_signer_expansion AS
+SELECT s.account_id,
+       s.last_auth_timestamp,
+       signer.value #>> '{}' AS signer_commitment,
+       COALESCE(
+           auth_state.variant_count = 1
+               AND jsonb_typeof(signer.value) = 'string'
+               AND (signer.value #>> '{}') ~ auth_state.commitment_pattern,
+           FALSE
+       ) AS is_canonical
+  FROM account_auth_state s
+  JOIN account_metadata m ON m.account_id = s.account_id
+ CROSS JOIN LATERAL (
+     SELECT COALESCE(
+                m.auth -> 'MidenFalconRpo' -> 'cosigner_commitments',
+                m.auth -> 'MidenEcdsa' -> 'cosigner_commitments',
+                m.auth -> 'EvmEcdsa' -> 'signers'
+            ) AS commitments,
+            CASE
+                WHEN m.auth ? 'EvmEcdsa' THEN '^0x[0-9a-f]{40}$'
+                ELSE '^0x[0-9a-f]{64}$'
+            END AS commitment_pattern,
+            (m.auth ? 'MidenFalconRpo')::integer
+              + (m.auth ? 'MidenEcdsa')::integer
+              + (m.auth ? 'EvmEcdsa')::integer AS variant_count
+ ) auth_state
+  LEFT JOIN LATERAL jsonb_array_elements(
+      CASE
+          WHEN jsonb_typeof(auth_state.commitments) = 'array'
+              THEN auth_state.commitments
+          ELSE '[]'::jsonb
+      END
+  ) signer(value) ON TRUE;
+
+DO $$
+DECLARE
+    invalid_accounts text;
+BEGIN
+    SELECT string_agg(DISTINCT account_id, ', ') INTO invalid_accounts
+      FROM auth_state_signer_expansion
+     WHERE NOT is_canonical;
+
+    IF invalid_accounts IS NOT NULL THEN
+        RAISE EXCEPTION
+            'account_auth_state: replay rows for account(s) % have no canonical authorized signer set; inspect account_metadata.auth for these accounts, then delete their account_auth_state rows to explicitly accept the replay-window risk',
+            invalid_accounts;
+    END IF;
+END $$;
+
+INSERT INTO account_auth_state_per_signer
+    (account_id, signer_commitment, last_auth_timestamp)
+SELECT DISTINCT account_id, signer_commitment, last_auth_timestamp
+  FROM auth_state_signer_expansion;
+
+DROP TABLE auth_state_signer_expansion;
+
+-- Independent of the expansion above: an account_auth_state row whose
+-- metadata row is missing produces no expansion at all, and would otherwise
+-- lose its replay floor to the DROP TABLE below without any error.
+DO $$
+DECLARE
+    unmatched_accounts text;
+BEGIN
+    SELECT string_agg(s.account_id, ', ') INTO unmatched_accounts
+      FROM account_auth_state s
+     WHERE NOT EXISTS (
+         SELECT 1
+           FROM account_auth_state_per_signer replacement
+          WHERE replacement.account_id = s.account_id
+     );
+
+    IF unmatched_accounts IS NOT NULL THEN
+        RAISE EXCEPTION
+            'account_auth_state: replay rows for account(s) % were not copied to per-signer state',
+            unmatched_accounts;
+    END IF;
+END $$;
+
+DROP TABLE account_auth_state;
+
+ALTER TABLE account_auth_state_per_signer RENAME TO account_auth_state;
+
+ALTER TABLE account_auth_state
+    RENAME CONSTRAINT account_auth_state_per_signer_pkey TO account_auth_state_pkey;
+
+ALTER TABLE account_auth_state
+    RENAME CONSTRAINT account_auth_state_per_signer_account_id_fkey
+    TO account_auth_state_account_id_fkey;

--- a/crates/server/migrations/2026-08-13-000001_auth_state_per_signer/up.sql
+++ b/crates/server/migrations/2026-08-13-000001_auth_state_per_signer/up.sql
@@ -2,7 +2,9 @@
 -- (issue #367) so independent authorized cosigners never contend on one
 -- timestamp. Each existing account-scoped row is expanded to one row per
 -- currently authorized signer commitment, preserving the replay floor across
--- the upgrade instead of re-accepting requests seen just before it.
+-- the upgrade instead of re-accepting requests seen just before it. A reserved
+-- account-level row is also retained so a signer absent during migration still
+-- inherits the old floor if it is authorized again later.
 --
 -- The exclusive lock blocks CAS writers still running the pre-#367 binary:
 -- a timestamp committed between the expansion snapshot and the table swap
@@ -30,14 +32,13 @@ CREATE TABLE account_auth_state_per_signer (
 -- Expand every account-scoped replay row against its authorized signer set
 -- exactly once, so the format check below and the copy that follows cannot
 -- read different metadata or disagree on which JSON paths hold commitments.
--- Producing a row is not enough on its own: reading these entries as text
--- also coerces numbers and objects, which would preserve the floor under a
--- key no real signer can ever present, silently resetting the replay window
--- once the metadata is repaired. Each element must be a canonical
--- commitment string: Miden writes 0x + 64 lowercase hex, EVM signers are
--- lowercased to 0x + 40 hex on ingest. An account whose signer set is empty
--- or whose auth JSON is not exactly one known variant yields a single row
--- with a NULL commitment, which fails the same check.
+-- Reading signer entries as text also coerces numbers and objects, which would
+-- create rows under keys no real signer can ever present. Only canonical
+-- commitments are expanded: Miden writes 0x + 64 lowercase hex, while EVM
+-- signers are lowercased to 0x + 40 hex on ingest. The reserved account-level
+-- row below retains the floor when metadata has no usable signer entries.
+-- Keep these patterns aligned with Auth::is_canonical_signer_commitment in
+-- crates/server/src/metadata/auth/mod.rs.
 CREATE TEMP TABLE auth_state_signer_expansion AS
 SELECT s.account_id,
        s.last_auth_timestamp,
@@ -72,25 +73,19 @@ SELECT s.account_id,
       END
   ) signer(value) ON TRUE;
 
-DO $$
-DECLARE
-    invalid_accounts text;
-BEGIN
-    SELECT string_agg(DISTINCT account_id, ', ') INTO invalid_accounts
-      FROM auth_state_signer_expansion
-     WHERE NOT is_canonical;
-
-    IF invalid_accounts IS NOT NULL THEN
-        RAISE EXCEPTION
-            'account_auth_state: replay rows for account(s) % have no canonical authorized signer set; inspect account_metadata.auth for these accounts, then delete their account_auth_state rows to explicitly accept the replay-window risk',
-            invalid_accounts;
-    END IF;
-END $$;
+-- Keep the old account-scoped floor under a value that no real signer can
+-- present. Runtime CAS checks this row as a lower bound for every signer.
+INSERT INTO account_auth_state_per_signer
+    (account_id, signer_commitment, last_auth_timestamp)
+SELECT s.account_id, '__legacy_account_floor__', s.last_auth_timestamp
+  FROM account_auth_state s
+  JOIN account_metadata m ON m.account_id = s.account_id;
 
 INSERT INTO account_auth_state_per_signer
     (account_id, signer_commitment, last_auth_timestamp)
 SELECT DISTINCT account_id, signer_commitment, last_auth_timestamp
-  FROM auth_state_signer_expansion;
+  FROM auth_state_signer_expansion
+ WHERE is_canonical;
 
 DROP TABLE auth_state_signer_expansion;
 

--- a/crates/server/src/api/http.rs
+++ b/crates/server/src/api/http.rs
@@ -149,68 +149,29 @@ pub struct ConfigureResponse {
     request_body = ConfigureRequest,
     responses(
         (status = 200, description = "Account configured", body = ConfigureResponse),
-        (status = 400, description = "Invalid request", body = ConfigureResponse),
+        (status = 400, description = "Invalid request", body = crate::openapi::ApiErrorResponse),
+        (status = 401, description = "Authentication failed or replay rejected", body = crate::openapi::ApiErrorResponse),
     )
 )]
 pub async fn configure(
     State(state): State<AppState>,
     AuthHeader(credentials): AuthHeader,
     Json(payload): Json<ConfigureRequest>,
-) -> (StatusCode, Json<ConfigureResponse>) {
-    let request_payload = match request_payload_from_serializable(&payload) {
-        Ok(request_payload) => request_payload,
-        Err(e) => {
-            // Log the raw detail; return only the user-safe message + stable
-            // code (feature 009-human-readable-errors).
-            let err = GuardianError::InvalidInput(e);
-            tracing::debug!(code = err.code(), detail = %err, "configure request invalid");
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(ConfigureResponse {
-                    success: false,
-                    message: err.user_message().to_string(),
-                    ack_pubkey: None,
-                    ack_commitment: None,
-                    code: Some(err.code()),
-                }),
-            );
-        }
-    };
+) -> Result<Json<ConfigureResponse>, GuardianError> {
+    let request_payload =
+        request_payload_from_serializable(&payload).map_err(GuardianError::InvalidInput)?;
 
     let mut params = ConfigureAccountParams::from(payload);
     params.credential = request_payload.apply_to(credentials);
 
-    match services::configure_account(&state, params).await {
-        Ok(response) => (
-            StatusCode::OK,
-            Json(ConfigureResponse {
-                success: true,
-                message: format!("Account '{}' configured successfully", response.account_id),
-                ack_pubkey: Some(response.ack_pubkey),
-                ack_commitment: Some(response.ack_commitment),
-                code: None,
-            }),
-        ),
-        Err(e) => {
-            // The diagnostic Display string is logged, not returned; the wire
-            // carries only the user-safe message + stable code (feature 009).
-            if e.http_status().is_server_error() {
-                tracing::error!(code = e.code(), detail = %e, "configure failed (5xx)");
-            } else {
-                tracing::debug!(code = e.code(), detail = %e, "configure rejected (4xx)");
-            }
-            (
-                e.http_status(),
-                Json(ConfigureResponse {
-                    success: false,
-                    message: e.user_message().to_string(),
-                    ack_pubkey: None,
-                    ack_commitment: None,
-                    code: Some(e.code()),
-                }),
-            )
-        }
-    }
+    let response = services::configure_account(&state, params).await?;
+    Ok(Json(ConfigureResponse {
+        success: true,
+        message: format!("Account '{}' configured successfully", response.account_id),
+        ack_pubkey: Some(response.ack_pubkey),
+        ack_commitment: Some(response.ack_commitment),
+        code: None,
+    }))
 }
 
 /// Push a signed state delta for a single-key account. The request
@@ -224,7 +185,7 @@ pub async fn configure(
     responses(
         (status = 200, description = "Delta accepted", body = DeltaObject),
         (status = 400, description = "Invalid delta payload", body = crate::openapi::ApiErrorResponse),
-        (status = 401, description = "Authentication failed", body = crate::openapi::ApiErrorResponse),
+        (status = 401, description = "Authentication failed or replay rejected", body = crate::openapi::ApiErrorResponse),
         (status = 409, description = "Conflicting pending delta/proposal", body = crate::openapi::ApiErrorResponse),
     )
 )]
@@ -257,7 +218,7 @@ pub async fn push_delta(
     params(DeltaQuery),
     responses(
         (status = 200, description = "Delta found", body = DeltaObject),
-        (status = 401, description = "Authentication failed", body = crate::openapi::ApiErrorResponse),
+        (status = 401, description = "Authentication failed or replay rejected", body = crate::openapi::ApiErrorResponse),
         (status = 404, description = "Delta not found", body = crate::openapi::ApiErrorResponse),
     )
 )]
@@ -289,7 +250,7 @@ pub async fn get_delta(
     params(DeltaQuery),
     responses(
         (status = 200, description = "Merged delta", body = DeltaObject),
-        (status = 401, description = "Authentication failed", body = crate::openapi::ApiErrorResponse),
+        (status = 401, description = "Authentication failed or replay rejected", body = crate::openapi::ApiErrorResponse),
         (status = 404, description = "No deltas found", body = crate::openapi::ApiErrorResponse),
     )
 )]
@@ -320,7 +281,7 @@ pub async fn get_delta_since(
     params(StateQuery),
     responses(
         (status = 200, description = "Current account state", body = StateObject),
-        (status = 401, description = "Authentication failed", body = crate::openapi::ApiErrorResponse),
+        (status = 401, description = "Authentication failed or replay rejected", body = crate::openapi::ApiErrorResponse),
         (status = 404, description = "State not found", body = crate::openapi::ApiErrorResponse),
     )
 )]
@@ -353,7 +314,7 @@ pub async fn get_state(
     responses(
         (status = 200, description = "Accounts whose authorization set contains the commitment", body = LookupResponse),
         (status = 400, description = "Malformed key commitment", body = crate::openapi::ApiErrorResponse),
-        (status = 401, description = "Authentication failed", body = crate::openapi::ApiErrorResponse),
+        (status = 401, description = "Authentication failed or replay rejected", body = crate::openapi::ApiErrorResponse),
         (status = 500, description = "Storage error", body = crate::openapi::ApiErrorResponse),
     )
 )]
@@ -473,7 +434,7 @@ pub async fn get_pubkey(
     responses(
         (status = 200, description = "Proposal created", body = DeltaProposalResponse),
         (status = 400, description = "Invalid proposal payload", body = crate::openapi::ApiErrorResponse),
-        (status = 401, description = "Authentication failed", body = crate::openapi::ApiErrorResponse),
+        (status = 401, description = "Authentication failed or replay rejected", body = crate::openapi::ApiErrorResponse),
         (status = 409, description = "Conflicting / too many pending proposals", body = crate::openapi::ApiErrorResponse),
     )
 )]
@@ -524,7 +485,7 @@ pub async fn push_delta_proposal(
     request_body = AbandonCandidateRequest,
     responses(
         (status = 202, description = "Abandon intent accepted (or already resolved)", body = AbandonCandidateResponse),
-        (status = 401, description = "Authentication failed", body = crate::openapi::ApiErrorResponse),
+        (status = 401, description = "Authentication failed or replay rejected", body = crate::openapi::ApiErrorResponse),
         (status = 404, description = "No candidate delta at this nonce", body = crate::openapi::ApiErrorResponse),
         (status = 409, description = "Candidate already landed on-chain, or account paused/released", body = crate::openapi::ApiErrorResponse),
     )
@@ -564,7 +525,7 @@ pub async fn abandon_candidate(
     params(ProposalQuery),
     responses(
         (status = 200, description = "Pending proposals", body = ProposalsResponse),
-        (status = 401, description = "Authentication failed", body = crate::openapi::ApiErrorResponse),
+        (status = 401, description = "Authentication failed or replay rejected", body = crate::openapi::ApiErrorResponse),
     )
 )]
 pub async fn get_delta_proposals(
@@ -595,7 +556,7 @@ pub async fn get_delta_proposals(
     params(ProposalItemQuery),
     responses(
         (status = 200, description = "Proposal found", body = DeltaObject),
-        (status = 401, description = "Authentication failed", body = crate::openapi::ApiErrorResponse),
+        (status = 401, description = "Authentication failed or replay rejected", body = crate::openapi::ApiErrorResponse),
         (status = 404, description = "Proposal not found", body = crate::openapi::ApiErrorResponse),
     )
 )]
@@ -628,7 +589,7 @@ pub async fn get_delta_proposal(
     responses(
         (status = 200, description = "Signature accepted", body = DeltaObject),
         (status = 400, description = "Invalid signature", body = crate::openapi::ApiErrorResponse),
-        (status = 401, description = "Authentication failed", body = crate::openapi::ApiErrorResponse),
+        (status = 401, description = "Authentication failed or replay rejected", body = crate::openapi::ApiErrorResponse),
         (status = 404, description = "Proposal not found", body = crate::openapi::ApiErrorResponse),
         (status = 409, description = "Proposal already signed by this signer", body = crate::openapi::ApiErrorResponse),
     )
@@ -902,10 +863,9 @@ mod tests {
         };
 
         let credentials = signed_credentials(&signer, &account_id, &request);
-        let (status, Json(response)) =
-            configure(State(state), AuthHeader(credentials), Json(request)).await;
-
-        assert_eq!(status, StatusCode::OK);
+        let Json(response) = configure(State(state), AuthHeader(credentials), Json(request))
+            .await
+            .expect("configure succeeds");
         assert!(response.success);
         assert!(response.ack_pubkey.is_some());
         assert!(response.message.contains("configured successfully"));

--- a/crates/server/src/error.rs
+++ b/crates/server/src/error.rs
@@ -329,7 +329,7 @@ impl GuardianError {
                 "There's already a pending change for this account. Finish or cancel it first."
             }
             GuardianError::AuthenticationFailed(_) => {
-                "Guardian could not authenticate this request. Please reconnect your signer."
+                "Guardian could not authenticate this request. Please authenticate again."
             }
             GuardianError::AuthenticationReplay => {
                 "Guardian received this request out of order. Please try again."

--- a/crates/server/src/error.rs
+++ b/crates/server/src/error.rs
@@ -328,11 +328,8 @@ impl GuardianError {
             | GuardianError::PendingProposalsLimit { .. } => {
                 "There's already a pending change for this account. Finish or cancel it first."
             }
-            // Per-request signed auth has no session; the same code also
-            // covers dashboard/EVM session auth, so the wording stays
-            // neutral between "retry" and "reconnect".
             GuardianError::AuthenticationFailed(_) => {
-                "Guardian could not authenticate this request. Please retry or reconnect your signer."
+                "Guardian could not authenticate this request. Please reconnect your signer."
             }
             GuardianError::AuthenticationReplay => {
                 "Guardian received this request out of order. Please try again."
@@ -1399,6 +1396,7 @@ mod tests {
             },
             GuardianError::InvalidCommitment("0xAAAACOMMITMENT".into()),
             GuardianError::AuthenticationFailed("bad creds for 0xSIGNER".into()),
+            GuardianError::AuthenticationReplay,
             GuardianError::AuthorizationFailed("0xSIGNER not in policy".into()),
             GuardianError::InvalidInput("/var/secret/path".into()),
             GuardianError::StorageError("/var/lib/guardian/db: disk full".into()),

--- a/crates/server/src/error.rs
+++ b/crates/server/src/error.rs
@@ -29,6 +29,15 @@ pub enum GuardianError {
     },
     InvalidCommitment(String),
     AuthenticationFailed(String),
+    /// A correctly signed request lost the replay-protection CAS: its
+    /// timestamp was not strictly greater than the last accepted timestamp
+    /// for that signer. Unlike every other authentication failure this is
+    /// transient: the client retries with a fresh timestamp and signature.
+    /// Stable code `authentication_replay`, HTTP 401, gRPC
+    /// `Unauthenticated`, `meta.retryable: true`. Deliberately coarse: it
+    /// reveals only that a replay was detected (not a useful oracle), while
+    /// signature-level diagnostics stay log-only (feature 009). Issue #367.
+    AuthenticationReplay,
     AuthorizationFailed(String),
     InvalidInput(String),
     StorageError(String),
@@ -149,6 +158,7 @@ impl GuardianError {
             GuardianError::PendingProposalsLimit { .. } => StatusCode::CONFLICT,
             GuardianError::ProposalAlreadySigned { .. } => StatusCode::CONFLICT,
             GuardianError::AuthenticationFailed(_) => StatusCode::UNAUTHORIZED,
+            GuardianError::AuthenticationReplay => StatusCode::UNAUTHORIZED,
             GuardianError::AuthorizationFailed(_) => StatusCode::FORBIDDEN,
             GuardianError::InvalidInput(_) => StatusCode::BAD_REQUEST,
             GuardianError::InvalidAccountId(_) => StatusCode::BAD_REQUEST,
@@ -193,6 +203,7 @@ impl GuardianError {
             GuardianError::PendingProposalsLimit { .. } => tonic::Code::FailedPrecondition,
             GuardianError::ProposalAlreadySigned { .. } => tonic::Code::AlreadyExists,
             GuardianError::AuthenticationFailed(_) => tonic::Code::Unauthenticated,
+            GuardianError::AuthenticationReplay => tonic::Code::Unauthenticated,
             GuardianError::AuthorizationFailed(_) => tonic::Code::PermissionDenied,
             GuardianError::InvalidInput(_) => tonic::Code::InvalidArgument,
             GuardianError::InvalidAccountId(_) => tonic::Code::InvalidArgument,
@@ -242,6 +253,7 @@ impl GuardianError {
             GuardianError::CommitmentMismatch { .. } => "commitment_mismatch",
             GuardianError::InvalidCommitment(_) => "invalid_commitment",
             GuardianError::AuthenticationFailed(_) => "authentication_failed",
+            GuardianError::AuthenticationReplay => "authentication_replay",
             GuardianError::AuthorizationFailed(_) => "authorization_failed",
             GuardianError::InvalidInput(_) => "invalid_input",
             GuardianError::StorageError(_) => "storage_error",
@@ -316,8 +328,14 @@ impl GuardianError {
             | GuardianError::PendingProposalsLimit { .. } => {
                 "There's already a pending change for this account. Finish or cancel it first."
             }
+            // Per-request signed auth has no session; the same code also
+            // covers dashboard/EVM session auth, so the wording stays
+            // neutral between "retry" and "reconnect".
             GuardianError::AuthenticationFailed(_) => {
-                "Your session has expired. Please sign in again."
+                "Guardian could not authenticate this request. Please retry or reconnect your signer."
+            }
+            GuardianError::AuthenticationReplay => {
+                "Guardian received this request out of order. Please try again."
             }
             GuardianError::AuthorizationFailed(_) | GuardianError::SignerNotAuthorized(_) => {
                 "You're not an authorized signer for this account."
@@ -375,7 +393,8 @@ impl GuardianError {
         // start serving the same request on retry), so it is NOT retryable.
         matches!(
             self,
-            GuardianError::AccountDataUnavailable(_)
+            GuardianError::AuthenticationReplay
+                | GuardianError::AccountDataUnavailable(_)
                 | GuardianError::StorageError(_)
                 | GuardianError::NetworkError(_)
                 | GuardianError::SigningError(_)
@@ -422,6 +441,11 @@ impl fmt::Display for GuardianError {
             }
             GuardianError::InvalidCommitment(msg) => write!(f, "Invalid commitment: {msg}"),
             GuardianError::AuthenticationFailed(msg) => write!(f, "Authentication failed: {msg}"),
+            GuardianError::AuthenticationReplay => write!(
+                f,
+                "Authentication replay rejected: request timestamp not greater \
+                 than the last accepted timestamp for this signer"
+            ),
             GuardianError::AuthorizationFailed(msg) => write!(f, "Authorization failed: {msg}"),
             GuardianError::InvalidInput(msg) => write!(f, "Invalid input: {msg}"),
             GuardianError::StorageError(msg) => write!(f, "Storage error: {msg}"),
@@ -895,6 +919,28 @@ mod tests {
             GuardianError::AuthorizationFailed("x".into()).grpc_status(),
             tonic::Code::PermissionDenied
         );
+    }
+
+    // -- Issue #367: AuthenticationReplay --
+
+    #[test]
+    fn authentication_replay_pins_http_grpc_code_and_retryable() {
+        let err = GuardianError::AuthenticationReplay;
+        assert_eq!(err.http_status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(err.grpc_status(), tonic::Code::Unauthenticated);
+        assert_eq!(err.code(), "authentication_replay");
+        assert!(err.retryable());
+        assert!(!GuardianError::AuthenticationFailed("x".into()).retryable());
+    }
+
+    #[test]
+    fn authentication_replay_grpc_details_carry_retryable_true() {
+        let status: tonic::Status = GuardianError::AuthenticationReplay.into();
+        assert_eq!(status.code(), tonic::Code::Unauthenticated);
+        let details: serde_json::Value =
+            serde_json::from_slice(status.details()).expect("details are JSON");
+        assert_eq!(details["code"], "authentication_replay");
+        assert_eq!(details["meta"]["retryable"], serde_json::Value::Bool(true));
     }
 
     #[test]

--- a/crates/server/src/metadata/auth/miden_ecdsa.rs
+++ b/crates/server/src/metadata/auth/miden_ecdsa.rs
@@ -10,6 +10,9 @@ use miden_protocol::utils::serde::{Deserializable, Serializable};
 /// fails or yields a commitment outside the authorized set, the server falls
 /// back to the caller-provided public key from `x-pubkey` for compatibility
 /// with wallet providers that use a different recovery encoding.
+///
+/// Returns the verified signer's public-key commitment (hex), which callers
+/// use to scope replay-protection state per signer.
 pub fn verify_request_signature(
     account_id: &str,
     timestamp: i64,
@@ -17,7 +20,7 @@ pub fn verify_request_signature(
     signature: &str,
     pubkey_hex: &str,
     request_payload: &AuthRequestPayload,
-) -> Result<(), String> {
+) -> Result<String, String> {
     let message = account_id_timestamp_to_digest(account_id, timestamp, request_payload)?;
     let sig = parse_signature(signature)?;
 
@@ -36,7 +39,9 @@ pub fn verify_request_signature(
         &sig,
         &public_key,
         &commitment_hex,
-    )
+    )?;
+
+    Ok(commitment_hex)
 }
 
 /// Convert an account ID and timestamp to a message digest (Word)

--- a/crates/server/src/metadata/auth/miden_falcon_rpo.rs
+++ b/crates/server/src/metadata/auth/miden_falcon_rpo.rs
@@ -6,6 +6,9 @@ use miden_protocol::utils::serde::{Deserializable, Serializable};
 
 /// Verify a Falcon RPO signature for a request with timestamp.
 ///
+/// Returns the verified signer's public-key commitment (hex), which callers
+/// use to scope replay-protection state per signer.
+///
 /// # Arguments
 /// * `account_id` - The account ID (hex-encoded)
 /// * `timestamp` - Unix timestamp included in the signed payload
@@ -18,7 +21,7 @@ pub fn verify_request_signature(
     authorized_commitments: &[String],
     signature: &str,
     request_payload: &AuthRequestPayload,
-) -> Result<(), String> {
+) -> Result<String, String> {
     let message = account_id_timestamp_to_digest(account_id, timestamp, request_payload)?;
     let sig = parse_signature(signature)?;
 
@@ -45,7 +48,7 @@ pub fn verify_request_signature(
 
     // Verify the signature cryptographically
     if public_key.verify(message, &sig) {
-        Ok(())
+        Ok(sig_commitment_hex)
     } else {
         tracing::error!(
             account_id = %account_id,

--- a/crates/server/src/metadata/auth/mod.rs
+++ b/crates/server/src/metadata/auth/mod.rs
@@ -3,6 +3,7 @@ use guardian_shared::hex::FromHex;
 use miden_protocol::crypto::dsa::ecdsa_k256_keccak::PublicKey as EcdsaPublicKey;
 use miden_protocol::crypto::dsa::falcon512_poseidon2::PublicKey as FalconPublicKey;
 use miden_protocol::utils::serde::{Deserializable, Serializable};
+use std::collections::HashSet;
 
 use crate::api::grpc::guardian::auth_config;
 use crate::error::GuardianError;
@@ -89,6 +90,52 @@ impl Auth {
             } => cosigner_commitments,
             Auth::EvmEcdsa { signers } => signers,
         }
+    }
+
+    fn signer_commitment_hex_length(&self) -> usize {
+        match self {
+            Auth::EvmEcdsa { .. } => 40,
+            Auth::MidenFalconRpo { .. } | Auth::MidenEcdsa { .. } => 64,
+        }
+    }
+
+    /// Returns whether a signer commitment uses the scheme's canonical
+    /// lowercase, `0x`-prefixed representation.
+    pub fn is_canonical_signer_commitment(&self, commitment: &str) -> bool {
+        let expected_hex_length = self.signer_commitment_hex_length();
+        let hex = commitment.strip_prefix("0x").unwrap_or("");
+        hex.len() == expected_hex_length
+            && hex
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    }
+
+    /// Validates the exact-string signer set used by authorization and account
+    /// state comparison. Non-canonical spellings cannot match reliably, an
+    /// empty set cannot authorize a request, and duplicates make the declared
+    /// signer set ambiguous.
+    pub fn validate_canonical_signer_set(&self) -> Result<(), String> {
+        let commitments = self.cosigner_commitments();
+        if commitments.is_empty() {
+            return Err("authorized signer set must not be empty".to_string());
+        }
+
+        let mut seen = HashSet::with_capacity(commitments.len());
+        for commitment in commitments {
+            if !self.is_canonical_signer_commitment(commitment) {
+                let expected_hex_length = self.signer_commitment_hex_length();
+                return Err(format!(
+                    "authorized signer entry '{commitment}' is not canonical \
+                     (expected 0x followed by {expected_hex_length} lowercase hex digits)"
+                ));
+            }
+            if !seen.insert(commitment) {
+                return Err(format!(
+                    "authorized signer set contains duplicate entry '{commitment}'"
+                ));
+            }
+        }
+        Ok(())
     }
 
     pub fn with_updated_commitments(&self, cosigner_commitments: Vec<String>) -> Self {

--- a/crates/server/src/metadata/auth/mod.rs
+++ b/crates/server/src/metadata/auth/mod.rs
@@ -112,10 +112,13 @@ impl Auth {
     ///    optionally bound to request bytes when provided by the transport layer
     /// 2. The signer's commitment is in the authorized list
     ///
+    /// Returns the verified signer's public-key commitment (hex), which
+    /// scopes replay-protection state per (account, signer).
+    ///
     /// # Arguments
     /// * `account_id` - The account ID
     /// * `credentials` - The credentials to verify (includes timestamp)
-    pub fn verify(&self, account_id: &str, credentials: &Credentials) -> Result<(), String> {
+    pub fn verify(&self, account_id: &str, credentials: &Credentials) -> Result<String, String> {
         match self {
             Auth::MidenFalconRpo {
                 cosigner_commitments,

--- a/crates/server/src/metadata/filesystem.rs
+++ b/crates/server/src/metadata/filesystem.rs
@@ -4,8 +4,8 @@ use crate::metadata::{
 use crate::services::account_status::{AccountStatus, PauseTransition};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use std::collections::hash_map::Entry;
 use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/crates/server/src/metadata/filesystem.rs
+++ b/crates/server/src/metadata/filesystem.rs
@@ -131,13 +131,18 @@ impl FilesystemMetadataStore {
 }
 
 /// Separator for the composite `{account_id}:{signer_commitment}` replay-state
-/// key. `:` cannot appear in hex account IDs or signer commitments, so the two
-/// segments cannot collide, and a key without it is recognizably account-scoped
-/// (pre-#367).
+/// key. Account IDs may themselves contain `:`, so startup classifies a key as
+/// signer-scoped only when the prefix before its final separator is a known
+/// account and the suffix is non-empty.
 const AUTH_STATE_KEY_SEPARATOR: char = ':';
 
 fn auth_state_key(account_id: &str, signer_commitment: &str) -> String {
     format!("{account_id}{AUTH_STATE_KEY_SEPARATOR}{signer_commitment}")
+}
+
+fn is_signer_scoped_auth_state_key(accounts: &HashMap<String, AccountMetadata>, key: &str) -> bool {
+    key.rsplit_once(AUTH_STATE_KEY_SEPARATOR)
+        .is_some_and(|(account_id, signer)| !signer.is_empty() && accounts.contains_key(account_id))
 }
 
 /// Replay state was account-scoped before issue #367. An account-scoped entry
@@ -153,7 +158,7 @@ fn expand_account_scoped_auth_state(
     let mut expanded = HashMap::with_capacity(state.len());
     let mut changed = false;
     for (key, timestamp) in state {
-        if key.contains(AUTH_STATE_KEY_SEPARATOR) {
+        if is_signer_scoped_auth_state_key(accounts, &key) {
             merge_auth_timestamp(&mut expanded, key, timestamp);
             continue;
         }
@@ -658,6 +663,7 @@ mod auth_state_tests {
 
     const SIGNER_A: &str = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     const SIGNER_B: &str = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    const EVM_SIGNER: &str = "0xcccccccccccccccccccccccccccccccccccccccc";
 
     fn sample_metadata(account_id: &str) -> AccountMetadata {
         AccountMetadata {
@@ -800,6 +806,58 @@ mod auth_state_tests {
                 .await
                 .unwrap(),
             "the pre-upgrade floor must still reject replays for every signer"
+        );
+    }
+
+    #[tokio::test]
+    async fn evm_account_scoped_auth_state_with_colons_expands_on_startup() {
+        let dir = tempfile::tempdir().unwrap();
+        let account_address = "0x1111111111111111111111111111111111111111";
+        let account_id = crate::metadata::network::evm_account_id(1, account_address);
+        {
+            let store = FilesystemMetadataStore::new(dir.path().to_path_buf())
+                .await
+                .unwrap();
+            store
+                .set(AccountMetadata {
+                    account_id: account_id.clone(),
+                    auth: Auth::EvmEcdsa {
+                        signers: vec![EVM_SIGNER.into()],
+                    },
+                    network_config: NetworkConfig::Evm {
+                        chain_id: 1,
+                        account_address: account_address.into(),
+                        multisig_validator_address: "0x2222222222222222222222222222222222222222"
+                            .into(),
+                    },
+                    created_at: "2026-05-19T10:00:00Z".into(),
+                    updated_at: "2026-05-19T10:00:00Z".into(),
+                    has_pending_candidate: false,
+                    paused_at: None,
+                    paused_reason: None,
+                    released_at: None,
+                })
+                .await
+                .unwrap();
+        }
+        std::fs::write(
+            auth_state_path(&dir),
+            serde_json::to_string(&HashMap::from([(account_id.clone(), 4242_i64)])).unwrap(),
+        )
+        .unwrap();
+
+        let store = FilesystemMetadataStore::new(dir.path().to_path_buf())
+            .await
+            .unwrap();
+
+        let signer_key = auth_state_key(&account_id, EVM_SIGNER);
+        assert_eq!(persisted_auth_state(&dir).get(&signer_key), Some(&4242));
+        assert!(
+            !store
+                .update_last_auth_timestamp_cas(&account_id, EVM_SIGNER, 4242)
+                .await
+                .unwrap(),
+            "the legacy EVM replay floor must remain enforced"
         );
     }
 

--- a/crates/server/src/metadata/filesystem.rs
+++ b/crates/server/src/metadata/filesystem.rs
@@ -94,6 +94,13 @@ impl FilesystemMetadataStore {
             ));
         };
 
+        let (auth_state, expanded) = expand_account_scoped_auth_state(&accounts, auth_state)?;
+        if expanded {
+            let content = serde_json::to_string_pretty(&auth_state)
+                .map_err(|e| format!("Failed to serialize auth state: {e}"))?;
+            write_atomic(&auth_state_path, &content).await?;
+        }
+
         let store = Self {
             file_path,
             auth_state_path,
@@ -121,6 +128,73 @@ impl FilesystemMetadataStore {
             .map_err(|e| format!("Failed to serialize auth state: {e}"))?;
         write_atomic(&self.auth_state_path, &content).await
     }
+}
+
+/// Separator for the composite `{account_id}:{signer_commitment}` replay-state
+/// key. `:` cannot appear in hex account IDs or signer commitments, so the two
+/// segments cannot collide, and a key without it is recognizably account-scoped
+/// (pre-#367).
+const AUTH_STATE_KEY_SEPARATOR: char = ':';
+
+fn auth_state_key(account_id: &str, signer_commitment: &str) -> String {
+    format!("{account_id}{AUTH_STATE_KEY_SEPARATOR}{signer_commitment}")
+}
+
+/// Replay state was account-scoped before issue #367. An account-scoped entry
+/// (key without the separator) is expanded to one per-signer entry for every
+/// currently authorized commitment (preserving the replay floor across the
+/// upgrade instead of re-accepting requests seen just before it), and the
+/// account-scoped entry is dropped. Entries for accounts that no longer exist
+/// are dropped with it.
+fn expand_account_scoped_auth_state(
+    accounts: &HashMap<String, AccountMetadata>,
+    state: HashMap<String, i64>,
+) -> Result<(HashMap<String, i64>, bool), String> {
+    let mut expanded = HashMap::with_capacity(state.len());
+    let mut changed = false;
+    for (key, timestamp) in state {
+        if key.contains(AUTH_STATE_KEY_SEPARATOR) {
+            merge_auth_timestamp(&mut expanded, key, timestamp);
+            continue;
+        }
+        changed = true;
+        let Some(metadata) = accounts.get(&key) else {
+            continue;
+        };
+        validate_auth_state_signers(&key, &metadata.auth)?;
+        for commitment in metadata.auth.cosigner_commitments() {
+            merge_auth_timestamp(&mut expanded, auth_state_key(&key, commitment), timestamp);
+        }
+    }
+    Ok((expanded, changed))
+}
+
+fn merge_auth_timestamp(state: &mut HashMap<String, i64>, key: String, timestamp: i64) {
+    let stored = state.entry(key).or_insert(timestamp);
+    *stored = (*stored).max(timestamp);
+}
+
+fn validate_auth_state_signers(account_id: &str, auth: &Auth) -> Result<(), String> {
+    let commitments = auth.cosigner_commitments();
+    let hex_length = match auth {
+        Auth::EvmEcdsa { .. } => 40,
+        Auth::MidenFalconRpo { .. } | Auth::MidenEcdsa { .. } => 64,
+    };
+    let invalid = commitments.is_empty()
+        || commitments.iter().any(|commitment| {
+            let hex = commitment.strip_prefix("0x").unwrap_or("");
+            hex.len() != hex_length
+                || !hex
+                    .bytes()
+                    .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        });
+    if invalid {
+        return Err(format!(
+            "Replay state for account {account_id} cannot be expanded because its auth metadata \
+             has no canonical authorized signer set"
+        ));
+    }
+    Ok(())
 }
 
 /// Replay timestamps recorded by pre-split servers inside the metadata file.
@@ -280,6 +354,7 @@ impl MetadataStore for FilesystemMetadataStore {
     async fn update_last_auth_timestamp_cas(
         &self,
         account_id: &str,
+        signer_commitment: &str,
         new_timestamp: i64,
     ) -> Result<bool, String> {
         // Advisory only: the cache lock is released before the auth-state
@@ -294,11 +369,12 @@ impl MetadataStore for FilesystemMetadataStore {
             }
         }
 
+        let key = auth_state_key(account_id, signer_commitment);
         let mut auth_state = self.auth_state.write().await;
 
         // One probe covers the replay check, the swap, and the prior value the
         // rollback below needs; only a first-ever record allocates a key.
-        let previous = match auth_state.get_mut(account_id) {
+        let previous = match auth_state.get_mut(&key) {
             Some(current) => {
                 if new_timestamp <= *current {
                     return Ok(false);
@@ -306,15 +382,15 @@ impl MetadataStore for FilesystemMetadataStore {
                 Some(std::mem::replace(current, new_timestamp))
             }
             None => {
-                auth_state.insert(account_id.to_string(), new_timestamp);
+                auth_state.insert(key.clone(), new_timestamp);
                 None
             }
         };
 
         if let Err(persist_error) = self.persist_auth_state(&auth_state).await {
             match previous {
-                Some(prior) => auth_state.insert(account_id.to_string(), prior),
-                None => auth_state.remove(account_id),
+                Some(prior) => auth_state.insert(key, prior),
+                None => auth_state.remove(&key),
             };
             return Err(persist_error);
         }
@@ -580,11 +656,14 @@ mod auth_state_tests {
     use super::*;
     use crate::metadata::{Auth, NetworkConfig};
 
+    const SIGNER_A: &str = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const SIGNER_B: &str = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
     fn sample_metadata(account_id: &str) -> AccountMetadata {
         AccountMetadata {
             account_id: account_id.into(),
             auth: Auth::MidenFalconRpo {
-                cosigner_commitments: vec![],
+                cosigner_commitments: vec![SIGNER_A.into(), SIGNER_B.into()],
             },
             network_config: NetworkConfig::Miden {
                 network_type: crate::metadata::network::MidenNetworkType::Testnet,
@@ -626,35 +705,155 @@ mod auth_state_tests {
 
         assert!(
             store
-                .update_last_auth_timestamp_cas("acct", 100)
+                .update_last_auth_timestamp_cas("acct", "0xaa", 100)
                 .await
                 .unwrap()
         );
         assert!(
             !store
-                .update_last_auth_timestamp_cas("acct", 100)
+                .update_last_auth_timestamp_cas("acct", "0xaa", 100)
                 .await
                 .unwrap()
         );
         assert!(
             !store
-                .update_last_auth_timestamp_cas("acct", 99)
+                .update_last_auth_timestamp_cas("acct", "0xaa", 99)
                 .await
                 .unwrap()
         );
         assert_eq!(
-            persisted_auth_state(&dir).get("acct"),
+            persisted_auth_state(&dir).get("acct:0xaa"),
             Some(&100),
             "rejected timestamps must not change the stored value"
         );
 
         assert!(
             store
-                .update_last_auth_timestamp_cas("acct", 101)
+                .update_last_auth_timestamp_cas("acct", "0xaa", 101)
                 .await
                 .unwrap()
         );
-        assert_eq!(persisted_auth_state(&dir).get("acct"), Some(&101));
+        assert_eq!(persisted_auth_state(&dir).get("acct:0xaa"), Some(&101));
+    }
+
+    #[tokio::test]
+    async fn cas_is_scoped_per_signer_commitment() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_with_account(&dir).await;
+
+        assert!(
+            store
+                .update_last_auth_timestamp_cas("acct", "0xaa", 100)
+                .await
+                .unwrap()
+        );
+        assert!(
+            store
+                .update_last_auth_timestamp_cas("acct", "0xbb", 50)
+                .await
+                .unwrap(),
+            "another signer's newer timestamp must not lock this signer out"
+        );
+        assert!(
+            !store
+                .update_last_auth_timestamp_cas("acct", "0xbb", 50)
+                .await
+                .unwrap(),
+            "a replay from the same signer must still be rejected"
+        );
+        assert_eq!(persisted_auth_state(&dir).get("acct:0xaa"), Some(&100));
+        assert_eq!(persisted_auth_state(&dir).get("acct:0xbb"), Some(&50));
+    }
+
+    #[tokio::test]
+    async fn account_scoped_auth_state_expands_to_per_signer_on_startup() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let _store = store_with_account(&dir).await;
+        }
+        std::fs::write(
+            auth_state_path(&dir),
+            serde_json::to_string(&HashMap::from([("acct".to_string(), 4242_i64)])).unwrap(),
+        )
+        .unwrap();
+
+        let store = FilesystemMetadataStore::new(dir.path().to_path_buf())
+            .await
+            .unwrap();
+
+        let persisted = persisted_auth_state(&dir);
+        assert_eq!(
+            persisted.get(&auth_state_key("acct", SIGNER_A)),
+            Some(&4242)
+        );
+        assert_eq!(
+            persisted.get(&auth_state_key("acct", SIGNER_B)),
+            Some(&4242)
+        );
+        assert!(
+            !persisted.contains_key("acct"),
+            "the account-scoped entry must be dropped after expansion"
+        );
+        assert!(
+            !store
+                .update_last_auth_timestamp_cas("acct", SIGNER_B, 4242)
+                .await
+                .unwrap(),
+            "the pre-upgrade floor must still reject replays for every signer"
+        );
+    }
+
+    #[tokio::test]
+    async fn account_scoped_auth_state_with_unusable_signers_fails_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let _store = store_with_account(&dir).await;
+        }
+        let mut accounts: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(accounts_path(&dir)).unwrap()).unwrap();
+        accounts["acct"]["auth"]["MidenFalconRpo"]["cosigner_commitments"] = serde_json::json!([]);
+        std::fs::write(
+            accounts_path(&dir),
+            serde_json::to_string(&accounts).unwrap(),
+        )
+        .unwrap();
+        std::fs::write(
+            auth_state_path(&dir),
+            serde_json::to_string(&HashMap::from([("acct".to_string(), 4242_i64)])).unwrap(),
+        )
+        .unwrap();
+
+        let error = FilesystemMetadataStore::new(dir.path().to_path_buf())
+            .await
+            .err()
+            .expect("an account-scoped floor without usable signers must reject startup");
+
+        assert!(error.contains("no canonical authorized signer set"));
+        assert_eq!(persisted_auth_state(&dir).get("acct"), Some(&4242));
+    }
+
+    #[tokio::test]
+    async fn mixed_auth_state_keys_keep_the_highest_timestamp() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let _store = store_with_account(&dir).await;
+        }
+        let signer_key = auth_state_key("acct", SIGNER_A);
+        std::fs::write(
+            auth_state_path(&dir),
+            serde_json::to_string(&HashMap::from([
+                ("acct".to_string(), 5000_i64),
+                (signer_key.clone(), 100_i64),
+            ]))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let _store = FilesystemMetadataStore::new(dir.path().to_path_buf())
+            .await
+            .unwrap();
+
+        assert_eq!(persisted_auth_state(&dir).get(&signer_key), Some(&5000));
     }
 
     #[tokio::test]
@@ -663,7 +862,7 @@ mod auth_state_tests {
         let store = store_with_account(&dir).await;
 
         let err = store
-            .update_last_auth_timestamp_cas("ghost", 100)
+            .update_last_auth_timestamp_cas("ghost", "0xaa", 100)
             .await
             .expect_err("unknown account must error");
         assert!(err.contains("Account not found"));
@@ -677,7 +876,7 @@ mod auth_state_tests {
 
         assert!(
             store
-                .update_last_auth_timestamp_cas("acct", 100)
+                .update_last_auth_timestamp_cas("acct", "0xaa", 100)
                 .await
                 .unwrap()
         );
@@ -699,7 +898,7 @@ mod auth_state_tests {
 
         assert!(
             store
-                .update_last_auth_timestamp_cas("acct", 100)
+                .update_last_auth_timestamp_cas("acct", "0xaa", 100)
                 .await
                 .unwrap()
         );
@@ -728,7 +927,11 @@ mod auth_state_tests {
 
         let attempts = (0..16).map(|_| {
             let store = store.clone();
-            tokio::spawn(async move { store.update_last_auth_timestamp_cas("acct", 500).await })
+            tokio::spawn(async move {
+                store
+                    .update_last_auth_timestamp_cas("acct", "0xaa", 500)
+                    .await
+            })
         });
         let mut accepted = 0;
         for attempt in attempts {
@@ -766,17 +969,25 @@ mod auth_state_tests {
             .await
             .unwrap();
 
-        assert_eq!(persisted_auth_state(&dir).get("acct"), Some(&4242));
+        assert_eq!(
+            persisted_auth_state(&dir).get(&auth_state_key("acct", SIGNER_A)),
+            Some(&4242)
+        );
+        assert_eq!(
+            persisted_auth_state(&dir).get(&auth_state_key("acct", SIGNER_B)),
+            Some(&4242),
+            "the legacy account-scoped floor must cover every authorized signer"
+        );
         assert!(
             !store
-                .update_last_auth_timestamp_cas("acct", 4242)
+                .update_last_auth_timestamp_cas("acct", SIGNER_A, 4242)
                 .await
                 .unwrap(),
             "seeded timestamp must be enforced"
         );
         assert!(
             store
-                .update_last_auth_timestamp_cas("acct", 4243)
+                .update_last_auth_timestamp_cas("acct", SIGNER_A, 4243)
                 .await
                 .unwrap()
         );
@@ -862,13 +1073,13 @@ mod auth_state_tests {
             .unwrap();
 
         assert_eq!(
-            persisted_auth_state(&dir).get("acct"),
+            persisted_auth_state(&dir).get(&auth_state_key("acct", SIGNER_A)),
             Some(&5000),
             "the newer of legacy and auth-state values must win the merge"
         );
         assert!(
             !store
-                .update_last_auth_timestamp_cas("acct", 5000)
+                .update_last_auth_timestamp_cas("acct", SIGNER_A, 5000)
                 .await
                 .unwrap()
         );
@@ -900,10 +1111,13 @@ mod auth_state_tests {
             .await
             .unwrap();
 
-        assert_eq!(persisted_auth_state(&dir).get("acct"), Some(&5000));
+        assert_eq!(
+            persisted_auth_state(&dir).get(&auth_state_key("acct", SIGNER_A)),
+            Some(&5000)
+        );
         assert!(
             !store
-                .update_last_auth_timestamp_cas("acct", 4999)
+                .update_last_auth_timestamp_cas("acct", SIGNER_A, 4999)
                 .await
                 .unwrap()
         );
@@ -915,7 +1129,7 @@ mod auth_state_tests {
         let store = store_with_account(&dir).await;
         assert!(
             store
-                .update_last_auth_timestamp_cas("acct", 50)
+                .update_last_auth_timestamp_cas("acct", "0xaa", 50)
                 .await
                 .unwrap()
         );
@@ -923,22 +1137,22 @@ mod auth_state_tests {
         std::fs::remove_file(auth_state_path(&dir)).unwrap();
         std::fs::create_dir(auth_state_path(&dir)).unwrap();
         store
-            .update_last_auth_timestamp_cas("acct", 100)
+            .update_last_auth_timestamp_cas("acct", "0xaa", 100)
             .await
             .expect_err("persisting over a directory must fail");
 
         std::fs::remove_dir(auth_state_path(&dir)).unwrap();
         assert!(
             store
-                .update_last_auth_timestamp_cas("acct", 100)
+                .update_last_auth_timestamp_cas("acct", "0xaa", 100)
                 .await
                 .unwrap(),
             "a timestamp that was never durably recorded must not be treated as a replay"
         );
-        assert_eq!(persisted_auth_state(&dir).get("acct"), Some(&100));
+        assert_eq!(persisted_auth_state(&dir).get("acct:0xaa"), Some(&100));
         assert!(
             !store
-                .update_last_auth_timestamp_cas("acct", 50)
+                .update_last_auth_timestamp_cas("acct", "0xaa", 50)
                 .await
                 .unwrap(),
             "rollback must restore the prior value, not clear it"
@@ -960,7 +1174,7 @@ mod auth_state_tests {
             .expect("an explicitly recreated auth-state file is an operator decision");
         assert!(
             store
-                .update_last_auth_timestamp_cas("acct", 1)
+                .update_last_auth_timestamp_cas("acct", "0xaa", 1)
                 .await
                 .unwrap()
         );

--- a/crates/server/src/metadata/filesystem.rs
+++ b/crates/server/src/metadata/filesystem.rs
@@ -4,6 +4,7 @@ use crate::metadata::{
 use crate::services::account_status::{AccountStatus, PauseTransition};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -220,8 +221,8 @@ fn expand_account_scoped_auth_state(
     if repair_missing_legacy_floors {
         for (account_id, timestamp) in signer_floors {
             let legacy_key = auth_state_key(&account_id, LEGACY_ACCOUNT_AUTH_FLOOR);
-            if !expanded.contains_key(&legacy_key) {
-                expanded.insert(legacy_key, timestamp);
+            if let Entry::Vacant(entry) = expanded.entry(legacy_key) {
+                entry.insert(timestamp);
                 changed = true;
             }
         }

--- a/crates/server/src/metadata/filesystem.rs
+++ b/crates/server/src/metadata/filesystem.rs
@@ -1,4 +1,6 @@
-use crate::metadata::{AccountListCursor, AccountMetadata, Auth, MetadataStore};
+use crate::metadata::{
+    AccountListCursor, AccountMetadata, Auth, LEGACY_ACCOUNT_AUTH_FLOOR, MetadataStore,
+};
 use crate::services::account_status::{AccountStatus, PauseTransition};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -35,6 +37,8 @@ impl FilesystemMetadataStore {
 
         let file_path = metadata_dir.join("accounts.json");
         let auth_state_path = metadata_dir.join("auth_state.json");
+        let auth_floor_migration_path = metadata_dir.join("auth_state_legacy_floor_v1");
+        let repair_missing_legacy_floors = !auth_floor_migration_path.exists();
 
         let (accounts, legacy) = if file_path.exists() {
             let content = fs::read_to_string(&file_path)
@@ -51,26 +55,25 @@ impl FilesystemMetadataStore {
         };
         let keys_present = legacy.keys_present;
 
-        let auth_state = if auth_state_path.exists() {
+        let (auth_state, auth_state_needs_write) = if auth_state_path.exists() {
             let content = fs::read_to_string(&auth_state_path)
                 .await
                 .map_err(|e| format!("Failed to read auth state file: {e}"))?;
             let mut state: HashMap<String, i64> = serde_json::from_str(&content)
                 .map_err(|e| format!("Failed to parse auth state file: {e}"))?;
+            let mut needs_write = false;
             if keys_present {
                 for (account_id, legacy_ts) in legacy.values {
                     match state.get(&account_id) {
                         Some(current) if *current >= legacy_ts => {}
                         _ => {
                             state.insert(account_id, legacy_ts);
+                            needs_write = true;
                         }
                     }
                 }
-                let content = serde_json::to_string_pretty(&state)
-                    .map_err(|e| format!("Failed to serialize auth state: {e}"))?;
-                write_atomic(&auth_state_path, &content).await?;
             }
-            state
+            (state, needs_write)
         } else if accounts.is_empty() || keys_present {
             if !accounts.is_empty() {
                 tracing::warn!(
@@ -79,10 +82,7 @@ impl FilesystemMetadataStore {
                     "auth state file missing; initializing replay state from legacy metadata values"
                 );
             }
-            let content = serde_json::to_string_pretty(&legacy.values)
-                .map_err(|e| format!("Failed to serialize auth state: {e}"))?;
-            write_atomic(&auth_state_path, &content).await?;
-            legacy.values
+            (legacy.values, true)
         } else {
             return Err(format!(
                 "Replay-protection state file {} is missing but the metadata store \
@@ -94,8 +94,9 @@ impl FilesystemMetadataStore {
             ));
         };
 
-        let (auth_state, expanded) = expand_account_scoped_auth_state(&accounts, auth_state)?;
-        if expanded {
+        let (auth_state, expanded) =
+            expand_account_scoped_auth_state(&accounts, auth_state, repair_missing_legacy_floors)?;
+        if auth_state_needs_write || expanded {
             let content = serde_json::to_string_pretty(&auth_state)
                 .map_err(|e| format!("Failed to serialize auth state: {e}"))?;
             write_atomic(&auth_state_path, &content).await?;
@@ -111,6 +112,9 @@ impl FilesystemMetadataStore {
         if keys_present {
             let cache = store.cache.read().await;
             store.persist(&cache).await?;
+        }
+        if repair_missing_legacy_floors {
+            write_atomic(&auth_floor_migration_path, "1\n").await?;
         }
 
         Ok(store)
@@ -140,35 +144,86 @@ fn auth_state_key(account_id: &str, signer_commitment: &str) -> String {
     format!("{account_id}{AUTH_STATE_KEY_SEPARATOR}{signer_commitment}")
 }
 
-fn is_signer_scoped_auth_state_key(accounts: &HashMap<String, AccountMetadata>, key: &str) -> bool {
-    key.rsplit_once(AUTH_STATE_KEY_SEPARATOR)
-        .is_some_and(|(account_id, signer)| !signer.is_empty() && accounts.contains_key(account_id))
+fn signer_scoped_auth_state_key<'a>(
+    accounts: &HashMap<String, AccountMetadata>,
+    key: &'a str,
+) -> Option<(&'a str, &'a str)> {
+    if accounts.contains_key(key) {
+        return None;
+    }
+    let (account_id, signer) = key.rsplit_once(AUTH_STATE_KEY_SEPARATOR)?;
+    let canonical_signer_shape = signer.strip_prefix("0x").is_some_and(|hex| {
+        matches!(hex.len(), 40 | 64) && hex.bytes().all(|byte| byte.is_ascii_hexdigit())
+    });
+    (accounts.contains_key(account_id)
+        || signer == LEGACY_ACCOUNT_AUTH_FLOOR
+        || canonical_signer_shape)
+        .then_some((account_id, signer))
 }
 
 /// Replay state was account-scoped before issue #367. An account-scoped entry
 /// (key without the separator) is expanded to one per-signer entry for every
 /// currently authorized commitment (preserving the replay floor across the
 /// upgrade instead of re-accepting requests seen just before it), and the
-/// account-scoped entry is dropped. Entries for accounts that no longer exist
-/// are dropped with it.
+/// account-scoped entry is dropped. A legacy account-level floor is retained so
+/// a signer absent during migration cannot regain a replay window when added
+/// later. Entries whose accounts are missing abort startup: they indicate an
+/// incomplete restore, and dropping them would silently reset replay state.
 fn expand_account_scoped_auth_state(
     accounts: &HashMap<String, AccountMetadata>,
     state: HashMap<String, i64>,
+    repair_missing_legacy_floors: bool,
 ) -> Result<(HashMap<String, i64>, bool), String> {
     let mut expanded = HashMap::with_capacity(state.len());
     let mut changed = false;
+    let mut signer_floors = HashMap::<String, i64>::new();
     for (key, timestamp) in state {
-        if is_signer_scoped_auth_state_key(accounts, &key) {
+        if let Some((account_id, signer)) = signer_scoped_auth_state_key(accounts, &key) {
+            if !accounts.contains_key(account_id) {
+                return Err(format!(
+                    "Replay state entry '{key}' belongs to account '{account_id}', which has no \
+                     matching account metadata. Do not delete the replay entry; restore \
+                     accounts.json and auth_state.json from the same backup"
+                ));
+            }
+            if signer != LEGACY_ACCOUNT_AUTH_FLOOR {
+                let floor = signer_floors
+                    .entry(account_id.to_string())
+                    .or_insert(timestamp);
+                *floor = (*floor).max(timestamp);
+            }
             merge_auth_timestamp(&mut expanded, key, timestamp);
             continue;
         }
         changed = true;
         let Some(metadata) = accounts.get(&key) else {
-            continue;
+            return Err(format!(
+                "Replay state entry '{key}' has no matching account metadata; it may be an \
+                 account-scoped or signer-scoped key from an incomplete restore; restore \
+                 accounts.json and auth_state.json from the same backup"
+            ));
         };
-        validate_auth_state_signers(&key, &metadata.auth)?;
-        for commitment in metadata.auth.cosigner_commitments() {
+        merge_auth_timestamp(
+            &mut expanded,
+            auth_state_key(&key, LEGACY_ACCOUNT_AUTH_FLOOR),
+            timestamp,
+        );
+        for commitment in metadata
+            .auth
+            .cosigner_commitments()
+            .iter()
+            .filter(|commitment| metadata.auth.is_canonical_signer_commitment(commitment))
+        {
             merge_auth_timestamp(&mut expanded, auth_state_key(&key, commitment), timestamp);
+        }
+    }
+    if repair_missing_legacy_floors {
+        for (account_id, timestamp) in signer_floors {
+            let legacy_key = auth_state_key(&account_id, LEGACY_ACCOUNT_AUTH_FLOOR);
+            if !expanded.contains_key(&legacy_key) {
+                expanded.insert(legacy_key, timestamp);
+                changed = true;
+            }
         }
     }
     Ok((expanded, changed))
@@ -177,29 +232,6 @@ fn expand_account_scoped_auth_state(
 fn merge_auth_timestamp(state: &mut HashMap<String, i64>, key: String, timestamp: i64) {
     let stored = state.entry(key).or_insert(timestamp);
     *stored = (*stored).max(timestamp);
-}
-
-fn validate_auth_state_signers(account_id: &str, auth: &Auth) -> Result<(), String> {
-    let commitments = auth.cosigner_commitments();
-    let hex_length = match auth {
-        Auth::EvmEcdsa { .. } => 40,
-        Auth::MidenFalconRpo { .. } | Auth::MidenEcdsa { .. } => 64,
-    };
-    let invalid = commitments.is_empty()
-        || commitments.iter().any(|commitment| {
-            let hex = commitment.strip_prefix("0x").unwrap_or("");
-            hex.len() != hex_length
-                || !hex
-                    .bytes()
-                    .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
-        });
-    if invalid {
-        return Err(format!(
-            "Replay state for account {account_id} cannot be expanded because its auth metadata \
-             has no canonical authorized signer set"
-        ));
-    }
-    Ok(())
 }
 
 /// Replay timestamps recorded by pre-split servers inside the metadata file.
@@ -375,17 +407,24 @@ impl MetadataStore for FilesystemMetadataStore {
         }
 
         let key = auth_state_key(account_id, signer_commitment);
+        let legacy_key = auth_state_key(account_id, LEGACY_ACCOUNT_AUTH_FLOOR);
         let mut auth_state = self.auth_state.write().await;
+
+        let signer_floor = auth_state.get(&key).copied();
+        let legacy_floor = auth_state.get(&legacy_key).copied();
+        if signer_floor
+            .into_iter()
+            .chain(legacy_floor)
+            .max()
+            .is_some_and(|floor| new_timestamp <= floor)
+        {
+            return Ok(false);
+        }
 
         // One probe covers the replay check, the swap, and the prior value the
         // rollback below needs; only a first-ever record allocates a key.
         let previous = match auth_state.get_mut(&key) {
-            Some(current) => {
-                if new_timestamp <= *current {
-                    return Ok(false);
-                }
-                Some(std::mem::replace(current, new_timestamp))
-            }
+            Some(current) => Some(std::mem::replace(current, new_timestamp)),
             None => {
                 auth_state.insert(key.clone(), new_timestamp);
                 None
@@ -699,6 +738,12 @@ mod auth_state_tests {
         dir.path().join(".metadata").join("accounts.json")
     }
 
+    fn auth_floor_migration_path(dir: &tempfile::TempDir) -> PathBuf {
+        dir.path()
+            .join(".metadata")
+            .join("auth_state_legacy_floor_v1")
+    }
+
     fn persisted_auth_state(dir: &tempfile::TempDir) -> HashMap<String, i64> {
         let content = std::fs::read_to_string(auth_state_path(dir)).unwrap();
         serde_json::from_str(&content).unwrap()
@@ -782,6 +827,7 @@ mod auth_state_tests {
             serde_json::to_string(&HashMap::from([("acct".to_string(), 4242_i64)])).unwrap(),
         )
         .unwrap();
+        std::fs::remove_file(auth_floor_migration_path(&dir)).unwrap();
 
         let store = FilesystemMetadataStore::new(dir.path().to_path_buf())
             .await
@@ -796,6 +842,10 @@ mod auth_state_tests {
             persisted.get(&auth_state_key("acct", SIGNER_B)),
             Some(&4242)
         );
+        assert_eq!(
+            persisted.get(&auth_state_key("acct", LEGACY_ACCOUNT_AUTH_FLOOR)),
+            Some(&4242)
+        );
         assert!(
             !persisted.contains_key("acct"),
             "the account-scoped entry must be dropped after expansion"
@@ -806,6 +856,71 @@ mod auth_state_tests {
                 .await
                 .unwrap(),
             "the pre-upgrade floor must still reject replays for every signer"
+        );
+    }
+
+    #[tokio::test]
+    async fn post_migration_accounts_remain_per_signer_after_restart() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let store = store_with_account(&dir).await;
+            assert!(
+                store
+                    .update_last_auth_timestamp_cas("acct", SIGNER_A, 100)
+                    .await
+                    .unwrap()
+            );
+        }
+
+        let store = FilesystemMetadataStore::new(dir.path().to_path_buf())
+            .await
+            .unwrap();
+
+        assert!(
+            store
+                .update_last_auth_timestamp_cas("acct", SIGNER_B, 50)
+                .await
+                .unwrap(),
+            "the one-time compatibility repair must not create a global floor for new accounts"
+        );
+        assert!(
+            !persisted_auth_state(&dir)
+                .contains_key(&auth_state_key("acct", LEGACY_ACCOUNT_AUTH_FLOOR))
+        );
+    }
+
+    #[tokio::test]
+    async fn already_expanded_auth_state_backfills_the_reserved_floor() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let _store = store_with_account(&dir).await;
+        }
+        std::fs::write(
+            auth_state_path(&dir),
+            serde_json::to_string(&HashMap::from([
+                (auth_state_key("acct", SIGNER_A), 4242_i64),
+                (auth_state_key("acct", SIGNER_B), 3131_i64),
+            ]))
+            .unwrap(),
+        )
+        .unwrap();
+        std::fs::remove_file(auth_floor_migration_path(&dir)).unwrap();
+
+        let store = FilesystemMetadataStore::new(dir.path().to_path_buf())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            persisted_auth_state(&dir).get(&auth_state_key("acct", LEGACY_ACCOUNT_AUTH_FLOOR)),
+            Some(&4242),
+            "an earlier per-signer expansion must inherit its highest observed floor"
+        );
+        assert!(
+            !store
+                .update_last_auth_timestamp_cas("acct", "0xdddd", 4242)
+                .await
+                .unwrap(),
+            "a signer first seen after the repair must inherit the reserved floor"
         );
     }
 
@@ -862,7 +977,7 @@ mod auth_state_tests {
     }
 
     #[tokio::test]
-    async fn account_scoped_auth_state_with_unusable_signers_fails_closed() {
+    async fn unusable_legacy_signers_keep_an_account_level_floor() {
         let dir = tempfile::tempdir().unwrap();
         {
             let _store = store_with_account(&dir).await;
@@ -881,13 +996,138 @@ mod auth_state_tests {
         )
         .unwrap();
 
+        let store = FilesystemMetadataStore::new(dir.path().to_path_buf())
+            .await
+            .expect("the account-level floor makes inert signer metadata safe to migrate");
+
+        assert_eq!(
+            persisted_auth_state(&dir).get(&auth_state_key("acct", LEGACY_ACCOUNT_AUTH_FLOOR)),
+            Some(&4242)
+        );
+        assert!(
+            !store
+                .update_last_auth_timestamp_cas("acct", SIGNER_A, 4242)
+                .await
+                .unwrap(),
+            "a repaired signer must inherit the legacy account floor"
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_account_metadata_aborts_without_rewriting_auth_state() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let _store = store_with_account(&dir).await;
+        }
+        let original = serde_json::to_string(&HashMap::from([
+            ("acct".to_string(), 4242_i64),
+            ("missing-account".to_string(), 3131_i64),
+        ]))
+        .unwrap();
+        std::fs::write(auth_state_path(&dir), &original).unwrap();
+
         let error = FilesystemMetadataStore::new(dir.path().to_path_buf())
             .await
             .err()
-            .expect("an account-scoped floor without usable signers must reject startup");
+            .expect("unmatched replay state must reject startup");
 
-        assert!(error.contains("no canonical authorized signer set"));
-        assert_eq!(persisted_auth_state(&dir).get("acct"), Some(&4242));
+        assert!(error.contains("missing-account"));
+        assert_eq!(
+            std::fs::read_to_string(auth_state_path(&dir)).unwrap(),
+            original
+        );
+    }
+
+    #[tokio::test]
+    async fn pre_split_merge_aborts_without_rewriting_auth_state() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let _store = store_with_account(&dir).await;
+        }
+        let mut accounts: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(accounts_path(&dir)).unwrap()).unwrap();
+        accounts["acct"]["last_auth_timestamp"] = serde_json::json!(4242);
+        std::fs::write(
+            accounts_path(&dir),
+            serde_json::to_string(&accounts).unwrap(),
+        )
+        .unwrap();
+        let original =
+            serde_json::to_string(&HashMap::from([("missing-account".to_string(), 3131_i64)]))
+                .unwrap();
+        std::fs::write(auth_state_path(&dir), &original).unwrap();
+
+        let error = FilesystemMetadataStore::new(dir.path().to_path_buf())
+            .await
+            .err()
+            .expect("the in-memory legacy merge must fail before persistence");
+
+        assert!(error.contains("missing-account"));
+        assert_eq!(
+            std::fs::read_to_string(auth_state_path(&dir)).unwrap(),
+            original
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_signer_scoped_account_reports_the_replay_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let _store = store_with_account(&dir).await;
+        }
+        let unknown_entry = auth_state_key("missing-account", SIGNER_A);
+        std::fs::write(
+            auth_state_path(&dir),
+            serde_json::to_string(&HashMap::from([(unknown_entry.clone(), 4242_i64)])).unwrap(),
+        )
+        .unwrap();
+
+        let error = FilesystemMetadataStore::new(dir.path().to_path_buf())
+            .await
+            .err()
+            .expect("unmatched signer-scoped replay state must reject startup");
+
+        assert!(error.contains(&format!("Replay state entry '{unknown_entry}'")));
+        assert!(error.contains("belongs to account 'missing-account'"));
+        assert!(error.contains("Do not delete the replay entry"));
+    }
+
+    #[tokio::test]
+    async fn signer_absent_during_migration_inherits_the_legacy_floor() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let _store = store_with_account(&dir).await;
+        }
+        std::fs::write(
+            auth_state_path(&dir),
+            serde_json::to_string(&HashMap::from([("acct".to_string(), 4242_i64)])).unwrap(),
+        )
+        .unwrap();
+
+        let store = FilesystemMetadataStore::new(dir.path().to_path_buf())
+            .await
+            .unwrap();
+
+        assert!(
+            !store
+                .update_last_auth_timestamp_cas(
+                    "acct",
+                    "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+                    4242
+                )
+                .await
+                .unwrap()
+        );
+        assert!(
+            store
+                .update_last_auth_timestamp_cas(
+                    "acct",
+                    "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+                    4243
+                )
+                .await
+                .unwrap()
+        );
     }
 
     #[tokio::test]

--- a/crates/server/src/metadata/mod.rs
+++ b/crates/server/src/metadata/mod.rs
@@ -11,6 +11,11 @@ pub mod postgres;
 pub use auth::{Auth, AuthHeader, Credentials, ExtractCredentials};
 pub use network::{MidenNetworkType, NetworkConfig};
 
+/// Per-account replay floor retained when legacy account-scoped state is
+/// expanded to signer-scoped rows. It protects signers that were absent during
+/// migration and are authorized again later.
+pub const LEGACY_ACCOUNT_AUTH_FLOOR: &str = "__legacy_account_floor__";
+
 /// Metadata for a single account
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct AccountMetadata {
@@ -182,7 +187,8 @@ pub trait MetadataStore: Send + Sync {
     /// authorized cosigners never contend on one timestamp, while a replay of a
     /// request from the same signer is still rejected: every accepted request
     /// advances its own signer's record, so a captured request can never win the
-    /// CAS again.
+    /// CAS again. A migrated account-level floor is also consulted for signers
+    /// first seen after migration, including signers removed and later restored.
     async fn update_last_auth_timestamp_cas(
         &self,
         account_id: &str,

--- a/crates/server/src/metadata/mod.rs
+++ b/crates/server/src/metadata/mod.rs
@@ -177,9 +177,16 @@ pub trait MetadataStore: Send + Sync {
     /// replay signal, which must never surface as `Err`; `Err` is reserved for
     /// storage failure. Replay state is owned exclusively by this method: no other
     /// store operation may read or write it, and it must not affect `updated_at`.
+    ///
+    /// Scope is per `(account_id, signer_commitment)` (issue #367): independent
+    /// authorized cosigners never contend on one timestamp, while a replay of a
+    /// request from the same signer is still rejected: every accepted request
+    /// advances its own signer's record, so a captured request can never win the
+    /// CAS again.
     async fn update_last_auth_timestamp_cas(
         &self,
         account_id: &str,
+        signer_commitment: &str,
         new_timestamp: i64,
     ) -> Result<bool, String>;
 

--- a/crates/server/src/metadata/postgres.rs
+++ b/crates/server/src/metadata/postgres.rs
@@ -261,6 +261,7 @@ impl MetadataStore for PostgresMetadataStore {
     async fn update_last_auth_timestamp_cas(
         &self,
         account_id: &str,
+        signer_commitment: &str,
         new_timestamp: i64,
     ) -> Result<bool, String> {
         let mut conn = self
@@ -270,13 +271,14 @@ impl MetadataStore for PostgresMetadataStore {
             .map_err(|e| format!("Failed to get connection: {e}"))?;
 
         let rows_updated = diesel::sql_query(
-            "INSERT INTO account_auth_state (account_id, last_auth_timestamp) \
-             VALUES ($1, $2) \
-             ON CONFLICT (account_id) DO UPDATE \
+            "INSERT INTO account_auth_state (account_id, signer_commitment, last_auth_timestamp) \
+             VALUES ($1, $2, $3) \
+             ON CONFLICT (account_id, signer_commitment) DO UPDATE \
              SET last_auth_timestamp = EXCLUDED.last_auth_timestamp \
              WHERE account_auth_state.last_auth_timestamp < EXCLUDED.last_auth_timestamp",
         )
         .bind::<Text, _>(account_id)
+        .bind::<Text, _>(signer_commitment)
         .bind::<diesel::sql_types::BigInt, _>(new_timestamp)
         .execute(&mut conn)
         .await
@@ -575,12 +577,46 @@ mod tests {
         LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
     }
 
+    fn insert_legacy_auth_state(
+        conn: &mut diesel::PgConnection,
+        account_id: &str,
+        auth: serde_json::Value,
+        last_auth_timestamp: i64,
+    ) {
+        diesel::RunQueryDsl::execute(
+            diesel::sql_query(
+                "INSERT INTO account_metadata \
+                 (account_id, auth, network_config, created_at, updated_at, \
+                  has_pending_candidate) \
+                 VALUES ($1, $2, '{}'::jsonb, now(), now(), false)",
+            )
+            .bind::<Text, _>(account_id)
+            .bind::<diesel::sql_types::Jsonb, _>(auth),
+            conn,
+        )
+        .expect("insert legacy metadata row");
+        diesel::RunQueryDsl::execute(
+            diesel::sql_query(
+                "INSERT INTO account_auth_state (account_id, last_auth_timestamp) \
+                 VALUES ($1, $2)",
+            )
+            .bind::<Text, _>(account_id)
+            .bind::<diesel::sql_types::BigInt, _>(last_auth_timestamp),
+            conn,
+        )
+        .expect("insert account-scoped replay row");
+    }
+
     async fn insert_account_row(store: &PostgresMetadataStore, account_id: &str) {
         let mut conn = store.pool.get().await.expect("conn");
         diesel::sql_query(
             "INSERT INTO account_metadata \
              (account_id, auth, network_config, created_at, updated_at, has_pending_candidate) \
-             VALUES ($1, '{}'::jsonb, '{}'::jsonb, now(), now(), false)",
+             VALUES ($1, \
+                     '{\"MidenFalconRpo\":{\"cosigner_commitments\":[\
+                        \"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\
+                        \"0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"]}}'::jsonb, \
+                     '{}'::jsonb, now(), now(), false)",
         )
         .bind::<Text, _>(account_id)
         .execute(&mut conn)
@@ -588,10 +624,15 @@ mod tests {
         .expect("insert metadata");
     }
 
-    async fn stored_auth_timestamp(store: &PostgresMetadataStore, account_id: &str) -> i64 {
+    async fn stored_auth_timestamp(
+        store: &PostgresMetadataStore,
+        account_id: &str,
+        signer_commitment: &str,
+    ) -> i64 {
         let mut conn = store.pool.get().await.expect("conn");
         account_auth_state::table
             .filter(account_auth_state::account_id.eq(account_id))
+            .filter(account_auth_state::signer_commitment.eq(signer_commitment))
             .select(account_auth_state::last_auth_timestamp)
             .first(&mut conn)
             .await
@@ -621,7 +662,7 @@ mod tests {
         let before = metadata_updated_at(&store, &account_id).await;
         assert!(
             store
-                .update_last_auth_timestamp_cas(&account_id, 100)
+                .update_last_auth_timestamp_cas(&account_id, "0xaa", 100)
                 .await
                 .unwrap()
         );
@@ -644,37 +685,77 @@ mod tests {
 
         assert!(
             store
-                .update_last_auth_timestamp_cas(&account_id, 100)
+                .update_last_auth_timestamp_cas(&account_id, "0xaa", 100)
                 .await
                 .unwrap(),
             "first timestamp creates the record"
         );
         assert!(
             !store
-                .update_last_auth_timestamp_cas(&account_id, 100)
+                .update_last_auth_timestamp_cas(&account_id, "0xaa", 100)
                 .await
                 .unwrap(),
             "equal timestamp is a replay"
         );
         assert!(
             !store
-                .update_last_auth_timestamp_cas(&account_id, 99)
+                .update_last_auth_timestamp_cas(&account_id, "0xaa", 99)
                 .await
                 .unwrap(),
             "older timestamp is a replay"
         );
         assert_eq!(
-            stored_auth_timestamp(&store, &account_id).await,
+            stored_auth_timestamp(&store, &account_id, "0xaa").await,
             100,
             "rejected timestamps must not change the stored value"
         );
         assert!(
             store
-                .update_last_auth_timestamp_cas(&account_id, 101)
+                .update_last_auth_timestamp_cas(&account_id, "0xaa", 101)
                 .await
                 .unwrap()
         );
-        assert_eq!(stored_auth_timestamp(&store, &account_id).await, 101);
+        assert_eq!(
+            stored_auth_timestamp(&store, &account_id, "0xaa").await,
+            101
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL with migrations applied"]
+    async fn cas_is_scoped_per_signer_commitment() {
+        let url = database_url().expect("DATABASE_URL must be set for this #[ignore] test");
+        let _guard = pg_serial_lock().lock().await;
+        run_migrations(&url).await.expect("migrations apply");
+        let store = PostgresMetadataStore::new(&url, 2).await.expect("store");
+        let account_id = format!("0xsigner{}", Utc::now().timestamp_micros());
+        insert_account_row(&store, &account_id).await;
+
+        assert!(
+            store
+                .update_last_auth_timestamp_cas(&account_id, "0xaa", 100)
+                .await
+                .unwrap()
+        );
+        assert!(
+            store
+                .update_last_auth_timestamp_cas(&account_id, "0xbb", 50)
+                .await
+                .unwrap(),
+            "another signer's newer timestamp must not lock this signer out"
+        );
+        assert!(
+            !store
+                .update_last_auth_timestamp_cas(&account_id, "0xbb", 50)
+                .await
+                .unwrap(),
+            "a replay from the same signer must still be rejected"
+        );
+        assert_eq!(
+            stored_auth_timestamp(&store, &account_id, "0xaa").await,
+            100
+        );
+        assert_eq!(stored_auth_timestamp(&store, &account_id, "0xbb").await, 50);
     }
 
     #[tokio::test]
@@ -687,7 +768,7 @@ mod tests {
         let account_id = format!("0xghost{}", Utc::now().timestamp_micros());
 
         store
-            .update_last_auth_timestamp_cas(&account_id, 100)
+            .update_last_auth_timestamp_cas(&account_id, "0xaa", 100)
             .await
             .expect_err("unknown account must violate the foreign key, not record state");
     }
@@ -709,7 +790,7 @@ mod tests {
                 let account_id = account_id.clone();
                 tokio::spawn(async move {
                     store
-                        .update_last_auth_timestamp_cas(&account_id, timestamp)
+                        .update_last_auth_timestamp_cas(&account_id, "0xaa", timestamp)
                         .await
                 })
             });
@@ -725,15 +806,28 @@ mod tests {
 
     #[tokio::test]
     #[ignore = "requires DATABASE_URL; reverts and re-applies the newest migration"]
-    async fn migration_backfills_legacy_timestamps_into_account_auth_state() {
+    async fn migration_expands_account_scoped_replay_state_to_per_signer() {
         let url = database_url().expect("DATABASE_URL must be set for this #[ignore] test");
         let _guard = pg_serial_lock().lock().await;
         run_migrations(&url).await.expect("migrations apply");
 
-        let account_id = format!("0xbackfill{}", Utc::now().timestamp_micros());
+        let suffix = Utc::now().timestamp_micros();
+        let falcon_account_id = format!("0xfalconbackfill{suffix}");
+        let ecdsa_account_id = format!("0xecdsa_backfill{suffix}");
+        let evm_account_id = format!("0xevm_backfill{suffix}");
+        let falcon_signer_a = format!("0x{}", "aa".repeat(32));
+        let falcon_signer_b = format!("0x{}", "bb".repeat(32));
+        let ecdsa_signer = format!("0x{}", "cc".repeat(32));
+        let evm_signer = format!("0x{}", "dd".repeat(20));
         {
             let url = url.clone();
-            let account_id = account_id.clone();
+            let falcon_account_id = falcon_account_id.clone();
+            let ecdsa_account_id = ecdsa_account_id.clone();
+            let evm_account_id = evm_account_id.clone();
+            let falcon_signer_a = falcon_signer_a.clone();
+            let falcon_signer_b = falcon_signer_b.clone();
+            let ecdsa_signer = ecdsa_signer.clone();
+            let evm_signer = evm_signer.clone();
             tokio::task::spawn_blocking(move || {
                 use diesel::Connection;
                 use diesel_migrations::MigrationHarness;
@@ -741,17 +835,32 @@ mod tests {
                     diesel::PgConnection::establish(&url).expect("sync connection for revert");
                 conn.revert_last_migration(crate::storage::postgres::MIGRATIONS)
                     .expect("revert newest migration");
-                diesel::RunQueryDsl::execute(
-                    diesel::sql_query(
-                        "INSERT INTO account_metadata \
-                         (account_id, auth, network_config, created_at, updated_at, \
-                          has_pending_candidate, last_auth_timestamp) \
-                         VALUES ($1, '{}'::jsonb, '{}'::jsonb, now(), now(), false, 4242)",
-                    )
-                    .bind::<Text, _>(&account_id),
+                insert_legacy_auth_state(
                     &mut conn,
-                )
-                .expect("insert legacy row");
+                    &falcon_account_id,
+                    serde_json::json!({
+                        "MidenFalconRpo": {
+                            "cosigner_commitments": [falcon_signer_a, falcon_signer_b]
+                        }
+                    }),
+                    4242,
+                );
+                insert_legacy_auth_state(
+                    &mut conn,
+                    &ecdsa_account_id,
+                    serde_json::json!({
+                        "MidenEcdsa": { "cosigner_commitments": [ecdsa_signer] }
+                    }),
+                    3131,
+                );
+                insert_legacy_auth_state(
+                    &mut conn,
+                    &evm_account_id,
+                    serde_json::json!({
+                        "EvmEcdsa": { "signers": [evm_signer] }
+                    }),
+                    2020,
+                );
             })
             .await
             .expect("blocking revert task");
@@ -761,23 +870,132 @@ mod tests {
 
         let store = PostgresMetadataStore::new(&url, 2).await.expect("store");
         assert_eq!(
-            stored_auth_timestamp(&store, &account_id).await,
+            stored_auth_timestamp(&store, &falcon_account_id, &falcon_signer_a).await,
             4242,
-            "legacy timestamp must be backfilled"
+            "the account-scoped floor must be expanded to each authorized signer"
+        );
+        assert_eq!(
+            stored_auth_timestamp(&store, &falcon_account_id, &falcon_signer_b).await,
+            4242
+        );
+        assert_eq!(
+            stored_auth_timestamp(&store, &ecdsa_account_id, &ecdsa_signer).await,
+            3131,
+            "Miden ECDSA replay state must use the same expansion"
+        );
+        assert_eq!(
+            stored_auth_timestamp(&store, &evm_account_id, &evm_signer).await,
+            2020,
+            "EVM signer sets live under a different JSON key and address width"
         );
         assert!(
             !store
-                .update_last_auth_timestamp_cas(&account_id, 4242)
+                .update_last_auth_timestamp_cas(&falcon_account_id, &falcon_signer_a, 4242)
                 .await
                 .unwrap(),
-            "backfilled timestamp must be enforced"
+            "expanded timestamp must be enforced"
         );
         assert!(
             store
-                .update_last_auth_timestamp_cas(&account_id, 4243)
+                .update_last_auth_timestamp_cas(&falcon_account_id, &falcon_signer_a, 4243)
                 .await
                 .unwrap()
         );
+        assert!(
+            store
+                .update_last_auth_timestamp_cas(&falcon_account_id, &falcon_signer_b, 4243)
+                .await
+                .unwrap(),
+            "signers must not contend after the expansion"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL; reverts and re-applies the newest migration"]
+    async fn migration_rejects_non_canonical_signer_metadata() {
+        let url = database_url().expect("DATABASE_URL must be set for this #[ignore] test");
+        let _guard = pg_serial_lock().lock().await;
+        run_migrations(&url).await.expect("migrations apply");
+
+        let suffix = Utc::now().timestamp_micros();
+        let coerced_object_account_id = format!("0xcoercedbackfill{suffix}");
+        let short_commitment_account_id = format!("0xshortbackfill{suffix}");
+        let empty_signers_account_id = format!("0xemptybackfill{suffix}");
+        let malformed_accounts = [
+            (
+                coerced_object_account_id.clone(),
+                serde_json::json!({
+                    "MidenFalconRpo": { "cosigner_commitments": [{ "invalid": true }] }
+                }),
+            ),
+            (
+                short_commitment_account_id.clone(),
+                serde_json::json!({
+                    "MidenFalconRpo": {
+                        "cosigner_commitments": [format!("0x{}", "aa".repeat(20))]
+                    }
+                }),
+            ),
+            (
+                empty_signers_account_id.clone(),
+                serde_json::json!({ "EvmEcdsa": { "signers": [] } }),
+            ),
+        ];
+        {
+            let url = url.clone();
+            let malformed_accounts = malformed_accounts.clone();
+            tokio::task::spawn_blocking(move || {
+                use diesel::Connection;
+                use diesel_migrations::MigrationHarness;
+                let mut conn =
+                    diesel::PgConnection::establish(&url).expect("sync connection for revert");
+                conn.revert_last_migration(crate::storage::postgres::MIGRATIONS)
+                    .expect("revert newest migration");
+                for (account_id, auth) in &malformed_accounts {
+                    insert_legacy_auth_state(&mut conn, account_id, auth.clone(), 4242);
+                }
+            })
+            .await
+            .expect("blocking revert task");
+        }
+
+        let migration_error = run_migrations(&url)
+            .await
+            .expect_err("malformed signer metadata must fail closed");
+
+        {
+            let url = url.clone();
+            let malformed_accounts = malformed_accounts.clone();
+            tokio::task::spawn_blocking(move || {
+                use diesel::Connection;
+                let mut conn =
+                    diesel::PgConnection::establish(&url).expect("sync connection for cleanup");
+                for (account_id, _) in &malformed_accounts {
+                    diesel::RunQueryDsl::execute(
+                        diesel::sql_query("DELETE FROM account_metadata WHERE account_id = $1")
+                            .bind::<Text, _>(account_id),
+                        &mut conn,
+                    )
+                    .expect("remove malformed legacy row");
+                }
+            })
+            .await
+            .expect("blocking cleanup task");
+        }
+        run_migrations(&url)
+            .await
+            .expect("migration applies after malformed rows are removed");
+
+        assert!(
+            migration_error.contains("canonical"),
+            "migration error should explain the abort: {migration_error}"
+        );
+        for (account_id, _) in &malformed_accounts {
+            assert!(
+                migration_error.contains(account_id),
+                "migration error should identify {account_id}: {migration_error}"
+            );
+        }
     }
 
     async fn flag(store: &PostgresMetadataStore, account_id: &str) -> bool {

--- a/crates/server/src/metadata/postgres.rs
+++ b/crates/server/src/metadata/postgres.rs
@@ -1,4 +1,7 @@
-use crate::metadata::{AccountListCursor, AccountMetadata, Auth, MetadataStore, NetworkConfig};
+use crate::metadata::{
+    AccountListCursor, AccountMetadata, Auth, LEGACY_ACCOUNT_AUTH_FLOOR, MetadataStore,
+    NetworkConfig,
+};
 use crate::schema::account_metadata;
 use crate::services::account_status::{AccountStatus, PauseTransition};
 use crate::storage::postgres::build_postgres_pool;
@@ -272,7 +275,14 @@ impl MetadataStore for PostgresMetadataStore {
 
         let rows_updated = diesel::sql_query(
             "INSERT INTO account_auth_state (account_id, signer_commitment, last_auth_timestamp) \
-             VALUES ($1, $2, $3) \
+             SELECT $1, $2, $3 \
+             WHERE NOT EXISTS ( \
+                 SELECT 1 \
+                   FROM account_auth_state legacy \
+                  WHERE legacy.account_id = $1 \
+                    AND legacy.signer_commitment = $4 \
+                    AND legacy.last_auth_timestamp >= $3 \
+             ) \
              ON CONFLICT (account_id, signer_commitment) DO UPDATE \
              SET last_auth_timestamp = EXCLUDED.last_auth_timestamp \
              WHERE account_auth_state.last_auth_timestamp < EXCLUDED.last_auth_timestamp",
@@ -280,6 +290,7 @@ impl MetadataStore for PostgresMetadataStore {
         .bind::<Text, _>(account_id)
         .bind::<Text, _>(signer_commitment)
         .bind::<diesel::sql_types::BigInt, _>(new_timestamp)
+        .bind::<Text, _>(LEGACY_ACCOUNT_AUTH_FLOOR)
         .execute(&mut conn)
         .await
         .map_err(|e| format!("Failed to update last_auth_timestamp: {e}"))?;
@@ -834,7 +845,7 @@ mod tests {
                 let mut conn =
                     diesel::PgConnection::establish(&url).expect("sync connection for revert");
                 conn.revert_last_migration(crate::storage::postgres::MIGRATIONS)
-                    .expect("revert newest migration");
+                    .expect("revert per-signer migration");
                 insert_legacy_auth_state(
                     &mut conn,
                     &falcon_account_id,
@@ -888,6 +899,11 @@ mod tests {
             2020,
             "EVM signer sets live under a different JSON key and address width"
         );
+        assert_eq!(
+            stored_auth_timestamp(&store, &falcon_account_id, LEGACY_ACCOUNT_AUTH_FLOOR,).await,
+            4242,
+            "the account-level floor protects signers absent during migration"
+        );
         assert!(
             !store
                 .update_last_auth_timestamp_cas(&falcon_account_id, &falcon_signer_a, 4242)
@@ -908,11 +924,33 @@ mod tests {
                 .unwrap(),
             "signers must not contend after the expansion"
         );
+        let signer_added_after_migration = format!("0x{}", "ee".repeat(32));
+        assert!(
+            !store
+                .update_last_auth_timestamp_cas(
+                    &falcon_account_id,
+                    &signer_added_after_migration,
+                    4242,
+                )
+                .await
+                .unwrap(),
+            "a signer absent during migration must inherit the account floor"
+        );
+        assert!(
+            store
+                .update_last_auth_timestamp_cas(
+                    &falcon_account_id,
+                    &signer_added_after_migration,
+                    4243,
+                )
+                .await
+                .unwrap()
+        );
     }
 
     #[tokio::test]
     #[ignore = "requires DATABASE_URL; reverts and re-applies the newest migration"]
-    async fn migration_rejects_non_canonical_signer_metadata() {
+    async fn migration_preserves_floor_for_non_canonical_signer_metadata() {
         let url = database_url().expect("DATABASE_URL must be set for this #[ignore] test");
         let _guard = pg_serial_lock().lock().await;
         run_migrations(&url).await.expect("migrations apply");
@@ -950,7 +988,7 @@ mod tests {
                 let mut conn =
                     diesel::PgConnection::establish(&url).expect("sync connection for revert");
                 conn.revert_last_migration(crate::storage::postgres::MIGRATIONS)
-                    .expect("revert newest migration");
+                    .expect("revert per-signer migration");
                 for (account_id, auth) in &malformed_accounts {
                     insert_legacy_auth_state(&mut conn, account_id, auth.clone(), 4242);
                 }
@@ -959,41 +997,15 @@ mod tests {
             .expect("blocking revert task");
         }
 
-        let migration_error = run_migrations(&url)
-            .await
-            .expect_err("malformed signer metadata must fail closed");
-
-        {
-            let url = url.clone();
-            let malformed_accounts = malformed_accounts.clone();
-            tokio::task::spawn_blocking(move || {
-                use diesel::Connection;
-                let mut conn =
-                    diesel::PgConnection::establish(&url).expect("sync connection for cleanup");
-                for (account_id, _) in &malformed_accounts {
-                    diesel::RunQueryDsl::execute(
-                        diesel::sql_query("DELETE FROM account_metadata WHERE account_id = $1")
-                            .bind::<Text, _>(account_id),
-                        &mut conn,
-                    )
-                    .expect("remove malformed legacy row");
-                }
-            })
-            .await
-            .expect("blocking cleanup task");
-        }
         run_migrations(&url)
             .await
-            .expect("migration applies after malformed rows are removed");
+            .expect("the legacy account floor makes inert signer metadata safe to migrate");
 
-        assert!(
-            migration_error.contains("canonical"),
-            "migration error should explain the abort: {migration_error}"
-        );
+        let store = PostgresMetadataStore::new(&url, 2).await.expect("store");
         for (account_id, _) in &malformed_accounts {
-            assert!(
-                migration_error.contains(account_id),
-                "migration error should identify {account_id}: {migration_error}"
+            assert_eq!(
+                stored_auth_timestamp(&store, account_id, LEGACY_ACCOUNT_AUTH_FLOOR).await,
+                4242
             );
         }
     }

--- a/crates/server/src/metadata/postgres.rs
+++ b/crates/server/src/metadata/postgres.rs
@@ -814,7 +814,7 @@ mod tests {
         let suffix = Utc::now().timestamp_micros();
         let falcon_account_id = format!("0xfalconbackfill{suffix}");
         let ecdsa_account_id = format!("0xecdsa_backfill{suffix}");
-        let evm_account_id = format!("0xevm_backfill{suffix}");
+        let evm_account_id = format!("evm:1:0x{suffix:040x}");
         let falcon_signer_a = format!("0x{}", "aa".repeat(32));
         let falcon_signer_b = format!("0x{}", "bb".repeat(32));
         let ecdsa_signer = format!("0x{}", "cc".repeat(32));

--- a/crates/server/src/schema.rs
+++ b/crates/server/src/schema.rs
@@ -93,8 +93,8 @@ diesel::table! {
     /// Representation of the `account_auth_state` table.
     ///
     /// Per-(account, signer) replay-protection record, kept apart from
-    /// `account_metadata` so the per-request CAS rewrites a ~40-byte
-    /// tuple instead of the full metadata row. Keyed per signer
+    /// `account_metadata` so the per-request CAS rewrites two identifiers
+    /// and a timestamp instead of the full metadata row. Keyed per signer
     /// commitment (issue #367) so independent cosigners never contend
     /// on one timestamp.
     account_auth_state (account_id, signer_commitment) {

--- a/crates/server/src/schema.rs
+++ b/crates/server/src/schema.rs
@@ -92,12 +92,16 @@ diesel::table! {
 diesel::table! {
     /// Representation of the `account_auth_state` table.
     ///
-    /// Per-account replay-protection record, kept apart from
+    /// Per-(account, signer) replay-protection record, kept apart from
     /// `account_metadata` so the per-request CAS rewrites a ~40-byte
-    /// tuple instead of the full metadata row.
-    account_auth_state (account_id) {
+    /// tuple instead of the full metadata row. Keyed per signer
+    /// commitment (issue #367) so independent cosigners never contend
+    /// on one timestamp.
+    account_auth_state (account_id, signer_commitment) {
         #[max_length = 128]
         account_id -> Varchar,
+        #[max_length = 128]
+        signer_commitment -> Varchar,
         last_auth_timestamp -> Int8,
     }
 }

--- a/crates/server/src/services/configure_account.rs
+++ b/crates/server/src/services/configure_account.rs
@@ -2,6 +2,7 @@ use crate::error::{GuardianError, Result};
 use crate::metadata::AccountMetadata;
 use crate::metadata::NetworkConfig;
 use crate::metadata::auth::{Auth, Credentials};
+use crate::services::{consume_auth_timestamp, validate_request_timestamp};
 use crate::state::AppState;
 use crate::state_object::StateObject;
 
@@ -19,42 +20,6 @@ pub struct ConfigureAccountResult {
     pub account_id: String,
     pub ack_pubkey: String,
     pub ack_commitment: String,
-}
-
-/// Requires each declared cosigner commitment to be canonical — `0x` plus
-/// 64 lowercase hex digits, the only form the server itself emits — and the
-/// list to be non-empty and duplicate-free. The list is later compared by
-/// exact string equality against the signer set extracted from
-/// `initial_state`, so a non-canonical spelling could only ever fail that
-/// comparison; rejecting it here names the offending entry instead of
-/// surfacing a confusing mismatch. An empty list can never match a real
-/// signer map and would leave the account unable to authorize any request.
-fn validate_commitment_list(commitments: &[String]) -> Result<()> {
-    if commitments.is_empty() {
-        return Err(GuardianError::InvalidInput(
-            "cosigner_commitments must not be empty".to_string(),
-        ));
-    }
-    let mut seen = std::collections::HashSet::new();
-    for entry in commitments {
-        let hex_digits = entry.strip_prefix("0x").unwrap_or("");
-        if hex_digits.len() != 64
-            || !hex_digits
-                .bytes()
-                .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
-        {
-            return Err(GuardianError::InvalidInput(format!(
-                "cosigner_commitments entry '{entry}' is not a canonical commitment \
-                 (expected 0x followed by 64 lowercase hex digits)"
-            )));
-        }
-        if !seen.insert(entry) {
-            return Err(GuardianError::InvalidInput(format!(
-                "cosigner_commitments contains duplicate entry '{entry}'"
-            )));
-        }
-    }
-    Ok(())
 }
 
 /// Configure a new account
@@ -80,7 +45,13 @@ pub async fn configure_account(
         });
     }
 
-    validate_commitment_list(params.auth.cosigner_commitments())?;
+    params
+        .auth
+        .validate_canonical_signer_set()
+        .map_err(GuardianError::InvalidInput)?;
+
+    let request_timestamp =
+        validate_request_timestamp(state, &params.account_id, &params.credential)?;
 
     let existing = state.metadata.get(&params.account_id).await.map_err(|e| {
         tracing::error!(
@@ -92,7 +63,7 @@ pub async fn configure_account(
     })?;
     let scheme = params.auth.scheme();
 
-    let commitment = {
+    let (commitment, signer_commitment) = {
         let client = &state.network_client;
         let expected_guardian_commitment = state.ack.commitment(&scheme);
 
@@ -159,7 +130,7 @@ pub async fn configure_account(
         }
 
         // Verifies the credential authorization.
-        params
+        let signer_commitment = params
             .auth
             .verify(&params.account_id, &params.credential)
             .map_err(|e| {
@@ -172,10 +143,21 @@ pub async fn configure_account(
             })?;
 
         // calculates the commitment of the account state.
-        client
+        let commitment = client
             .get_state_commitment(&params.account_id, &params.initial_state)
-            .map_err(GuardianError::NetworkError)?
+            .map_err(GuardianError::NetworkError)?;
+        (commitment, signer_commitment)
     };
+
+    if existing.is_some() {
+        consume_auth_timestamp(
+            state,
+            &params.account_id,
+            &signer_commitment,
+            request_timestamp,
+        )
+        .await?;
+    }
 
     let now = state.clock.now_rfc3339();
     let created_at = existing
@@ -236,6 +218,18 @@ pub async fn configure_account(
         );
         GuardianError::StorageError(format!("Failed to store metadata: {e}"))
     })?;
+
+    if existing.is_none() {
+        // The replay-state row has an FK to account metadata, so first-time
+        // configuration must seed its floor only after `metadata.set`.
+        consume_auth_timestamp(
+            state,
+            &params.account_id,
+            &signer_commitment,
+            request_timestamp,
+        )
+        .await?;
+    }
 
     // Deliberate asymmetry with pause: `released` means "a guardian
     // switch moved this account away from this server", and this very
@@ -309,7 +303,7 @@ mod tests {
             network_client: Arc::new(network_client),
             ack,
             canonicalization: None, // Optimistic mode for tests
-            clock: Arc::new(crate::clock::test::MockClock::default()),
+            clock: Arc::new(crate::clock::SystemClock),
             dashboard: Arc::new(crate::dashboard::DashboardState::default()),
             auditor: Arc::new(crate::audit::LogAuditor::new()),
             #[cfg(feature = "evm")]
@@ -324,17 +318,22 @@ mod tests {
         let account_id_hex = "0x1d1d1d1c1d1d1d011d1d1d1d1d1d1d";
         let (pubkey_hex, commitment_hex, signature_hex, timestamp) =
             generate_falcon_signature(account_id_hex);
+        let verified_signer_commitment = commitment_hex.clone();
+        let other_signer_commitment = format!("0x{}", "ab".repeat(32));
+        let configured_commitments =
+            vec![other_signer_commitment, verified_signer_commitment.clone()];
 
         let network_client = MockNetworkClient::new()
             .with_validate_credential(Ok(()))
             .with_should_update_auth(Ok(Some(Auth::MidenFalconRpo {
-                cosigner_commitments: vec![commitment_hex.clone()],
+                cosigner_commitments: configured_commitments.clone(),
             })))
             .with_get_state_commitment(Ok("0x1234".to_string()));
 
         let storage_backend = MockStorageBackend::new().with_submit_state(Ok(()));
 
         let metadata_store = MockMetadataStore::new().with_get(Ok(None)).with_set(Ok(()));
+        let observed_metadata = metadata_store.clone();
 
         let state = create_test_app_state(network_client, storage_backend, metadata_store).await;
 
@@ -347,7 +346,7 @@ mod tests {
         let params = ConfigureAccountParams {
             account_id: account_id_hex.to_string(),
             auth: Auth::MidenFalconRpo {
-                cosigner_commitments: vec![commitment_hex],
+                cosigner_commitments: configured_commitments,
             },
             network_config: crate::metadata::NetworkConfig::miden_default(),
             initial_state,
@@ -370,6 +369,39 @@ mod tests {
             ack_commitment.starts_with("0x"),
             "ack_commitment should be hex format"
         );
+        assert_eq!(
+            observed_metadata.get_update_timestamp_cas_calls(),
+            vec![(
+                account_id_hex.to_string(),
+                verified_signer_commitment,
+                timestamp,
+            )]
+        );
+    }
+
+    #[tokio::test]
+    async fn configure_rejects_timestamp_outside_the_skew_window() {
+        let state = create_test_app_state(
+            MockNetworkClient::new(),
+            MockStorageBackend::new(),
+            MockMetadataStore::new(),
+        )
+        .await;
+        let account_id = "0x1d1d1d1c1d1d1d011d1d1d1d1d1d1d";
+        let params = ConfigureAccountParams {
+            account_id: account_id.to_string(),
+            auth: Auth::MidenFalconRpo {
+                cosigner_commitments: vec![format!("0x{}", "aa".repeat(32))],
+            },
+            network_config: crate::metadata::NetworkConfig::miden_default(),
+            initial_state: serde_json::json!({}),
+            credential: Credentials::signature("0x00".into(), "0x00".into(), 0),
+        };
+
+        assert!(matches!(
+            configure_account(&state, params).await,
+            Err(GuardianError::AuthenticationFailed(_))
+        ));
     }
 
     #[tokio::test]
@@ -483,6 +515,60 @@ mod tests {
         assert!(result.is_ok(), "Reconfiguration should succeed");
         let result = result.unwrap();
         assert_eq!(result.account_id, account_id_hex);
+    }
+
+    #[tokio::test]
+    async fn configure_rejects_replayed_reconfiguration_before_writes() {
+        use crate::testing::helpers::generate_falcon_signature;
+
+        let account_id = "0x1d1d1d1c1d1d1d011d1d1d1d1d1d1d";
+        let (pubkey, commitment, signature, timestamp) = generate_falcon_signature(account_id);
+        let existing = AccountMetadata {
+            account_id: account_id.to_string(),
+            auth: Auth::MidenFalconRpo {
+                cosigner_commitments: vec![commitment.clone()],
+            },
+            network_config: crate::metadata::NetworkConfig::miden_default(),
+            created_at: "2024-01-01T00:00:00Z".into(),
+            updated_at: "2024-01-01T00:00:00Z".into(),
+            has_pending_candidate: false,
+            paused_at: None,
+            paused_reason: None,
+            released_at: None,
+        };
+        let metadata = MockMetadataStore::new()
+            .with_get(Ok(Some(existing)))
+            .with_update_timestamp_cas(Ok(false));
+        let observed = metadata.clone();
+        let state = create_test_app_state(
+            MockNetworkClient::new()
+                .with_validate_credential(Ok(()))
+                .with_get_state_commitment(Ok("0x1234".into())),
+            MockStorageBackend::new(),
+            metadata,
+        )
+        .await;
+        let initial_state =
+            serde_json::from_str(include_str!("../testing/fixtures/account.json")).unwrap();
+        let params = ConfigureAccountParams {
+            account_id: account_id.to_string(),
+            auth: Auth::MidenFalconRpo {
+                cosigner_commitments: vec![commitment.clone()],
+            },
+            network_config: crate::metadata::NetworkConfig::miden_default(),
+            initial_state,
+            credential: Credentials::signature(pubkey, signature, timestamp),
+        };
+
+        assert!(matches!(
+            configure_account(&state, params).await,
+            Err(GuardianError::AuthenticationReplay)
+        ));
+        assert_eq!(
+            observed.get_update_timestamp_cas_calls(),
+            vec![(account_id.to_string(), commitment, timestamp)]
+        );
+        assert!(observed.get_set_calls().is_empty());
     }
 
     /// Regression: reconfiguring a paused account must NOT clear

--- a/crates/server/src/services/mod.rs
+++ b/crates/server/src/services/mod.rs
@@ -136,33 +136,30 @@ pub async fn resolve_account(
         )));
     }
 
-    if metadata.network_config.is_evm() {
+    if metadata.network_config.is_evm()
+        || matches!(metadata.auth, crate::metadata::Auth::EvmEcdsa { .. })
+    {
         return Err(GuardianError::UnsupportedForNetwork {
             network: "evm".to_string(),
             operation: "delta_api".to_string(),
         });
-    } else {
-        if matches!(metadata.auth, crate::metadata::Auth::EvmEcdsa { .. }) {
-            return Err(GuardianError::UnsupportedForNetwork {
-                network: "evm".to_string(),
-                operation: "delta_api".to_string(),
-            });
-        }
-
-        metadata.auth.verify(account_id, creds).map_err(|e| {
-            tracing::warn!(
-                account_id = %account_id,
-                error = %e,
-                "Authentication failed in resolve_account"
-            );
-            GuardianError::AuthenticationFailed(e)
-        })?;
     }
 
-    // Atomically check and update the last auth timestamp for replay protection
+    let signer_commitment = metadata.auth.verify(account_id, creds).map_err(|e| {
+        tracing::warn!(
+            account_id = %account_id,
+            error = %e,
+            "Authentication failed in resolve_account"
+        );
+        GuardianError::AuthenticationFailed(e)
+    })?;
+
+    // Atomically check and update the last auth timestamp for replay
+    // protection, scoped per (account, signer) so independent cosigners
+    // never contend on one timestamp (issue #367)
     let updated = state
         .metadata
-        .update_last_auth_timestamp_cas(account_id, request_timestamp)
+        .update_last_auth_timestamp_cas(account_id, &signer_commitment, request_timestamp)
         .await
         .map_err(|e| {
             tracing::error!(
@@ -176,12 +173,11 @@ pub async fn resolve_account(
     if !updated {
         tracing::warn!(
             account_id = %account_id,
+            signer_commitment = %signer_commitment,
             request_timestamp = %request_timestamp,
-            "Replay attack detected: timestamp not greater than last seen (CAS failed)"
+            "Replay rejected: timestamp not greater than last seen for signer (CAS failed)"
         );
-        return Err(GuardianError::AuthenticationFailed(
-            "Replay attack detected: timestamp must be greater than previous request".to_string(),
-        ));
+        return Err(GuardianError::AuthenticationReplay);
     }
 
     let storage = state.storage.clone();
@@ -543,10 +539,8 @@ mod tests {
 
         assert!(result.is_err());
         match result.unwrap_err() {
-            GuardianError::AuthenticationFailed(msg) => {
-                assert!(msg.contains("Replay attack detected"));
-            }
-            e => panic!("Expected AuthenticationFailed with replay, got: {:?}", e),
+            GuardianError::AuthenticationReplay => {}
+            e => panic!("Expected AuthenticationReplay, got: {:?}", e),
         }
     }
 
@@ -642,18 +636,14 @@ mod replay_protection_tests {
     use crate::testing::helpers::{TestSigner, create_test_app_state};
 
     const ACCOUNT_ID: &str = "0x7b7b7b7a7b7b7b017b7b7b7b7b7b7b";
-    const REPLAY_MESSAGE: &str =
-        "Replay attack detected: timestamp must be greater than previous request";
 
-    async fn app_state_with_account(commitment: &str) -> AppState {
+    async fn app_state_with_account(auth: Auth) -> AppState {
         let state = create_test_app_state().await;
         state
             .metadata
             .set(AccountMetadata {
                 account_id: ACCOUNT_ID.to_string(),
-                auth: Auth::MidenFalconRpo {
-                    cosigner_commitments: vec![commitment.to_string()],
-                },
+                auth,
                 network_config: crate::metadata::NetworkConfig::miden_default(),
                 created_at: "2024-01-01T00:00:00Z".to_string(),
                 updated_at: "2024-01-01T00:00:00Z".to_string(),
@@ -669,15 +659,18 @@ mod replay_protection_tests {
 
     fn assert_replay_rejected(result: Result<ResolvedAccount>) {
         match result.expect_err("replayed request must be rejected") {
-            GuardianError::AuthenticationFailed(msg) => assert_eq!(msg, REPLAY_MESSAGE),
-            e => panic!("Expected AuthenticationFailed, got: {e:?}"),
+            GuardianError::AuthenticationReplay => {}
+            e => panic!("Expected AuthenticationReplay, got: {e:?}"),
         }
     }
 
     #[tokio::test]
     async fn first_request_accepted_then_identical_replay_rejected() {
         let signer = TestSigner::new();
-        let state = app_state_with_account(&signer.commitment_hex).await;
+        let state = app_state_with_account(Auth::MidenFalconRpo {
+            cosigner_commitments: vec![signer.commitment_hex.clone()],
+        })
+        .await;
         let timestamp = chrono::Utc::now().timestamp_millis();
         let (signature, _) = signer.sign_with_timestamp(ACCOUNT_ID, timestamp);
         let creds = Credentials::signature(signer.pubkey_hex.clone(), signature, timestamp);
@@ -691,7 +684,10 @@ mod replay_protection_tests {
     #[tokio::test]
     async fn timestamp_older_than_last_accepted_is_rejected() {
         let signer = TestSigner::new();
-        let state = app_state_with_account(&signer.commitment_hex).await;
+        let state = app_state_with_account(Auth::MidenFalconRpo {
+            cosigner_commitments: vec![signer.commitment_hex.clone()],
+        })
+        .await;
         let newer = chrono::Utc::now().timestamp_millis();
         let older = newer - 1_000;
 
@@ -716,9 +712,184 @@ mod replay_protection_tests {
     }
 
     #[tokio::test]
+    async fn cosigners_do_not_contend_on_replay_state() {
+        let signer_a = TestSigner::new();
+        let signer_b = TestSigner::new();
+        let state = app_state_with_account(Auth::MidenFalconRpo {
+            cosigner_commitments: vec![
+                signer_a.commitment_hex.clone(),
+                signer_b.commitment_hex.clone(),
+            ],
+        })
+        .await;
+
+        let newer = chrono::Utc::now().timestamp_millis();
+        let older = newer - 60_000;
+
+        let (signature_a, _) = signer_a.sign_with_timestamp(ACCOUNT_ID, newer);
+        resolve_account(
+            &state,
+            ACCOUNT_ID,
+            &Credentials::signature(signer_a.pubkey_hex.clone(), signature_a, newer),
+        )
+        .await
+        .expect("first cosigner accepted");
+
+        let (signature_b, _) = signer_b.sign_with_timestamp(ACCOUNT_ID, older);
+        resolve_account(
+            &state,
+            ACCOUNT_ID,
+            &Credentials::signature(signer_b.pubkey_hex.clone(), signature_b, older),
+        )
+        .await
+        .expect("second cosigner accepted although its clock trails the first cosigner's");
+
+        let (replayed_b, _) = signer_b.sign_with_timestamp(ACCOUNT_ID, older);
+        assert_replay_rejected(
+            resolve_account(
+                &state,
+                ACCOUNT_ID,
+                &Credentials::signature(signer_b.pubkey_hex.clone(), replayed_b, older),
+            )
+            .await,
+        );
+    }
+
+    #[tokio::test]
+    async fn same_signer_clock_ahead_within_skew_is_a_retryable_replay_not_terminal() {
+        let signer = TestSigner::new();
+        let state = app_state_with_account(Auth::MidenFalconRpo {
+            cosigner_commitments: vec![signer.commitment_hex.clone()],
+        })
+        .await;
+
+        let now = chrono::Utc::now().timestamp_millis();
+        let ahead = now + 60_000;
+
+        let (ahead_signature, _) = signer.sign_with_timestamp(ACCOUNT_ID, ahead);
+        resolve_account(
+            &state,
+            ACCOUNT_ID,
+            &Credentials::signature(signer.pubkey_hex.clone(), ahead_signature, ahead),
+        )
+        .await
+        .expect("a fast clock within the skew window is accepted");
+
+        let (wall_clock_signature, _) = signer.sign_with_timestamp(ACCOUNT_ID, now);
+        assert_replay_rejected(
+            resolve_account(
+                &state,
+                ACCOUNT_ID,
+                &Credentials::signature(signer.pubkey_hex.clone(), wall_clock_signature, now),
+            )
+            .await,
+        );
+    }
+
+    #[tokio::test]
+    async fn in_flight_reorder_of_adjacent_timestamps_rejects_only_the_late_arrival() {
+        let signer = TestSigner::new();
+        let state = app_state_with_account(Auth::MidenFalconRpo {
+            cosigner_commitments: vec![signer.commitment_hex.clone()],
+        })
+        .await;
+
+        let first = chrono::Utc::now().timestamp_millis();
+        let second = first + 1;
+        let (first_signature, _) = signer.sign_with_timestamp(ACCOUNT_ID, first);
+        let (second_signature, _) = signer.sign_with_timestamp(ACCOUNT_ID, second);
+
+        resolve_account(
+            &state,
+            ACCOUNT_ID,
+            &Credentials::signature(signer.pubkey_hex.clone(), second_signature, second),
+        )
+        .await
+        .expect("the later-minted request lands first and is accepted");
+
+        assert_replay_rejected(
+            resolve_account(
+                &state,
+                ACCOUNT_ID,
+                &Credentials::signature(signer.pubkey_hex.clone(), first_signature, first),
+            )
+            .await,
+        );
+
+        let third = second + 1;
+        let (third_signature, _) = signer.sign_with_timestamp(ACCOUNT_ID, third);
+        resolve_account(
+            &state,
+            ACCOUNT_ID,
+            &Credentials::signature(signer.pubkey_hex.clone(), third_signature, third),
+        )
+        .await
+        .expect("a fresh timestamp minted after the rejection is accepted");
+    }
+
+    #[tokio::test]
+    async fn ecdsa_replay_scope_is_per_signer() {
+        use crate::testing::helpers::TestEcdsaSigner;
+
+        let signer_a = TestEcdsaSigner::new();
+        let signer_b = TestEcdsaSigner::new();
+        let state = app_state_with_account(Auth::MidenEcdsa {
+            cosigner_commitments: vec![
+                signer_a.commitment_hex.clone(),
+                signer_b.commitment_hex.clone(),
+            ],
+        })
+        .await;
+
+        let newer = chrono::Utc::now().timestamp_millis();
+        let older = newer - 60_000;
+
+        let (signature_a, _) = signer_a.sign_with_timestamp(ACCOUNT_ID, newer);
+        resolve_account(
+            &state,
+            ACCOUNT_ID,
+            &Credentials::signature(signer_a.pubkey_hex.clone(), signature_a, newer),
+        )
+        .await
+        .expect("first ECDSA cosigner accepted");
+
+        let (signature_b, _) = signer_b.sign_with_timestamp(ACCOUNT_ID, older);
+        resolve_account(
+            &state,
+            ACCOUNT_ID,
+            &Credentials::signature(signer_b.pubkey_hex.clone(), signature_b, older),
+        )
+        .await
+        .expect("second ECDSA cosigner accepted although its clock trails the first cosigner's");
+
+        let (replayed_b, _) = signer_b.sign_with_timestamp(ACCOUNT_ID, older);
+        assert_replay_rejected(
+            resolve_account(
+                &state,
+                ACCOUNT_ID,
+                &Credentials::signature(signer_b.pubkey_hex.clone(), replayed_b, older),
+            )
+            .await,
+        );
+
+        let fresher = older + 1;
+        let (fresh_b, _) = signer_b.sign_with_timestamp(ACCOUNT_ID, fresher);
+        resolve_account(
+            &state,
+            ACCOUNT_ID,
+            &Credentials::signature(signer_b.pubkey_hex.clone(), fresh_b, fresher),
+        )
+        .await
+        .expect("the ECDSA signer recovers with a fresh timestamp");
+    }
+
+    #[tokio::test]
     async fn replay_state_survives_metadata_reconfiguration() {
         let signer = TestSigner::new();
-        let state = app_state_with_account(&signer.commitment_hex).await;
+        let state = app_state_with_account(Auth::MidenFalconRpo {
+            cosigner_commitments: vec![signer.commitment_hex.clone()],
+        })
+        .await;
         let timestamp = chrono::Utc::now().timestamp_millis();
         let (signature, _) = signer.sign_with_timestamp(ACCOUNT_ID, timestamp);
         let creds = Credentials::signature(signer.pubkey_hex.clone(), signature, timestamp);
@@ -751,10 +922,8 @@ mod replay_protection_tests {
             panic!("{endpoint}: first request failed authentication: {msg}");
         }
         match second.expect_err("replayed request must be rejected") {
-            GuardianError::AuthenticationFailed(msg) => {
-                assert_eq!(msg, REPLAY_MESSAGE, "{endpoint}: wrong rejection message")
-            }
-            e => panic!("{endpoint}: expected AuthenticationFailed, got: {e:?}"),
+            GuardianError::AuthenticationReplay => {}
+            e => panic!("{endpoint}: expected AuthenticationReplay, got: {e:?}"),
         }
     }
 
@@ -768,7 +937,10 @@ mod replay_protection_tests {
             "get_delta",
         ] {
             let signer = TestSigner::new();
-            let state = app_state_with_account(&signer.commitment_hex).await;
+            let state = app_state_with_account(Auth::MidenFalconRpo {
+                cosigner_commitments: vec![signer.commitment_hex.clone()],
+            })
+            .await;
             let timestamp = chrono::Utc::now().timestamp_millis();
             let (signature, _) = signer.sign_with_timestamp(ACCOUNT_ID, timestamp);
             let credentials =

--- a/crates/server/src/services/mod.rs
+++ b/crates/server/src/services/mod.rs
@@ -1,6 +1,6 @@
 use crate::error::{GuardianError, Result};
-use crate::metadata::AccountMetadata;
 use crate::metadata::auth::{Credentials, MAX_TIMESTAMP_SKEW_MS};
+use crate::metadata::{AccountMetadata, LEGACY_ACCOUNT_AUTH_FLOOR};
 use crate::state::AppState;
 use crate::storage::StorageBackend;
 use base64::Engine;
@@ -118,23 +118,7 @@ pub async fn resolve_account(
         })?
         .ok_or_else(|| GuardianError::AccountNotFound(account_id.to_string()))?;
 
-    let request_timestamp = creds.timestamp();
-    let server_now_ms = state.clock.now().timestamp_millis();
-    let time_diff_ms = (server_now_ms - request_timestamp).abs();
-    if time_diff_ms > MAX_TIMESTAMP_SKEW_MS {
-        tracing::warn!(
-            account_id = %account_id,
-            request_timestamp = %request_timestamp,
-            server_now_ms = %server_now_ms,
-            time_diff_ms = %time_diff_ms,
-            max_skew_ms = %MAX_TIMESTAMP_SKEW_MS,
-            "Request timestamp outside allowed skew window"
-        );
-        return Err(GuardianError::AuthenticationFailed(format!(
-            "Request timestamp outside allowed window: {}ms drift (max {}ms)",
-            time_diff_ms, MAX_TIMESTAMP_SKEW_MS
-        )));
-    }
+    let request_timestamp = validate_request_timestamp(state, account_id, creds)?;
 
     if metadata.network_config.is_evm()
         || matches!(metadata.auth, crate::metadata::Auth::EvmEcdsa { .. })
@@ -154,12 +138,48 @@ pub async fn resolve_account(
         GuardianError::AuthenticationFailed(e)
     })?;
 
-    // Atomically check and update the last auth timestamp for replay
-    // protection, scoped per (account, signer) so independent cosigners
-    // never contend on one timestamp (issue #367)
+    consume_auth_timestamp(state, account_id, &signer_commitment, request_timestamp).await?;
+
+    let storage = state.storage.clone();
+
+    Ok(ResolvedAccount { metadata, storage })
+}
+
+pub(crate) fn validate_request_timestamp(
+    state: &AppState,
+    account_id: &str,
+    creds: &Credentials,
+) -> Result<i64> {
+    let request_timestamp = creds.timestamp();
+    let server_now_ms = state.clock.now().timestamp_millis();
+    let time_diff_ms = (server_now_ms - request_timestamp).abs();
+    if time_diff_ms > MAX_TIMESTAMP_SKEW_MS {
+        tracing::warn!(
+            account_id = %account_id,
+            request_timestamp = %request_timestamp,
+            server_now_ms = %server_now_ms,
+            time_diff_ms = %time_diff_ms,
+            max_skew_ms = %MAX_TIMESTAMP_SKEW_MS,
+            "Request timestamp outside allowed skew window"
+        );
+        return Err(GuardianError::AuthenticationFailed(format!(
+            "Request timestamp outside allowed window: {}ms drift (max {}ms)",
+            time_diff_ms, MAX_TIMESTAMP_SKEW_MS
+        )));
+    }
+    Ok(request_timestamp)
+}
+
+pub(crate) async fn consume_auth_timestamp(
+    state: &AppState,
+    account_id: &str,
+    signer_commitment: &str,
+    request_timestamp: i64,
+) -> Result<()> {
+    debug_assert_ne!(signer_commitment, LEGACY_ACCOUNT_AUTH_FLOOR);
     let updated = state
         .metadata
-        .update_last_auth_timestamp_cas(account_id, &signer_commitment, request_timestamp)
+        .update_last_auth_timestamp_cas(account_id, signer_commitment, request_timestamp)
         .await
         .map_err(|e| {
             tracing::error!(
@@ -180,9 +200,7 @@ pub async fn resolve_account(
         return Err(GuardianError::AuthenticationReplay);
     }
 
-    let storage = state.storage.clone();
-
-    Ok(ResolvedAccount { metadata, storage })
+    Ok(())
 }
 
 pub fn normalize_payload(payload: Value) -> Result<Value> {

--- a/crates/server/src/testing/integration/auth_http.rs
+++ b/crates/server/src/testing/integration/auth_http.rs
@@ -3,11 +3,51 @@ use crate::testing::helpers::{
 };
 
 use axum::{
-    body::Body,
+    body::{Body, to_bytes},
     http::{Request, StatusCode, header},
 };
 use serde_json::json;
 use tower::{Service, ServiceExt};
+
+#[tokio::test]
+async fn test_configure_replay_uses_standard_error_envelope() {
+    let state = create_test_app_state().await;
+    let app = create_router(state);
+    let (_account_id, account_id_hex, initial_state) = load_fixture_account();
+    let signer = TestSigner::new();
+    let configure_body = json!({
+        "account_id": account_id_hex.clone(),
+        "auth": {
+            "MidenFalconRpo": {
+                "cosigner_commitments": [signer.commitment_hex]
+            }
+        },
+        "initial_state": initial_state
+    });
+    let body = serde_json::to_string(&configure_body).unwrap();
+    let (signature, timestamp) = signer.sign_json_payload(&account_id_hex, &configure_body);
+
+    for expected_status in [StatusCode::OK, StatusCode::UNAUTHORIZED] {
+        let request = Request::builder()
+            .uri("/configure")
+            .method("POST")
+            .header(header::CONTENT_TYPE, "application/json")
+            .header("x-pubkey", &signer.pubkey_hex)
+            .header("x-signature", &signature)
+            .header("x-timestamp", timestamp.to_string())
+            .body(Body::from(body.clone()))
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), expected_status);
+        if expected_status == StatusCode::UNAUTHORIZED {
+            let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+            let envelope: serde_json::Value = serde_json::from_slice(&body).unwrap();
+            assert_eq!(envelope["code"], "authentication_replay");
+            assert_eq!(envelope["meta"]["retryable"], true);
+            assert!(envelope.get("success").is_none());
+        }
+    }
+}
 
 #[tokio::test]
 async fn test_configure_and_push_delta_with_auth() {

--- a/crates/server/src/testing/mocks.rs
+++ b/crates/server/src/testing/mocks.rs
@@ -1210,6 +1210,7 @@ impl MetadataStore for MockMetadataStore {
     async fn update_last_auth_timestamp_cas(
         &self,
         _account_id: &str,
+        _signer_commitment: &str,
         _new_timestamp: i64,
     ) -> StdResult<bool, String> {
         self.update_timestamp_cas_responses

--- a/crates/server/src/testing/mocks.rs
+++ b/crates/server/src/testing/mocks.rs
@@ -1054,6 +1054,7 @@ pub struct MockMetadataStore {
         Arc<StdMutex<Vec<StdResult<Vec<crate::metadata::AccountMetadata>, String>>>>,
     pub list_with_pending_candidates_responses: Arc<StdMutex<Vec<ListResult>>>,
     pub update_timestamp_cas_responses: Arc<StdMutex<Vec<StdResult<bool, String>>>>,
+    pub update_timestamp_cas_calls: Arc<StdMutex<Vec<(String, String, i64)>>>,
     pub find_by_cosigner_commitment_responses: Arc<StdMutex<Vec<ListResult>>>,
     pub find_by_cosigner_commitment_calls: Arc<StdMutex<Vec<String>>>,
     pub set_released_calls: Arc<StdMutex<Vec<String>>>,
@@ -1149,6 +1150,10 @@ impl MockMetadataStore {
     pub fn get_set_calls(&self) -> Vec<crate::metadata::AccountMetadata> {
         self.set_calls.lock().unwrap().clone()
     }
+
+    pub fn get_update_timestamp_cas_calls(&self) -> Vec<(String, String, i64)> {
+        self.update_timestamp_cas_calls.lock().unwrap().clone()
+    }
 }
 
 #[async_trait]
@@ -1209,10 +1214,15 @@ impl MetadataStore for MockMetadataStore {
 
     async fn update_last_auth_timestamp_cas(
         &self,
-        _account_id: &str,
-        _signer_commitment: &str,
-        _new_timestamp: i64,
+        account_id: &str,
+        signer_commitment: &str,
+        new_timestamp: i64,
     ) -> StdResult<bool, String> {
+        self.update_timestamp_cas_calls.lock().unwrap().push((
+            account_id.to_string(),
+            signer_commitment.to_string(),
+            new_timestamp,
+        ));
         self.update_timestamp_cas_responses
             .lock()
             .unwrap()

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -74,19 +74,26 @@ Most startup failures are environment misconfiguration. Check in order:
      includes the Amazon Trust Services roots, not only the RDS CA roots.
    - works under `verify-ca` but fails under `verify-full` → hostname/SAN
      mismatch with the endpoint. See [Database TLS](./CONFIGURATION.md#database-tls).
-8. **Replay-protection state file missing or inconsistent (filesystem builds).** Startup
+9. **Replay-protection state file missing or inconsistent (filesystem builds).** Startup
    fails with `Replay-protection state file ... is missing` when
    `.metadata/auth_state.json` has been deleted from a store whose
    `accounts.json` was already migrated off legacy timestamps. Starting
    anyway would reset replay protection and re-accept previously seen
    request timestamps, so the server refuses instead. Restore
    `auth_state.json` from backup together with the rest of the metadata
-   directory. If no backup exists, recreating the file with the literal
-   content `{}` lets the server start — that is an explicit operator
-   decision to accept a replay window as wide as the timestamp skew
-   allowance. If startup instead reports replay state with no matching account
-   metadata, restore `accounts.json` and `auth_state.json` from the same backup;
-   Guardian will not rewrite or discard the unmatched floors.
+   directory, including `.metadata/auth_state_legacy_floor_v1` when it
+   exists. If a restore predates that marker, startup re-runs floor
+   repair and synthesizes an account-level floor from the highest stored
+   signer timestamp for every account, including ones created after the
+   per-signer migration. A newly added signer whose first request
+   timestamp is at or below that floor is rejected once; the next
+   strictly later timestamp succeeds. If no backup exists, recreating
+   `auth_state.json` with the literal content `{}` lets the server start
+   — that is an explicit operator decision to accept a replay window as
+   wide as the timestamp skew allowance. If startup instead reports
+   replay state with no matching account metadata, restore
+   `accounts.json` and `auth_state.json` from the same backup; Guardian
+   will not rewrite or discard the unmatched floors.
 
 ### Preflight the per-signer replay-state migration
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -50,9 +50,10 @@ Most startup failures are environment misconfiguration. Check in order:
    permissions.
 5. **Postgres migrations fail.** The Postgres path runs migrations at
    startup. If the DB user lacks `CREATE` permissions, startup fails.
-   Grant `CREATE` on the schema or run migrations as a privileged user. Before
-   upgrading an account-scoped replay-state database to per-signer state, run
-   the [replay-state preflight](#preflight-the-per-signer-replay-state-migration).
+   Grant `CREATE` on the schema or run migrations as a privileged user.
+   For a migration that times out, crash-loops the task, or breaks
+   authentication mid-deploy, see [Postgres migrations block startup or fail
+   mid-deploy](#postgres-migrations-block-startup-or-fail-mid-deploy).
 6. **ACK secrets missing in prod.**
    `scripts/aws-deploy.sh deploy` refuses to apply if either ACK secret
    is missing. Run `DEPLOY_STAGE=prod ./scripts/aws-deploy.sh bootstrap-ack-keys`
@@ -88,60 +89,70 @@ Most startup failures are environment misconfiguration. Check in order:
    per-signer migration. A newly added signer whose first request
    timestamp is at or below that floor is rejected once; the next
    strictly later timestamp succeeds. If no backup exists, recreating
-   `auth_state.json` with the literal content `{}` lets the server start
-   — that is an explicit operator decision to accept a replay window as
+   `auth_state.json` with the literal content `{}` lets the server start.
+   That is an explicit operator decision to accept a replay window as
    wide as the timestamp skew allowance. If startup instead reports
    replay state with no matching account metadata, restore
    `accounts.json` and `auth_state.json` from the same backup; Guardian
    will not rewrite or discard the unmatched floors.
 
-### Preflight the per-signer replay-state migration
+### Postgres migrations block startup or fail mid-deploy
 
-Before deploying the migration that expands `account_auth_state` by signer,
-run this read-only query against the pre-upgrade database. Keep its canonical
-commitment patterns aligned with `Auth::is_canonical_signer_commitment` in
-`crates/server/src/metadata/auth/mod.rs` and the migration SQL:
+Migrations run at server startup, before the connection pools are built.
+Each migration runs in a single transaction, so a failure never leaves a
+half-applied schema: the task exits, the orchestrator restarts it, and it
+retries from the same point.
+
+**Check which migrations are applied.** Compare the database against the
+migration directory (`crates/server/migrations/`, whose directory-name
+timestamps are the versions):
 
 ```sql
-WITH auth_sets AS (
-    SELECT s.account_id,
-           COALESCE(
-               m.auth -> 'MidenFalconRpo' -> 'cosigner_commitments',
-               m.auth -> 'MidenEcdsa' -> 'cosigner_commitments',
-               m.auth -> 'EvmEcdsa' -> 'signers'
-           ) AS commitments,
-           CASE WHEN m.auth ? 'EvmEcdsa'
-                THEN '^0x[0-9a-f]{40}$'
-                ELSE '^0x[0-9a-f]{64}$'
-           END AS commitment_pattern,
-           (m.auth ? 'MidenFalconRpo')::integer
-             + (m.auth ? 'MidenEcdsa')::integer
-             + (m.auth ? 'EvmEcdsa')::integer AS variant_count
-      FROM account_auth_state s
-      LEFT JOIN account_metadata m ON m.account_id = s.account_id
-)
-SELECT account_id
-  FROM auth_sets
- WHERE variant_count IS NULL
-    OR variant_count <> 1
-    OR CASE
-           WHEN jsonb_typeof(commitments) = 'array' THEN
-               jsonb_array_length(commitments) = 0
-               OR EXISTS (
-                   SELECT 1
-                     FROM jsonb_array_elements(commitments) signer(value)
-                    WHERE jsonb_typeof(signer.value) <> 'string'
-                       OR NOT ((signer.value #>> '{}') ~ commitment_pattern)
-               )
-           ELSE TRUE
-       END;
+SELECT version FROM __diesel_schema_migrations ORDER BY version DESC LIMIT 5;
 ```
 
-An empty result is clean. Returned accounts have missing or inert signer
-metadata that should be repaired before deployment. The migration does not
-delete their replay state: it retains the old account-level floor, so a signer
-authorized after repair cannot replay an older request. Do not delete
-`account_auth_state` rows as remediation.
+**`Timed out after 60s waiting for the migration advisory lock`.** Only one
+replica migrates at a time, serialised by a Postgres advisory lock. This
+message means another replica held it for the whole wait, or a session died
+mid-migration without releasing it. Find the holder:
+
+```sql
+SELECT a.pid, a.state, now() - a.xact_start AS age, left(a.query, 120) AS query
+  FROM pg_locks l
+  JOIN pg_stat_activity a USING (pid)
+ WHERE l.locktype = 'advisory';
+```
+
+The lock is released when its session ends, so a restart of the stuck replica
+clears it. Do not unlock it manually while another replica is still migrating.
+
+**`Failed to run migrations: ... canceling statement due to lock timeout`.**
+Migrations that rewrite a hot table take an explicit table lock with a 5s
+`lock_timeout`, so they fail fast rather than queueing every later writer
+behind them. A concurrent long-running transaction on the locked table is the
+usual cause:
+
+```sql
+SELECT pid, now() - xact_start AS age, state, left(query, 120) AS query
+  FROM pg_stat_activity
+ WHERE xact_start IS NOT NULL
+   AND now() - xact_start > interval '5 seconds'
+ ORDER BY age DESC;
+```
+
+A restart normally succeeds. Repeated failures mean a persistent long
+transaction, not a broken migration.
+
+**Authenticated requests fail on some replicas during a deploy.** A migration
+that changes a table the *previous* binary writes is not backward compatible,
+and the deployment keeps old tasks serving until the new one is healthy
+(`deployment_minimum_healthy_percent = 100`). Between the migration committing
+and the old tasks draining, requests routed to an old task fail. This is
+deliberate: failing closed beats writing state the new schema cannot represent.
+It is expected for `2026-07-31-000001_account_auth_state` and
+`2026-08-13-000001_auth_state_per_signer`. To eliminate the window rather than
+ride it out, stop the old tasks before the new one migrates, which trades the
+partial errors for brief full downtime.
 
 ### Guardian public key changes unexpectedly
 
@@ -209,8 +220,8 @@ not succeed until the underlying cause (clock, key, payload) changes.
 
 **Mixed server/client rollout:** SDK clients retry only
 `authentication_replay`; they never retry `authentication_failed`. A replay CAS
-reported under the older authentication code—or received by a client without
-replay-specific retry handling—can therefore surface as a terminal 401 until
+reported under the older authentication code, or received by a client without
+replay-specific retry handling, can therefore surface as a terminal 401 until
 both sides use the same error contract.
 
 The same server upgrade changes HTTP `/configure` failures from a

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -50,7 +50,9 @@ Most startup failures are environment misconfiguration. Check in order:
    permissions.
 5. **Postgres migrations fail.** The Postgres path runs migrations at
    startup. If the DB user lacks `CREATE` permissions, startup fails.
-   Grant `CREATE` on the schema or run migrations as a privileged user.
+   Grant `CREATE` on the schema or run migrations as a privileged user. Before
+   upgrading an account-scoped replay-state database to per-signer state, run
+   the [replay-state preflight](#preflight-the-per-signer-replay-state-migration).
 6. **ACK secrets missing in prod.**
    `scripts/aws-deploy.sh deploy` refuses to apply if either ACK secret
    is missing. Run `DEPLOY_STAGE=prod ./scripts/aws-deploy.sh bootstrap-ack-keys`
@@ -72,7 +74,7 @@ Most startup failures are environment misconfiguration. Check in order:
      includes the Amazon Trust Services roots, not only the RDS CA roots.
    - works under `verify-ca` but fails under `verify-full` → hostname/SAN
      mismatch with the endpoint. See [Database TLS](./CONFIGURATION.md#database-tls).
-8. **Replay-protection state file missing (filesystem builds).** Startup
+8. **Replay-protection state file missing or inconsistent (filesystem builds).** Startup
    fails with `Replay-protection state file ... is missing` when
    `.metadata/auth_state.json` has been deleted from a store whose
    `accounts.json` was already migrated off legacy timestamps. Starting
@@ -82,7 +84,57 @@ Most startup failures are environment misconfiguration. Check in order:
    directory. If no backup exists, recreating the file with the literal
    content `{}` lets the server start — that is an explicit operator
    decision to accept a replay window as wide as the timestamp skew
-   allowance.
+   allowance. If startup instead reports replay state with no matching account
+   metadata, restore `accounts.json` and `auth_state.json` from the same backup;
+   Guardian will not rewrite or discard the unmatched floors.
+
+### Preflight the per-signer replay-state migration
+
+Before deploying the migration that expands `account_auth_state` by signer,
+run this read-only query against the pre-upgrade database. Keep its canonical
+commitment patterns aligned with `Auth::is_canonical_signer_commitment` in
+`crates/server/src/metadata/auth/mod.rs` and the migration SQL:
+
+```sql
+WITH auth_sets AS (
+    SELECT s.account_id,
+           COALESCE(
+               m.auth -> 'MidenFalconRpo' -> 'cosigner_commitments',
+               m.auth -> 'MidenEcdsa' -> 'cosigner_commitments',
+               m.auth -> 'EvmEcdsa' -> 'signers'
+           ) AS commitments,
+           CASE WHEN m.auth ? 'EvmEcdsa'
+                THEN '^0x[0-9a-f]{40}$'
+                ELSE '^0x[0-9a-f]{64}$'
+           END AS commitment_pattern,
+           (m.auth ? 'MidenFalconRpo')::integer
+             + (m.auth ? 'MidenEcdsa')::integer
+             + (m.auth ? 'EvmEcdsa')::integer AS variant_count
+      FROM account_auth_state s
+      LEFT JOIN account_metadata m ON m.account_id = s.account_id
+)
+SELECT account_id
+  FROM auth_sets
+ WHERE variant_count IS NULL
+    OR variant_count <> 1
+    OR CASE
+           WHEN jsonb_typeof(commitments) = 'array' THEN
+               jsonb_array_length(commitments) = 0
+               OR EXISTS (
+                   SELECT 1
+                     FROM jsonb_array_elements(commitments) signer(value)
+                    WHERE jsonb_typeof(signer.value) <> 'string'
+                       OR NOT ((signer.value #>> '{}') ~ commitment_pattern)
+               )
+           ELSE TRUE
+       END;
+```
+
+An empty result is clean. Returned accounts have missing or inert signer
+metadata that should be repaired before deployment. The migration does not
+delete their replay state: it retains the old account-level floor, so a signer
+authorized after repair cannot replay an older request. Do not delete
+`account_auth_state` rows as remediation.
 
 ### Guardian public key changes unexpectedly
 
@@ -147,6 +199,18 @@ Headers required on every authenticated request: `x-pubkey`,
 `x-signature`, `x-timestamp`. If any are missing the response is also
 `authentication_failed`. Never retry `authentication_failed`; it will
 not succeed until the underlying cause (clock, key, payload) changes.
+
+**Mixed server/client rollout:** SDK clients retry only
+`authentication_replay`; they never retry `authentication_failed`. A replay CAS
+reported under the older authentication code—or received by a client without
+replay-specific retry handling—can therefore surface as a terminal 401 until
+both sides use the same error contract.
+
+The same server upgrade changes HTTP `/configure` failures from a
+`ConfigureResponse` carrying `success: false` to the standard
+`{ code, message, meta }` error envelope. Update direct HTTP integrations that
+inspect the old body shape before rolling out the server; gRPC continues to use
+the shared protobuf response.
 
 ### Pending proposals never resolve
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -108,32 +108,45 @@ Common benign causes:
 
 ### Signed requests are rejected at the auth layer
 
-This section covers the auth-middleware verdict — `401` with
-`code: authentication_failed`. If your request was *authenticated* but
-still rejected (e.g. `403 authorization_failed`,
-`403 signer_not_authorized`, `400 commitment_mismatch`,
-`409 conflict_pending_*`), jump straight to the
-[error code reference](#error-code-reference) — the signature was fine,
-the service layer rejected the operation.
+This section covers the auth-middleware verdicts, `401` with
+`code: authentication_failed` or `code: authentication_replay`. If your
+request was *authenticated* but still rejected (e.g.
+`403 authorization_failed`, `403 signer_not_authorized`,
+`400 commitment_mismatch`, `409 conflict_pending_*`), jump straight to
+the [error code reference](#error-code-reference): the signature was
+fine, the service layer rejected the operation.
 
-The auth middleware returns `401 authentication_failed` for three
-reasons:
+The two 401 codes mean different things (issue #367 split them):
 
-1. **Clock skew.** Timestamps must be within ±5 minutes of server time
-   ([`metadata/auth/credentials.rs:6`](../crates/server/src/metadata/auth/credentials.rs#L6)).
-   Sync the client clock (NTP) or check for container time drift.
-2. **Reused timestamp.** The server enforces *strictly monotonic*
-   timestamps per public key. If you replay an old request, or two
-   in-flight requests share a millisecond, the second is rejected.
-   Generate fresh timestamps per request and serialise concurrent
-   requests from the same key.
-3. **Modified payload after signing.** The signature covers the request
-   body hash. Mutating the body (proxy reformatting, JSON re-serialise)
-   invalidates the signature. Sign-then-send; do not transform between.
+- **`authentication_replay`** (`meta.retryable: true`). The request was
+  correctly signed, but its `x-timestamp` was not strictly greater than
+  the last timestamp Guardian accepted *from the same signer* on that
+  account. This is the replay-protection CAS, not a credential problem:
+  it happens when two in-flight requests from one client land out of
+  order, or when the same key is used from two processes at once. Both
+  SDK clients retry it automatically (bounded, fresh timestamp and
+  signature per attempt); a user-visible `authentication_replay` means
+  the condition persisted through the retry budget; look for a second
+  process (background poller, second tab, another host) signing with
+  the same key. Replay state is scoped per `(account, signer)`, so
+  other cosigners of a multisig never cause this for you.
+- **`authentication_failed`** (`meta.retryable: false`, terminal) for
+  three reasons:
+  1. **Clock skew.** Timestamps must be within ±5 minutes of server time
+     ([`metadata/auth/credentials.rs:6`](../crates/server/src/metadata/auth/credentials.rs#L6)).
+     Sync the client clock (NTP) or check for container time drift.
+  2. **Invalid or unauthorized signature.** The signer's public-key
+     commitment is not in the account's authorized set, or the signature
+     does not verify.
+  3. **Modified payload after signing.** The signature covers the
+     request body hash. Mutating the body (proxy reformatting, JSON
+     re-serialise) invalidates the signature. Sign-then-send; do not
+     transform between.
 
 Headers required on every authenticated request: `x-pubkey`,
 `x-signature`, `x-timestamp`. If any are missing the response is also
-`authentication_failed`.
+`authentication_failed`. Never retry `authentication_failed`; it will
+not succeed until the underlying cause (clock, key, payload) changes.
 
 ### Pending proposals never resolve
 
@@ -354,7 +367,8 @@ come from
 
 | Code | HTTP | First check |
 |---|---|---|
-| `authentication_failed` | 401 | Clock skew, reused timestamp, modified payload, missing headers. |
+| `authentication_failed` | 401 | Clock skew, invalid/unauthorized signature, modified payload, missing headers. Terminal; never retried. |
+| `authentication_replay` | 401 | Correctly signed but the timestamp lost the per-signer replay CAS. `retryable: true`; SDK clients retry it automatically with a fresh timestamp and signature. See [the auth-layer section](#signed-requests-are-rejected-at-the-auth-layer). |
 | `authorization_failed` | 403 | Account credentials don't authorize the operation. |
 | `signer_not_authorized` | 403 | Signer isn't on the proposal's allowed signer set. |
 | `GUARDIAN_INSUFFICIENT_OPERATOR_PERMISSION` | 403 | Operator dashboard call requires a permission the operator doesn't have. Response body carries `missing_permissions: string[]` (lex-sorted, deduplicated) and `retryable: false`. See [`DASHBOARD.md`](./DASHBOARD.md#permission-vocabulary). |

--- a/docs/guides/horizontal-scaling/README.md
+++ b/docs/guides/horizontal-scaling/README.md
@@ -91,7 +91,7 @@ directly on `:50052` (A) and `:50053` (B).
 | Operator/EVM sessions | `auth_sessions` | Log in on A, your cookie works on B; logout is honored fleet-wide. |
 | Login challenges | `auth_challenges` | A challenge is single-use even if issued on A and verified on B. |
 | Canonicalization lease | `worker_leases` | Exactly one replica promotes candidates; the others stand by. |
-| Replay protection | `account_auth_state` | A request timestamp accepted on A cannot be replayed to B; each per-account timestamp is usable exactly once fleet-wide. |
+| Replay protection | `account_auth_state` | A request timestamp accepted on A cannot be replayed to B; each per-account-and-signer timestamp is usable exactly once fleet-wide. A retained migration floor also protects signers first authorized after an account-scoped upgrade. |
 
 Coordination is **backend-derived**: it is on because the backend is Postgres.
 No environment variable enables or disables it.

--- a/docs/openapi-client.json
+++ b/docs/openapi-client.json
@@ -84,7 +84,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ConfigureResponse"
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed or replay rejected",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
                 }
               }
             }
@@ -158,7 +168,7 @@
             }
           },
           "401": {
-            "description": "Authentication failed",
+            "description": "Authentication failed or replay rejected",
             "content": {
               "application/json": {
                 "schema": {
@@ -244,7 +254,7 @@
             }
           },
           "401": {
-            "description": "Authentication failed",
+            "description": "Authentication failed or replay rejected",
             "content": {
               "application/json": {
                 "schema": {
@@ -323,7 +333,7 @@
             }
           },
           "401": {
-            "description": "Authentication failed",
+            "description": "Authentication failed or replay rejected",
             "content": {
               "application/json": {
                 "schema": {
@@ -411,7 +421,7 @@
             }
           },
           "401": {
-            "description": "Authentication failed",
+            "description": "Authentication failed or replay rejected",
             "content": {
               "application/json": {
                 "schema": {
@@ -487,7 +497,7 @@
             }
           },
           "401": {
-            "description": "Authentication failed",
+            "description": "Authentication failed or replay rejected",
             "content": {
               "application/json": {
                 "schema": {
@@ -583,7 +593,7 @@
             }
           },
           "401": {
-            "description": "Authentication failed",
+            "description": "Authentication failed or replay rejected",
             "content": {
               "application/json": {
                 "schema": {
@@ -669,7 +679,7 @@
             }
           },
           "401": {
-            "description": "Authentication failed",
+            "description": "Authentication failed or replay rejected",
             "content": {
               "application/json": {
                 "schema": {
@@ -757,7 +767,7 @@
             }
           },
           "401": {
-            "description": "Authentication failed",
+            "description": "Authentication failed or replay rejected",
             "content": {
               "application/json": {
                 "schema": {
@@ -886,7 +896,7 @@
             }
           },
           "401": {
-            "description": "Authentication failed",
+            "description": "Authentication failed or replay rejected",
             "content": {
               "application/json": {
                 "schema": {
@@ -974,7 +984,7 @@
             }
           },
           "401": {
-            "description": "Authentication failed",
+            "description": "Authentication failed or replay rejected",
             "content": {
               "application/json": {
                 "schema": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -282,7 +282,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ConfigureResponse"
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed or replay rejected",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
                 }
               }
             }
@@ -1518,7 +1528,7 @@
             }
           },
           "401": {
-            "description": "Authentication failed",
+            "description": "Authentication failed or replay rejected",
             "content": {
               "application/json": {
                 "schema": {
@@ -1604,7 +1614,7 @@
             }
           },
           "401": {
-            "description": "Authentication failed",
+            "description": "Authentication failed or replay rejected",
             "content": {
               "application/json": {
                 "schema": {
@@ -1683,7 +1693,7 @@
             }
           },
           "401": {
-            "description": "Authentication failed",
+            "description": "Authentication failed or replay rejected",
             "content": {
               "application/json": {
                 "schema": {
@@ -1771,7 +1781,7 @@
             }
           },
           "401": {
-            "description": "Authentication failed",
+            "description": "Authentication failed or replay rejected",
             "content": {
               "application/json": {
                 "schema": {
@@ -1847,7 +1857,7 @@
             }
           },
           "401": {
-            "description": "Authentication failed",
+            "description": "Authentication failed or replay rejected",
             "content": {
               "application/json": {
                 "schema": {
@@ -1943,7 +1953,7 @@
             }
           },
           "401": {
-            "description": "Authentication failed",
+            "description": "Authentication failed or replay rejected",
             "content": {
               "application/json": {
                 "schema": {
@@ -2029,7 +2039,7 @@
             }
           },
           "401": {
-            "description": "Authentication failed",
+            "description": "Authentication failed or replay rejected",
             "content": {
               "application/json": {
                 "schema": {
@@ -2117,7 +2127,7 @@
             }
           },
           "401": {
-            "description": "Authentication failed",
+            "description": "Authentication failed or replay rejected",
             "content": {
               "application/json": {
                 "schema": {
@@ -3054,7 +3064,7 @@
             }
           },
           "401": {
-            "description": "Authentication failed",
+            "description": "Authentication failed or replay rejected",
             "content": {
               "application/json": {
                 "schema": {
@@ -3142,7 +3152,7 @@
             }
           },
           "401": {
-            "description": "Authentication failed",
+            "description": "Authentication failed or replay rejected",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/guardian-client/README.md
+++ b/packages/guardian-client/README.md
@@ -255,6 +255,17 @@ payload each attempt. Terminal authentication failures
 unauthorized signature) are never retried; branch on `error.code`, never
 on message text.
 
+The client retries only `authentication_replay`; it never retries
+`authentication_failed`. During a mixed server/client rollout, a replay CAS
+reported under the older authentication code—or received by a client without
+replay-specific retry handling—can therefore surface as a terminal 401 until
+both sides use the same error contract.
+
+The upgraded server also returns the standard `{ code, message, meta }` error
+envelope for failed HTTP `/configure` requests instead of a
+`ConfigureResponse` with `success: false`. Direct HTTP integrations that inspect
+the old error body must migrate with the server rollout.
+
 ## Testing
 
 ```bash

--- a/packages/guardian-client/README.md
+++ b/packages/guardian-client/README.md
@@ -218,8 +218,8 @@ class), and `retryAfterSecs()` returns the server's hint, preferring the
 `Retry-After` header over the envelope value.
 
 Rate-limit rejections happen before the server touches any state, so
-retrying them is always safe. The client does not retry automatically
-(automatic backoff is tracked in
+retrying them is always safe. The client does not retry rate limits
+automatically (automatic backoff is tracked in
 [#360](https://github.com/OpenZeppelin/guardian/issues/360)); a bounded
 loop over the exposed hint is a few lines:
 
@@ -241,6 +241,19 @@ async function getStateWithRetry(accountId: string, maxAttempts = 3) {
   }
 }
 ```
+
+### Replay-protection retries
+
+Signed requests carry a strictly increasing per-instance timestamp
+(`max(Date.now(), previous + 1)`). When a correctly signed request still
+loses the server's per-signer replay check (stable code
+`authentication_replay`, typically two in-flight requests landing out of
+order), the client retries automatically, up to 2 times with a 50ms
+backoff, minting a fresh timestamp and signature over the identical
+payload each attempt. Terminal authentication failures
+(`authentication_failed`: clock outside the skew window, invalid or
+unauthorized signature) are never retried; branch on `error.code`, never
+on message text.
 
 ## Testing
 

--- a/packages/guardian-client/src/error-codes.ts
+++ b/packages/guardian-client/src/error-codes.ts
@@ -15,6 +15,7 @@ export const GUARDIAN_ERROR_CODES = [
   'account_paused',
   'account_released',
   'authentication_failed',
+  'authentication_replay',
   'authorization_failed',
   'candidate_landed',
   'commitment_mismatch',

--- a/packages/guardian-client/src/http.test.ts
+++ b/packages/guardian-client/src/http.test.ts
@@ -1114,17 +1114,13 @@ describe('GuardianHttpError', () => {
       expect(parsed.delta).toBeUndefined();
     });
 
-    it('surfaces 401 AUTHENTICATION_FAILED with a parseable error envelope', async () => {
+    it('does not retry a terminal 401 authentication_failed rejection', async () => {
       client.setSigner(mockSigner);
       const envelope = {
         code: 'authentication_failed',
-        message: 'Your session has expired. Please sign in again.',
+        message: 'Guardian could not authenticate this request.',
         meta: { retryable: false },
       };
-      // `authentication_failed` triggers the replay-retry path (the specific
-      // "Replay attack" detail is sanitized off the wire in feature 009, so we
-      // retry on the auth code). Use a persistent mock so the retries resolve
-      // and the final attempt throws the typed error.
       mockFetch.mockResolvedValue({
         ok: false,
         headers: new Headers(),
@@ -1146,9 +1142,89 @@ describe('GuardianHttpError', () => {
       expect(e.status).toBe(401);
       expect(e.code).toBe('authentication_failed');
       expect(typeof e.userMessage).toBe('string');
+      expect(mockFetch).toHaveBeenCalledTimes(1);
       const parsed = JSON.parse(e.body);
       expect(parsed.success).toBeUndefined();
       expect(parsed.delta).toBeUndefined();
+    });
+
+    it('retries an authentication_replay rejection with a fresh timestamp and signature', async () => {
+      client.setSigner(mockSigner);
+      vi.mocked(mockSigner.signRequest!).mockClear();
+      const replayResponse = {
+        ok: false,
+        headers: new Headers(),
+        status: 401,
+        statusText: 'Unauthorized',
+        text: async () =>
+          JSON.stringify({
+            code: 'authentication_replay',
+            message: 'Guardian received this request out of order. Please try again.',
+            meta: { retryable: true },
+          }),
+      };
+      const serverResponse = {
+        delta: {
+          account_id: '0x' + 'a'.repeat(30),
+          nonce: 1,
+          prev_commitment: '0x' + 'b'.repeat(64),
+          delta_payload: { tx_summary: { data: '' }, signatures: [] },
+          status: {
+            status: 'pending',
+            timestamp: '2024-01-01T00:00:00Z',
+            proposer_id: '0x' + 'c'.repeat(64),
+            cosigner_sigs: [],
+          },
+        },
+        commitment: '0x' + 'd'.repeat(64),
+      };
+      mockFetch
+        .mockResolvedValueOnce(replayResponse)
+        .mockResolvedValueOnce({ ok: true, json: async () => serverResponse });
+
+      const result = await client.pushDeltaProposal({
+        accountId: '0x' + 'a'.repeat(30),
+        nonce: 1,
+        deltaPayload: { txSummary: { data: '' }, signatures: [] },
+      });
+
+      expect(result.commitment).toBe('0x' + 'd'.repeat(64));
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      const timestamps = mockFetch.mock.calls.map((call) =>
+        Number((call[1].headers as Record<string, string>)['x-timestamp'])
+      );
+      expect(timestamps[1]).toBeGreaterThan(timestamps[0]);
+      expect(mockSigner.signRequest).toHaveBeenCalledTimes(2);
+    });
+
+    it('gives up after exhausting the bounded replay retry budget', async () => {
+      client.setSigner(mockSigner);
+      mockFetch.mockResolvedValue({
+        ok: false,
+        headers: new Headers(),
+        status: 401,
+        statusText: 'Unauthorized',
+        text: async () =>
+          JSON.stringify({
+            code: 'authentication_replay',
+            message: 'Guardian received this request out of order. Please try again.',
+            meta: { retryable: true },
+          }),
+      });
+
+      const error = await client
+        .pushDeltaProposal({
+          accountId: '0x' + 'a'.repeat(30),
+          nonce: 1,
+          deltaPayload: { txSummary: { data: '' }, signatures: [] },
+        })
+        .catch((e) => e as GuardianHttpError);
+
+      expect(error).toBeInstanceOf(GuardianHttpError);
+      const e = error as GuardianHttpError;
+      expect(e.code).toBe('authentication_replay');
+      expect(e.meta?.retryable).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
     });
   });
 });

--- a/packages/guardian-client/src/http.test.ts
+++ b/packages/guardian-client/src/http.test.ts
@@ -1150,7 +1150,17 @@ describe('GuardianHttpError', () => {
 
     it('retries an authentication_replay rejection with a fresh timestamp and signature', async () => {
       client.setSigner(mockSigner);
-      vi.mocked(mockSigner.signRequest!).mockClear();
+      const signRequest = mockSigner.signRequest;
+      if (!signRequest) {
+        throw new Error('test signer must implement signRequest');
+      }
+      const signRequestMock = vi.mocked(signRequest);
+      signRequestMock.mockClear();
+      const signatureForTimestamp = (_accountId: string, timestamp: number) =>
+        `0x${timestamp.toString(16).padStart(128, '0')}`;
+      signRequestMock
+        .mockImplementationOnce(signatureForTimestamp)
+        .mockImplementationOnce(signatureForTimestamp);
       const replayResponse = {
         ok: false,
         headers: new Headers(),
@@ -1193,8 +1203,12 @@ describe('GuardianHttpError', () => {
       const timestamps = mockFetch.mock.calls.map((call) =>
         Number((call[1].headers as Record<string, string>)['x-timestamp'])
       );
+      const signatures = mockFetch.mock.calls.map(
+        (call) => (call[1].headers as Record<string, string>)['x-signature']
+      );
       expect(timestamps[1]).toBeGreaterThan(timestamps[0]);
-      expect(mockSigner.signRequest).toHaveBeenCalledTimes(2);
+      expect(signatures[1]).not.toBe(signatures[0]);
+      expect(signRequestMock).toHaveBeenCalledTimes(2);
     });
 
     it('gives up after exhausting the bounded replay retry budget', async () => {

--- a/packages/guardian-client/src/http.test.ts
+++ b/packages/guardian-client/src/http.test.ts
@@ -232,6 +232,52 @@ describe('GuardianHttpClient', () => {
 
       await expect(client.configure(request)).rejects.toThrow('No signer configured');
     });
+
+    it('retries a configure replay rejection with fresh authentication', async () => {
+      client.setSigner(mockSigner);
+      const signRequest = mockSigner.signRequest;
+      if (!signRequest) {
+        throw new Error('test signer must implement signRequest');
+      }
+      const signRequestMock = vi.mocked(signRequest);
+      signRequestMock.mockImplementation(
+        (_accountId, timestamp) => `0x${timestamp.toString(16).padStart(128, '0')}`
+      );
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: false,
+          headers: new Headers(),
+          status: 401,
+          statusText: 'Unauthorized',
+          text: async () =>
+            JSON.stringify({
+              code: 'authentication_replay',
+              message: 'Guardian received this request out of order. Please try again.',
+              meta: { retryable: true },
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ success: true, message: 'Account configured' }),
+        });
+
+      await client.configure({
+        accountId: '0x' + 'd'.repeat(30),
+        auth: {
+          MidenFalconRpo: {
+            cosigner_commitments: ['0x' + 'e'.repeat(64)],
+          },
+        },
+        initialState: { data: 'base64data', accountId: '0x' + 'd'.repeat(30) },
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      const timestamps = mockFetch.mock.calls.map((call) =>
+        Number((call[1].headers as Record<string, string>)['x-timestamp'])
+      );
+      expect(timestamps[1]).toBeGreaterThan(timestamps[0]);
+      expect(signRequestMock).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('getState', () => {

--- a/packages/guardian-client/src/http.ts
+++ b/packages/guardian-client/src/http.ts
@@ -542,15 +542,16 @@ export class GuardianHttpClient {
         },
       });
     } catch (err) {
-      // Replay rejections (stale timestamp) are transient: retry once with a
-      // fresh timestamp. The specific "Replay attack" detail is now sanitized
-      // off the wire (feature 009), so branch on the stable auth code instead.
-      // Retrying a genuine auth failure is harmless — one extra attempt that
-      // also fails — and only happens when a retry budget remains.
+      // Replay rejections are transient: the request was correctly signed
+      // but lost the server's per-signer timestamp CAS. Retry with a fresh
+      // timestamp and signature, branching only on the dedicated
+      // `authentication_replay` code (issue #367); terminal authentication
+      // failures (invalid signature, clock outside the skew window) are
+      // never retried.
       if (
         retries > 0 &&
         err instanceof GuardianHttpError &&
-        err.code === 'authentication_failed'
+        err.code === 'authentication_replay'
       ) {
         await new Promise((resolve) => setTimeout(resolve, 50));
         return this.fetchAuthenticated(path, init, accountId, requestPayload, retries - 1);

--- a/spec/api.md
+++ b/spec/api.md
@@ -13,8 +13,10 @@
 
 - The signed payload includes a Unix timestamp in milliseconds.
 - The server enforces a maximum clock skew window of **300,000 milliseconds** (5 minutes).
-- The server tracks `last_auth_timestamp` per account; requests with a timestamp less than or equal to the last accepted timestamp are rejected.
-- `last_auth_timestamp` is updated atomically when authentication succeeds.
+- The server tracks `last_auth_timestamp` per `(account, signer commitment)`; a request whose timestamp is not strictly greater than the last accepted timestamp from the same signer is rejected with the dedicated stable code `authentication_replay` (HTTP 401 / gRPC `Unauthenticated`, `meta.retryable: true`). Independent authorized signers never contend on one timestamp, while a replayed request from the same signer always loses: every accepted request advances that signer's own record.
+- All other authentication failures (clock skew, invalid or unauthorized signature, malformed credentials) share the terminal code `authentication_failed` (`meta.retryable: false`). Clients MUST branch on the stable code, never on message text.
+- `last_auth_timestamp` is updated atomically (compare-and-swap) when authentication succeeds.
+- Clients generate strictly increasing timestamps per instance (`max(now_ms, previous + 1)`) and retry only `authentication_replay`, bounded, with a fresh timestamp, recomputed digest, and fresh signature over the identical payload on each attempt. Terminal authentication failures are never retried.
 
 ### Miden Request Signing
 
@@ -370,6 +372,7 @@ Stable error codes include:
 - `commitment_mismatch`
 - `invalid_commitment`
 - `authentication_failed`
+- `authentication_replay` (retryable replay-CAS rejection, see [Replay Protection](#replay-protection))
 - `authorization_failed`
 - `invalid_input`
 - `storage_error`

--- a/spec/api.md
+++ b/spec/api.md
@@ -16,7 +16,29 @@
 - The server tracks `last_auth_timestamp` per `(account, signer commitment)`; a request whose timestamp is not strictly greater than the last accepted timestamp from the same signer is rejected with the dedicated stable code `authentication_replay` (HTTP 401 / gRPC `Unauthenticated`, `meta.retryable: true`). Independent authorized signers never contend on one timestamp, while a replayed request from the same signer always loses: every accepted request advances that signer's own record.
 - All other authentication failures (clock skew, invalid or unauthorized signature, malformed credentials) share the terminal code `authentication_failed` (`meta.retryable: false`). Clients MUST branch on the stable code, never on message text.
 - `last_auth_timestamp` is updated atomically (compare-and-swap) when authentication succeeds.
+- `POST /configure` enforces the same timestamp skew and replay CAS. A first-time
+  configuration seeds the verified signer's floor once the account metadata row
+  exists; reconfiguration consumes the timestamp before changing stored state.
+  The first-time seed is deliberately post-write because replay state has a
+  foreign key to account metadata. A crash in that narrow interval can leave the
+  new account without a floor, allowing any captured, still-fresh request signed
+  by that signer to initialize the floor and execute. Replaying the configure
+  itself only idempotently re-submits the same state, but the bounded first-write
+  window applies to other signed routes too. Concurrent first configurations are
+  not serialized across different signers; callers must not use `/configure` as
+  a general concurrent state-update mechanism.
+- Migrated stores retain the former account-scoped value as a lower bound for
+  signers first seen later, preventing a removed signer from regaining a replay
+  window when it is authorized again.
 - Clients generate strictly increasing timestamps per instance (`max(now_ms, previous + 1)`) and retry only `authentication_replay`, bounded, with a fresh timestamp, recomputed digest, and fresh signature over the identical payload on each attempt. Terminal authentication failures are never retried.
+- During a mixed server/client rollout, a replay CAS reported under the older
+  authentication code—or received by a client without replay-specific retry
+  handling—can surface as a terminal 401. Current clients retry only
+  `authentication_replay` and never retry `authentication_failed`.
+- HTTP `/configure` failures use the standard API error envelope
+  (`{ code, message, meta }`), not `ConfigureResponse` with `success: false`.
+  Direct HTTP consumers that inspect the old error body must migrate with the
+  server rollout. The shared protobuf response fields remain for gRPC.
 
 ### Miden Request Signing
 

--- a/spec/components.md
+++ b/spec/components.md
@@ -9,7 +9,7 @@ The operator dashboard surface is HTTP-only and lives under `/dashboard/*`. Auth
 ## Metadata
 
 - Stores per-account configuration required to authorise requests, dispatch network-specific behavior, and route to storage.
-- Records: `account_id`, authentication policy, `network_config`, storage backend type, timestamps, and `last_auth_timestamp` for replay protection.
+- Records: `account_id`, authentication policy, `network_config`, storage backend type, and timestamps. Replay-protection timestamps live in a dedicated `account_auth_state` store keyed by `(account_id, signer_commitment)` so the per-request CAS never rewrites account metadata.
 - `network_config` is the durable source for account network identity.
 - Miden account metadata is created by `/configure` with initial state and acknowledgement binding.
 - EVM account metadata is created by `/evm/accounts` with the canonical smart account address, chain ID, multisig validator address, and signer snapshot auth policy. Chain RPC URLs and the shared EntryPoint address remain server-owned configuration.
@@ -25,7 +25,7 @@ The operator dashboard surface is HTTP-only and lives under `/dashboard/*`. Auth
 - Requests carry `x-pubkey`, `x-signature`, and `x-timestamp`.
 - Miden verification derives a commitment from the supplied public key, checks it is authorised, and verifies the signature over `(account_id, timestamp, request_payload_digest)`.
 - EVM verification uses `/evm/auth/*`: the server recovers the EOA from an EIP-712 session challenge and stores that address in a secure cookie-backed session.
-- Replay protection: the signed timestamp is validated against a 300-second skew window and must be strictly greater than the account's `last_auth_timestamp`.
+- Replay protection: the signed timestamp is validated against a 300-second skew window and must be strictly greater than the `last_auth_timestamp` recorded for the same `(account, signer commitment)`. A CAS loss is surfaced as the retryable stable code `authentication_replay`; every other authentication failure is the terminal `authentication_failed`.
 - Default server builds do not register EVM routes or initialize EVM state, sessions, contract readers, or proposal handlers.
 - The account-less lookup endpoint (`GET /state/lookup`, gRPC `GetAccountByKeyCommitment`) uses a dedicated signing primitive `LookupAuthMessage` whose digest is **domain-separated by construction** from the per-account `AuthRequestMessage` (a fixed RPO domain tag is prepended to the lookup digest input, and the array shapes differ in length and leading felts). A signature crafted under one shape cannot validate against the other in either direction. Lookup auth derives identity from the signature itself — Falcon signatures embed the public key, ECDSA signatures recover it via the recovery byte — and then enforces `commitment_of(derived_pk) == queried_key_commitment`. The `x-pubkey` header is sent for wire-format parity with per-account requests but not consulted on this path, so wallet signers that only expose a 32-byte commitment work without weakening proof-of-possession (the signature is what proves possession). New endpoints (including this one) emit failures via the structured `GuardianError` → `IntoResponse` envelope, NOT the legacy `get_state`-style 404-shaped body.
 

--- a/spec/components.md
+++ b/spec/components.md
@@ -9,7 +9,7 @@ The operator dashboard surface is HTTP-only and lives under `/dashboard/*`. Auth
 ## Metadata
 
 - Stores per-account configuration required to authorise requests, dispatch network-specific behavior, and route to storage.
-- Records: `account_id`, authentication policy, `network_config`, storage backend type, and timestamps. Replay-protection timestamps live in a dedicated `account_auth_state` store keyed by `(account_id, signer_commitment)` so the per-request CAS never rewrites account metadata.
+- Records: `account_id`, authentication policy, `network_config`, storage backend type, and timestamps. Replay-protection timestamps live in a dedicated `account_auth_state` store keyed by `(account_id, signer_commitment)` so the per-request CAS never rewrites account metadata. Stores migrated from account-scoped replay state retain a reserved account-level floor consulted for every first-seen signer.
 - `network_config` is the durable source for account network identity.
 - Miden account metadata is created by `/configure` with initial state and acknowledgement binding.
 - EVM account metadata is created by `/evm/accounts` with the canonical smart account address, chain ID, multisig validator address, and signer snapshot auth policy. Chain RPC URLs and the shared EntryPoint address remain server-owned configuration.

--- a/spec/processes.md
+++ b/spec/processes.md
@@ -48,8 +48,8 @@ sequenceDiagram
   participant N as Network
   C->>S: POST /delta {delta, credentials}
   S->>M: get(account_id) & verify(credentials, timestamp, request_payload_digest)
-  S->>S: check timestamp > last_auth_timestamp
-  S->>M: update last_auth_timestamp
+  S->>S: check timestamp > last_auth_timestamp (per signer)
+  S->>M: update last_auth_timestamp (per signer, CAS)
   alt EVM account
     S-->>C: error unsupported_for_network
   else Miden account
@@ -82,8 +82,8 @@ sequenceDiagram
   participant ST as Storage
   C->>S: GET /state?account_id=... {credentials}
   S->>M: get(account_id) & verify(credentials, timestamp, request_payload_digest)
-  S->>S: check timestamp > last_auth_timestamp
-  S->>M: update last_auth_timestamp
+  S->>S: check timestamp > last_auth_timestamp (per signer)
+  S->>M: update last_auth_timestamp (per signer, CAS)
   S->>ST: pull_state(account_id)
   S-->>C: 200 {state}
 ```
@@ -98,8 +98,8 @@ sequenceDiagram
   participant ST as Storage
   C->>S: GET /delta?account_id=...&nonce=... {credentials}
   S->>M: get(account_id) & verify(credentials, timestamp, request_payload_digest)
-  S->>S: check timestamp > last_auth_timestamp
-  S->>M: update last_auth_timestamp
+  S->>S: check timestamp > last_auth_timestamp (per signer)
+  S->>M: update last_auth_timestamp (per signer, CAS)
   S->>ST: pull_delta(account_id, nonce)
   S-->>C: 200 {delta}
 ```
@@ -115,8 +115,8 @@ sequenceDiagram
   participant N as Network
   C->>S: GET /delta/since?account_id=...&nonce=... {credentials}
   S->>M: get(account_id) & verify(credentials, timestamp, request_payload_digest)
-  S->>S: check timestamp > last_auth_timestamp
-  S->>M: update last_auth_timestamp
+  S->>S: check timestamp > last_auth_timestamp (per signer)
+  S->>M: update last_auth_timestamp (per signer, CAS)
   S->>ST: pull_deltas_after(account_id, nonce)
   S->>S: filter -> only canonical
   S->>N: merge_deltas(delta_payloads) -> merged_payload
@@ -135,8 +135,8 @@ sequenceDiagram
   participant N as Network
   C->>S: POST /delta/proposal {account_id, nonce, delta_payload}
   S->>M: get(account_id) & verify(credentials, timestamp, request_payload_digest)
-  S->>S: check timestamp > last_auth_timestamp
-  S->>M: update last_auth_timestamp
+  S->>S: check timestamp > last_auth_timestamp (per signer)
+  S->>M: update last_auth_timestamp (per signer, CAS)
   S->>ST: pull_state(account_id)
   S->>N: verify_delta(prev_commitment, state_json, tx_summary)
   S->>N: delta_proposal_id(account_id, nonce, tx_summary)
@@ -154,8 +154,8 @@ sequenceDiagram
   participant ST as Storage
   C->>S: PUT /delta/proposal {account_id, commitment, signature}
   S->>M: get(account_id) & verify(credentials, timestamp, request_payload_digest)
-  S->>S: check timestamp > last_auth_timestamp
-  S->>M: update last_auth_timestamp
+  S->>S: check timestamp > last_auth_timestamp (per signer)
+  S->>M: update last_auth_timestamp (per signer, CAS)
   S->>ST: pull_delta_proposal(account_id, commitment)
   S->>S: ensure status.pending & signer not recorded
   S->>S: derive signer commitment from x-pubkey
@@ -210,8 +210,8 @@ sequenceDiagram
   participant ST as Storage
   C->>S: GET /delta/proposal?account_id=... {credentials}
   S->>M: get(account_id) & verify(credentials, timestamp, request_payload_digest)
-  S->>S: check timestamp > last_auth_timestamp
-  S->>M: update last_auth_timestamp
+  S->>S: check timestamp > last_auth_timestamp (per signer)
+  S->>M: update last_auth_timestamp (per signer, CAS)
   S->>ST: pull_all_delta_proposals(account_id)
   S->>S: filter(status.pending) & sort_by_nonce
   S-->>C: 200 {proposals}

--- a/spec/processes.md
+++ b/spec/processes.md
@@ -32,8 +32,15 @@ sequenceDiagram
   S->>S: reject unless auth.cosigner_commitments == extracted signer map\n(exact set and order)
   S->>S: auth.verify(account_id, timestamp, request_payload_digest, credential)
   S->>N: get_state_commitment(account_id, initial_state)
+  alt existing account
+    S->>M: update last_auth_timestamp (verified signer, CAS)
+  end
   S->>ST: submit_state(state_json, commitment)
   S->>M: set(account_id, auth, network_config, timestamps)
+  alt first-time account
+    Note over S,M: metadata must exist first because replay state references it by FK
+    S->>M: seed last_auth_timestamp (verified signer, CAS)
+  end
   S-->>C: 200 {account_id, ack_pubkey, ack_commitment}
 ```
 


### PR DESCRIPTION
Scope replay protection per account and signer.
Add retryable authentication_replay error handling and bounded SDK retries.
Safely migrate PostgreSQL and filesystem replay state.

## Compatibility and rollout notes

Successful `POST /configure` responses keep their existing shape. Non-2xx HTTP
responses now use Guardian's standard `{ code, message, meta }` error envelope
instead of a `ConfigureResponse` with `success: false`. Direct HTTP consumers
that inspect `success` on configure errors must switch to the HTTP status and
stable error `code`. The published TypeScript client already throws
`GuardianHttpError` for non-2xx responses.

Clients retry only `authentication_replay`; they never retry
`authentication_failed`. During a mixed server/client rollout, a replay CAS
reported under the older authentication code—or received by a client without
replay-specific retry handling—can therefore surface as a terminal 401 until
both sides use the same error contract. This PR documents that rollout window
instead of adding a compatibility shim.

The filesystem startup migration validates the complete in-memory expansion
before rewriting `auth_state.json`. Filesystem stores from an earlier revision
without a reserved account floor are forward-repaired from the maximum existing
signer timestamp. No PostgreSQL repair migration is needed because no database
ran an earlier revision of this PR.

First-time `/configure` must create account metadata before seeding replay state
because the replay row has a foreign key to the account. A crash or storage
failure in that narrow interval can leave the new account without a floor, so a
captured request that is still inside the five-minute skew window can initialize
the floor and execute. Replaying configure itself is an idempotent re-submit;
the accepted bounded window is documented in `spec/api.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic replay-protection retries for signed requests with refreshed timestamps and signatures.
  - Supports independent replay protection for multiple authorized signers on the same account.
  - Added the `authentication_replay` error code for retryable authentication conflicts.

- **Bug Fixes**
  - Terminal authentication failures are no longer retried unnecessarily.
  - Improved handling of concurrent requests, clock changes, and request reordering.
  - Standardized configuration error responses.

- **Documentation**
  - Updated client, API, migration, scaling, and troubleshooting guidance for replay protection and authentication errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
