### PR TITLE
chore(server): serve status content on GET / instead of "Hello, World!"

### DIFF
--- a/crates/server/src/api/http.rs
+++ b/crates/server/src/api/http.rs
@@ -735,34 +735,34 @@ mod tests {
         (state, storage, network, metadata)
     }
 
-    #[tokio::test]
-    async fn status_route_returns_ok_without_auth() {
+    async fn get_json(state: AppState, uri: &str) -> serde_json::Value {
         use crate::testing::helpers::create_router;
         use axum::body::{Body, to_bytes};
         use axum::http::{Request, StatusCode};
         use tower::ServiceExt;
 
-        let (state, ..) = create_test_state();
-        let app = create_router(state);
-
-        let res = app
+        let res = create_router(state)
             .oneshot(
                 Request::builder()
                     .method("GET")
-                    .uri("/status")
+                    .uri(uri)
                     .body(Body::empty())
                     .unwrap(),
             )
             .await
-            .expect("status request should succeed");
-
-        assert_eq!(res.status(), StatusCode::OK);
+            .expect("request should succeed");
+        assert_eq!(res.status(), StatusCode::OK, "{uri} should return 200");
 
         let bytes = to_bytes(res.into_body(), usize::MAX)
             .await
-            .expect("status body should read");
-        let json: serde_json::Value =
-            serde_json::from_slice(&bytes).expect("status body should be JSON");
+            .expect("body should read");
+        serde_json::from_slice(&bytes).expect("body should be JSON")
+    }
+
+    #[tokio::test]
+    async fn status_route_returns_ok_without_auth() {
+        let (state, ..) = create_test_state();
+        let json = get_json(state, "/status").await;
 
         assert_eq!(json["status"], "ok");
         assert!(json["version"].is_string());
@@ -776,30 +776,6 @@ mod tests {
 
     #[tokio::test]
     async fn root_route_returns_the_status_body_without_auth() {
-        use crate::testing::helpers::create_router;
-        use axum::body::{Body, to_bytes};
-        use axum::http::{Request, StatusCode};
-        use tower::ServiceExt;
-
-        async fn get_json(state: AppState, uri: &str) -> serde_json::Value {
-            let res = create_router(state)
-                .oneshot(
-                    Request::builder()
-                        .method("GET")
-                        .uri(uri)
-                        .body(Body::empty())
-                        .unwrap(),
-                )
-                .await
-                .expect("request should succeed");
-            assert_eq!(res.status(), StatusCode::OK, "{uri} should return 200");
-
-            let bytes = to_bytes(res.into_body(), usize::MAX)
-                .await
-                .expect("body should read");
-            serde_json::from_slice(&bytes).expect("body should be JSON")
-        }
-
         let (state, ..) = create_test_state();
         let mut root = get_json(state.clone(), "/").await;
         let mut status = get_json(state, "/status").await;

--- a/crates/server/src/api/http.rs
+++ b/crates/server/src/api/http.rs
@@ -420,6 +420,21 @@ pub async fn status(State(state): State<AppState>) -> Json<crate::services::Stat
     ))
 }
 
+/// Alias of `GET /status` mounted at the site root. Health checks and
+/// load balancers that probe `/` get the same machine-readable status
+/// body, with the identical response shape and no authentication.
+#[utoipa::path(
+    get,
+    path = "/",
+    tag = "client",
+    responses(
+        (status = 200, description = "Alias of `GET /status`: server liveness, version, and environment", body = crate::services::StatusResponse),
+    )
+)]
+pub async fn status_root(state: State<AppState>) -> Json<crate::services::StatusResponse> {
+    status(state).await
+}
+
 /// Return the Guardian acknowledgement (ACK) public key / commitment
 /// for the requested signature scheme (`falcon` default, or `ecdsa`).
 #[utoipa::path(
@@ -757,6 +772,47 @@ mod tests {
         // Must not leak any dashboard/inventory fields.
         assert!(json.get("total_account_count").is_none());
         assert!(json.get("accounts_by_auth_method").is_none());
+    }
+
+    #[tokio::test]
+    async fn root_route_returns_the_status_body_without_auth() {
+        use crate::testing::helpers::create_router;
+        use axum::body::{Body, to_bytes};
+        use axum::http::{Request, StatusCode};
+        use tower::ServiceExt;
+
+        async fn get_json(state: AppState, uri: &str) -> serde_json::Value {
+            let res = create_router(state)
+                .oneshot(
+                    Request::builder()
+                        .method("GET")
+                        .uri(uri)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .expect("request should succeed");
+            assert_eq!(res.status(), StatusCode::OK, "{uri} should return 200");
+
+            let bytes = to_bytes(res.into_body(), usize::MAX)
+                .await
+                .expect("body should read");
+            serde_json::from_slice(&bytes).expect("body should be JSON")
+        }
+
+        let (state, ..) = create_test_state();
+        let mut root = get_json(state.clone(), "/").await;
+        let mut status = get_json(state, "/status").await;
+
+        assert_eq!(root["status"], "ok");
+        // `uptime_seconds` is derived from the wall clock, so the two
+        // requests can straddle a second boundary. Every other field is
+        // identical by construction.
+        assert!(root["uptime_seconds"].is_number());
+        assert!(status["uptime_seconds"].is_number());
+        root.as_object_mut().unwrap().remove("uptime_seconds");
+        status.as_object_mut().unwrap().remove("uptime_seconds");
+        assert_eq!(root, status, "GET / must mirror GET /status");
     }
 
     fn create_account_metadata(

--- a/crates/server/src/builder/handle.rs
+++ b/crates/server/src/builder/handle.rs
@@ -60,12 +60,6 @@ pub struct ServerHandle {
 impl ServerHandle {
     /// Run the server with the configured settings
     pub async fn run(self) {
-        // Issue #241: serve the auto-generated OpenAPI spec. Unauthenticated
-        // and read-only — it documents the contract, not data.
-        async fn openapi_json() -> axum::Json<utoipa::openapi::OpenApi> {
-            axum::Json(crate::openapi::openapi())
-        }
-
         self.startup_info.log();
 
         let mut tasks = Vec::new();
@@ -161,151 +155,15 @@ impl ServerHandle {
             let body_limit_config = self.body_limit_config;
 
             let task = tokio::spawn(async move {
-                // Feature 006-operator-authz FR-013: every existing dashboard
-                // read route requires `{dashboard:read}`. The authorization
-                // middleware is layered *inside* the session middleware so
-                // session validation always runs first (FR-012) — axum
-                // `route_layer`s compose outer-first, so the session layer
-                // is added last and the authz layer first.
-                use crate::dashboard::authz::{AuthzState, enforce as enforce_authz};
-                use crate::dashboard::permissions::Permission;
-                let dashboard_read_authz =
-                    AuthzState::new(state.clone(), &[Permission::DashboardRead]);
-
-                let dashboard_routes = Router::new()
-                    .route("/accounts", get(list_operator_accounts))
-                    .route("/accounts/{account_id}", get(get_operator_account))
-                    .route(
-                        "/accounts/{account_id}/snapshot",
-                        get(get_operator_account_snapshot),
-                    )
-                    .route(
-                        "/accounts/{account_id}/deltas",
-                        get(list_account_deltas_handler),
-                    )
-                    .route(
-                        "/accounts/{account_id}/deltas/{nonce}",
-                        get(list_account_delta_detail_handler),
-                    )
-                    .route(
-                        "/accounts/{account_id}/proposals",
-                        get(list_account_proposals_handler),
-                    )
-                    .route("/info", get(get_dashboard_info_handler))
-                    .route("/deltas", get(list_global_deltas_handler))
-                    .route("/proposals", get(list_global_proposals_handler))
-                    .route_layer(from_fn_with_state(dashboard_read_authz, enforce_authz))
-                    .route_layer(from_fn_with_state(state.clone(), require_dashboard_session));
-
-                // FR-034: /session sits outside the dashboard:read
-                // authz layer so `permissions: []` operators get 200,
-                // not 403.
-                let session_router = Router::new()
-                    .route("/session", get(get_dashboard_session_handler))
-                    .route_layer(from_fn_with_state(state.clone(), require_dashboard_session));
-                let dashboard_routes = dashboard_routes.merge(session_router);
-
-                // Per-account pause / unpause endpoints. Same per-route
-                // authz composition as the probe: declares the
-                // `accounts:pause` permission and reuses the session
-                // middleware.
-                let dashboard_routes = {
-                    let accounts_pause_authz =
-                        AuthzState::new(state.clone(), &[Permission::AccountsPause]);
-                    let pause_router = Router::new()
-                        .route("/accounts/{account_id}/pause", post(pause_account_handler))
-                        .route(
-                            "/accounts/{account_id}/unpause",
-                            post(unpause_account_handler),
-                        )
-                        .route_layer(from_fn_with_state(accounts_pause_authz, enforce_authz))
-                        .route_layer(from_fn_with_state(state.clone(), require_dashboard_session));
-                    dashboard_routes.merge(pause_router)
-                };
-
-                // Feature 006-operator-authz FR-027 / FR-028: the
-                // authz-test-probe Cargo feature gates a single test-only
-                // route that exercises the middleware end-to-end with
-                // a non-`dashboard:read` requirement. Default-off in
-                // release builds.
-                #[cfg(feature = "authz-test-probe")]
-                let dashboard_routes = {
-                    let accounts_pause_authz =
-                        AuthzState::new(state.clone(), &[Permission::AccountsPause]);
-                    let probe_router = Router::new()
-                        .route(
-                            crate::dashboard::probe::PROBE_PATH,
-                            post(crate::dashboard::probe::handle),
-                        )
-                        .route_layer(from_fn_with_state(accounts_pause_authz, enforce_authz))
-                        .route_layer(from_fn_with_state(state.clone(), require_dashboard_session));
-                    dashboard_routes.merge(probe_router)
-                };
-
-                let app = Router::new()
-                    .route("/", get(status_root))
-                    .route("/api-docs/openapi.json", get(openapi_json))
-                    .route("/delta", post(push_delta))
-                    .route("/delta", get(get_delta))
-                    .route("/delta/since", get(get_delta_since))
-                    .route("/delta/proposal", post(push_delta_proposal))
-                    .route("/delta/proposal", get(get_delta_proposals))
-                    .route("/delta/proposal/single", get(get_delta_proposal))
-                    .route("/delta/proposal", put(sign_delta_proposal))
-                    .route("/delta/candidate/abandon", post(abandon_candidate))
-                    .route("/configure", post(configure))
-                    .route("/state", get(get_state))
-                    .route("/state/lookup", get(lookup))
-                    .route("/pubkey", get(get_pubkey))
-                    .route("/status", get(status))
-                    .route("/auth/challenge", get(challenge_operator_login))
-                    .route("/auth/verify", post(verify_operator_login))
-                    .route("/auth/logout", post(logout_operator));
-
-                #[cfg(feature = "evm")]
-                let app = app
-                    .route("/evm/auth/challenge", get(challenge_evm_session))
-                    .route("/evm/auth/verify", post(verify_evm_session))
-                    .route("/evm/auth/logout", post(logout_evm_session))
-                    .route("/evm/accounts", post(register_evm_account))
-                    .route(
-                        "/evm/proposals",
-                        post(create_evm_proposal).get(list_evm_proposals),
-                    )
-                    .route("/evm/proposals/{proposal_id}", get(get_evm_proposal))
-                    .route(
-                        "/evm/proposals/{proposal_id}/approve",
-                        post(approve_evm_proposal),
-                    )
-                    .route(
-                        "/evm/proposals/{proposal_id}/executable",
-                        get(get_executable_evm_proposal),
-                    )
-                    .route(
-                        "/evm/proposals/{proposal_id}/cancel",
-                        post(cancel_evm_proposal),
-                    );
-
-                let mut app = app.nest("/dashboard", dashboard_routes).with_state(state);
-
-                // Apply body size limit
-                let body_limit = body_limit_config.unwrap_or_else(BodyLimitConfig::from_env);
-                app = app.layer(DefaultBodyLimit::max(body_limit.max_bytes));
-
-                // Apply rate limiting
-                app = app.layer(RateLimitLayer::new(rate_limit_store));
-
-                if let Some(cors) = cors_layer {
-                    app = app.layer(cors);
-                }
-
-                // Outermost layer (added last) so rate-limit 429s and
-                // CORS short-circuits are observed too. Router-level
-                // layers run after routing, so MatchedPath is
-                // available for the bounded route label.
-                if metrics_enabled {
-                    app = app.layer(axum::middleware::from_fn(track_http));
-                }
+                let app = build_http_router(
+                    state,
+                    HttpRouterConfig {
+                        cors_layer,
+                        rate_limit_store,
+                        body_limit_config,
+                        metrics_enabled,
+                    },
+                );
 
                 let addr = format!("0.0.0.0:{port}");
                 let listener = tokio::net::TcpListener::bind(&addr)
@@ -387,6 +245,336 @@ impl ServerHandle {
         // Wait for all servers
         for task in tasks {
             let _ = task.await;
+        }
+    }
+}
+
+/// Layer wiring the HTTP router needs beyond the application state.
+pub(crate) struct HttpRouterConfig {
+    pub(crate) cors_layer: Option<CorsLayer>,
+    pub(crate) rate_limit_store: RateLimitStore,
+    pub(crate) body_limit_config: Option<BodyLimitConfig>,
+    pub(crate) metrics_enabled: bool,
+}
+
+/// Build the HTTP router the server serves. The single source of truth
+/// for the mounted route table: `run()` serves exactly what this returns,
+/// so a routing test against it is a test of production behavior.
+pub(crate) fn build_http_router(state: AppState, config: HttpRouterConfig) -> Router {
+    // Issue #241: serve the auto-generated OpenAPI spec. Unauthenticated
+    // and read-only — it documents the contract, not data.
+    async fn openapi_json() -> axum::Json<utoipa::openapi::OpenApi> {
+        axum::Json(crate::openapi::openapi())
+    }
+
+    // Feature 006-operator-authz FR-013: every existing dashboard
+    // read route requires `{dashboard:read}`. The authorization
+    // middleware is layered *inside* the session middleware so
+    // session validation always runs first (FR-012) — axum
+    // `route_layer`s compose outer-first, so the session layer
+    // is added last and the authz layer first.
+    use crate::dashboard::authz::{AuthzState, enforce as enforce_authz};
+    use crate::dashboard::permissions::Permission;
+    let dashboard_read_authz = AuthzState::new(state.clone(), &[Permission::DashboardRead]);
+
+    let dashboard_routes = Router::new()
+        .route("/accounts", get(list_operator_accounts))
+        .route("/accounts/{account_id}", get(get_operator_account))
+        .route(
+            "/accounts/{account_id}/snapshot",
+            get(get_operator_account_snapshot),
+        )
+        .route(
+            "/accounts/{account_id}/deltas",
+            get(list_account_deltas_handler),
+        )
+        .route(
+            "/accounts/{account_id}/deltas/{nonce}",
+            get(list_account_delta_detail_handler),
+        )
+        .route(
+            "/accounts/{account_id}/proposals",
+            get(list_account_proposals_handler),
+        )
+        .route("/info", get(get_dashboard_info_handler))
+        .route("/deltas", get(list_global_deltas_handler))
+        .route("/proposals", get(list_global_proposals_handler))
+        .route_layer(from_fn_with_state(dashboard_read_authz, enforce_authz))
+        .route_layer(from_fn_with_state(state.clone(), require_dashboard_session));
+
+    // FR-034: /session sits outside the dashboard:read
+    // authz layer so `permissions: []` operators get 200,
+    // not 403.
+    let session_router = Router::new()
+        .route("/session", get(get_dashboard_session_handler))
+        .route_layer(from_fn_with_state(state.clone(), require_dashboard_session));
+    let dashboard_routes = dashboard_routes.merge(session_router);
+
+    // Per-account pause / unpause endpoints. Same per-route
+    // authz composition as the probe: declares the
+    // `accounts:pause` permission and reuses the session
+    // middleware.
+    let dashboard_routes = {
+        let accounts_pause_authz = AuthzState::new(state.clone(), &[Permission::AccountsPause]);
+        let pause_router = Router::new()
+            .route("/accounts/{account_id}/pause", post(pause_account_handler))
+            .route(
+                "/accounts/{account_id}/unpause",
+                post(unpause_account_handler),
+            )
+            .route_layer(from_fn_with_state(accounts_pause_authz, enforce_authz))
+            .route_layer(from_fn_with_state(state.clone(), require_dashboard_session));
+        dashboard_routes.merge(pause_router)
+    };
+
+    // Feature 006-operator-authz FR-027 / FR-028: the
+    // authz-test-probe Cargo feature gates a single test-only
+    // route that exercises the middleware end-to-end with
+    // a non-`dashboard:read` requirement. Default-off in
+    // release builds.
+    #[cfg(feature = "authz-test-probe")]
+    let dashboard_routes = {
+        let accounts_pause_authz = AuthzState::new(state.clone(), &[Permission::AccountsPause]);
+        let probe_router = Router::new()
+            .route(
+                crate::dashboard::probe::PROBE_PATH,
+                post(crate::dashboard::probe::handle),
+            )
+            .route_layer(from_fn_with_state(accounts_pause_authz, enforce_authz))
+            .route_layer(from_fn_with_state(state.clone(), require_dashboard_session));
+        dashboard_routes.merge(probe_router)
+    };
+
+    let app = Router::new()
+        .route("/", get(status_root))
+        .route("/api-docs/openapi.json", get(openapi_json))
+        .route("/delta", post(push_delta))
+        .route("/delta", get(get_delta))
+        .route("/delta/since", get(get_delta_since))
+        .route("/delta/proposal", post(push_delta_proposal))
+        .route("/delta/proposal", get(get_delta_proposals))
+        .route("/delta/proposal/single", get(get_delta_proposal))
+        .route("/delta/proposal", put(sign_delta_proposal))
+        .route("/delta/candidate/abandon", post(abandon_candidate))
+        .route("/configure", post(configure))
+        .route("/state", get(get_state))
+        .route("/state/lookup", get(lookup))
+        .route("/pubkey", get(get_pubkey))
+        .route("/status", get(status))
+        .route("/auth/challenge", get(challenge_operator_login))
+        .route("/auth/verify", post(verify_operator_login))
+        .route("/auth/logout", post(logout_operator));
+
+    #[cfg(feature = "evm")]
+    let app = app
+        .route("/evm/auth/challenge", get(challenge_evm_session))
+        .route("/evm/auth/verify", post(verify_evm_session))
+        .route("/evm/auth/logout", post(logout_evm_session))
+        .route("/evm/accounts", post(register_evm_account))
+        .route(
+            "/evm/proposals",
+            post(create_evm_proposal).get(list_evm_proposals),
+        )
+        .route("/evm/proposals/{proposal_id}", get(get_evm_proposal))
+        .route(
+            "/evm/proposals/{proposal_id}/approve",
+            post(approve_evm_proposal),
+        )
+        .route(
+            "/evm/proposals/{proposal_id}/executable",
+            get(get_executable_evm_proposal),
+        )
+        .route(
+            "/evm/proposals/{proposal_id}/cancel",
+            post(cancel_evm_proposal),
+        );
+
+    let mut app = app.nest("/dashboard", dashboard_routes).with_state(state);
+
+    // Apply body size limit
+    let body_limit = config
+        .body_limit_config
+        .unwrap_or_else(BodyLimitConfig::from_env);
+    app = app.layer(DefaultBodyLimit::max(body_limit.max_bytes));
+
+    // Apply rate limiting
+    app = app.layer(RateLimitLayer::new(config.rate_limit_store));
+
+    if let Some(cors) = config.cors_layer {
+        app = app.layer(cors);
+    }
+
+    // Outermost layer (added last) so rate-limit 429s and
+    // CORS short-circuits are observed too. Router-level
+    // layers run after routing, so MatchedPath is
+    // available for the bounded route label.
+    if config.metrics_enabled {
+        app = app.layer(axum::middleware::from_fn(track_http));
+    }
+
+    app
+}
+
+#[cfg(all(test, not(any(feature = "integration", feature = "e2e"))))]
+mod tests {
+    use super::*;
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    async fn production_router() -> Router {
+        let state = crate::testing::helpers::create_test_app_state().await;
+        build_http_router(
+            state,
+            HttpRouterConfig {
+                cors_layer: None,
+                rate_limit_store: RateLimitStore::new(RateLimitConfig::new(10_000, 10_000)),
+                body_limit_config: Some(BodyLimitConfig {
+                    max_bytes: 1024 * 1024,
+                }),
+                metrics_enabled: false,
+            },
+        )
+    }
+
+    /// The ALB target group health-checks `path = "/"` with
+    /// `matcher = "200"` (`infra/alb.tf`), so an unmounted or
+    /// authenticated root drains every target.
+    #[tokio::test]
+    async fn root_serves_the_status_body_unauthenticated() {
+        let res = production_router()
+            .await
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("request should succeed");
+
+        assert_eq!(res.status(), StatusCode::OK, "GET / must not require auth");
+
+        let bytes = to_bytes(res.into_body(), usize::MAX)
+            .await
+            .expect("body should read");
+        let json: serde_json::Value =
+            serde_json::from_slice(&bytes).expect("GET / must return JSON");
+        assert_eq!(json["status"], "ok");
+        assert!(json["version"].is_string());
+        assert!(json["uptime_seconds"].is_number());
+    }
+
+    /// Independent restatement of the mounted route table. Every other
+    /// test reaches these routes through `create_router`, which delegates
+    /// here, so a renamed or deleted `.route(...)` moves both the code and
+    /// its callers together and stays green. This list does not move with
+    /// them: it is the copy that has to be updated deliberately.
+    #[tokio::test]
+    async fn every_documented_route_is_mounted() {
+        let routes = [
+            ("GET", "/"),
+            ("GET", "/api-docs/openapi.json"),
+            ("POST", "/delta"),
+            ("GET", "/delta"),
+            ("GET", "/delta/since"),
+            ("POST", "/delta/proposal"),
+            ("GET", "/delta/proposal"),
+            ("PUT", "/delta/proposal"),
+            ("GET", "/delta/proposal/single"),
+            ("POST", "/delta/candidate/abandon"),
+            ("POST", "/configure"),
+            ("GET", "/state"),
+            ("GET", "/state/lookup"),
+            ("GET", "/pubkey"),
+            ("GET", "/status"),
+            ("GET", "/auth/challenge"),
+            ("POST", "/auth/verify"),
+            ("POST", "/auth/logout"),
+            ("GET", "/dashboard/info"),
+            ("GET", "/dashboard/session"),
+            ("GET", "/dashboard/accounts"),
+            ("GET", "/dashboard/accounts/0x1"),
+            ("GET", "/dashboard/accounts/0x1/snapshot"),
+            ("GET", "/dashboard/accounts/0x1/deltas"),
+            ("GET", "/dashboard/accounts/0x1/deltas/1"),
+            ("GET", "/dashboard/accounts/0x1/proposals"),
+            ("POST", "/dashboard/accounts/0x1/pause"),
+            ("POST", "/dashboard/accounts/0x1/unpause"),
+            ("GET", "/dashboard/deltas"),
+            ("GET", "/dashboard/proposals"),
+        ];
+
+        let router = production_router().await;
+
+        for (method, path) in routes {
+            let res = router
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method(method)
+                        .uri(path)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .expect("request should succeed");
+
+            assert_ne!(
+                res.status(),
+                StatusCode::NOT_FOUND,
+                "{method} {path} is not mounted"
+            );
+            assert_ne!(
+                res.status(),
+                StatusCode::METHOD_NOT_ALLOWED,
+                "{method} {path} is mounted under a different method"
+            );
+        }
+    }
+
+    #[cfg(feature = "evm")]
+    #[tokio::test]
+    async fn every_evm_route_is_mounted() {
+        let routes = [
+            ("GET", "/evm/auth/challenge"),
+            ("POST", "/evm/auth/verify"),
+            ("POST", "/evm/auth/logout"),
+            ("POST", "/evm/accounts"),
+            ("POST", "/evm/proposals"),
+            ("GET", "/evm/proposals"),
+            ("GET", "/evm/proposals/1"),
+            ("POST", "/evm/proposals/1/approve"),
+            ("GET", "/evm/proposals/1/executable"),
+            ("POST", "/evm/proposals/1/cancel"),
+        ];
+
+        let router = production_router().await;
+
+        for (method, path) in routes {
+            let res = router
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method(method)
+                        .uri(path)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .expect("request should succeed");
+
+            assert_ne!(
+                res.status(),
+                StatusCode::NOT_FOUND,
+                "{method} {path} is not mounted"
+            );
+            assert_ne!(
+                res.status(),
+                StatusCode::METHOD_NOT_ALLOWED,
+                "{method} {path} is mounted under a different method"
+            );
         }
     }
 }

--- a/crates/server/src/builder/handle.rs
+++ b/crates/server/src/builder/handle.rs
@@ -26,7 +26,7 @@ use crate::api::grpc::guardian::guardian_server::GuardianServer;
 use crate::api::http::{
     abandon_candidate, configure, get_delta, get_delta_proposal, get_delta_proposals,
     get_delta_since, get_pubkey, get_state, lookup, push_delta, push_delta_proposal,
-    sign_delta_proposal, status,
+    sign_delta_proposal, status, status_root,
 };
 use crate::builder::startup::StartupInfo;
 use crate::dashboard::require_dashboard_session;
@@ -60,10 +60,6 @@ pub struct ServerHandle {
 impl ServerHandle {
     /// Run the server with the configured settings
     pub async fn run(self) {
-        async fn root() -> &'static str {
-            "Hello, World!"
-        }
-
         // Issue #241: serve the auto-generated OpenAPI spec. Unauthenticated
         // and read-only — it documents the contract, not data.
         async fn openapi_json() -> axum::Json<utoipa::openapi::OpenApi> {
@@ -247,7 +243,7 @@ impl ServerHandle {
                 };
 
                 let app = Router::new()
-                    .route("/", get(root))
+                    .route("/", get(status_root))
                     .route("/api-docs/openapi.json", get(openapi_json))
                     .route("/delta", post(push_delta))
                     .route("/delta", get(get_delta))

--- a/crates/server/src/openapi.rs
+++ b/crates/server/src/openapi.rs
@@ -379,6 +379,36 @@ mod tests {
         );
     }
 
+    fn strip_prose(value: &serde_json::Value) -> serde_json::Value {
+        match value {
+            serde_json::Value::Object(map) => serde_json::Value::Object(
+                map.iter()
+                    .filter(|(key, _)| {
+                        !matches!(key.as_str(), "description" | "summary" | "operationId")
+                    })
+                    .map(|(key, val)| (key.clone(), strip_prose(val)))
+                    .collect(),
+            ),
+            serde_json::Value::Array(items) => {
+                serde_json::Value::Array(items.iter().map(strip_prose).collect())
+            }
+            _ => value.clone(),
+        }
+    }
+
+    #[test]
+    fn root_alias_operation_matches_status() {
+        let json = serde_json::to_value(openapi()).expect("spec serializes to JSON");
+        let root = strip_prose(&json["paths"]["/"]["get"]);
+        let status = strip_prose(&json["paths"]["/status"]["get"]);
+
+        assert_eq!(
+            root, status,
+            "GET / is an alias of GET /status: their documented contracts must \
+             agree on parameters, security, response codes, and body schemas"
+        );
+    }
+
     #[test]
     fn per_surface_specs_are_scoped() {
         let client = serde_json::to_value(client_openapi()).unwrap();

--- a/crates/server/src/openapi.rs
+++ b/crates/server/src/openapi.rs
@@ -194,6 +194,7 @@ impl Modify for CommonResponsesAddon {
         crate::api::http::lookup,
         crate::api::http::get_pubkey,
         crate::api::http::status,
+        crate::api::http::status_root,
         crate::api::http::push_delta_proposal,
         crate::api::http::get_delta_proposals,
         crate::api::http::get_delta_proposal,
@@ -326,6 +327,7 @@ mod tests {
         let paths = json["paths"].as_object().expect("paths object");
         assert!(paths.contains_key("/configure"), "client API path missing");
         assert!(paths.contains_key("/delta"), "client API path missing");
+        assert!(paths.contains_key("/"), "root status alias missing");
         assert!(
             paths.contains_key("/dashboard/accounts"),
             "dashboard API path missing"
@@ -370,6 +372,10 @@ mod tests {
         assert!(
             json["paths"]["/pubkey"]["get"].get("security").is_none(),
             "/pubkey should be public"
+        );
+        assert!(
+            json["paths"]["/"]["get"].get("security").is_none(),
+            "root status alias should be public"
         );
     }
 

--- a/crates/server/src/testing/helpers.rs
+++ b/crates/server/src/testing/helpers.rs
@@ -376,6 +376,7 @@ pub fn create_router(state: AppState) -> axum::Router {
     };
 
     let router = axum::Router::new()
+        .route("/", axum::routing::get(http::status_root))
         .route("/configure", axum::routing::post(http::configure))
         .route("/push_delta", axum::routing::post(http::push_delta))
         .route("/get_delta", axum::routing::get(http::get_delta))

--- a/crates/server/src/testing/helpers.rs
+++ b/crates/server/src/testing/helpers.rs
@@ -3,9 +3,11 @@ use std::sync::Arc;
 
 use crate::ack::AckRegistry;
 use crate::api::grpc::GuardianService;
+use crate::builder::handle::{HttpRouterConfig, build_http_router};
 use crate::dashboard::DashboardState;
 use crate::metadata::auth::Auth;
 use crate::metadata::filesystem::FilesystemMetadataStore;
+use crate::middleware::{BodyLimitConfig, RateLimitConfig, RateLimitStore};
 use crate::network::{NetworkClient, StateVerification};
 use crate::state::AppState;
 use crate::storage::StorageBackend;
@@ -258,204 +260,37 @@ pub fn create_miden_network_config() -> NetworkConfig {
     }
 }
 
+/// Router under test. Delegates to the production route table so tests
+/// exercise the paths, methods, and layer composition the deployed server
+/// actually serves. Layers are permissive by default; tests that assert on
+/// body-limit or rate-limit behavior override the relevant field:
+///
+/// ```ignore
+/// build_http_router(state, HttpRouterConfig {
+///     body_limit_config: Some(BodyLimitConfig { max_bytes: 100 }),
+///     ..test_router_config()
+/// })
+/// ```
 pub fn create_router(state: AppState) -> axum::Router {
-    use crate::api::http;
-    let dashboard_routes = axum::Router::new()
-        .route(
-            "/accounts",
-            axum::routing::get(crate::api::dashboard::list_operator_accounts),
-        )
-        .route(
-            "/accounts/{account_id}",
-            axum::routing::get(crate::api::dashboard::get_operator_account),
-        )
-        .route(
-            "/accounts/{account_id}/snapshot",
-            axum::routing::get(crate::api::dashboard::get_operator_account_snapshot),
-        )
-        .route(
-            "/accounts/{account_id}/deltas",
-            axum::routing::get(crate::api::dashboard_feeds::list_account_deltas_handler),
-        )
-        .route(
-            "/accounts/{account_id}/proposals",
-            axum::routing::get(crate::api::dashboard_feeds::list_account_proposals_handler),
-        )
-        .route(
-            "/info",
-            axum::routing::get(crate::api::dashboard::get_dashboard_info_handler),
-        )
-        .route(
-            "/deltas",
-            axum::routing::get(crate::api::dashboard_feeds::list_global_deltas_handler),
-        )
-        .route(
-            "/proposals",
-            axum::routing::get(crate::api::dashboard_feeds::list_global_proposals_handler),
-        )
-        // Feature 006-operator-authz: existing dashboard reads now
-        // require `{dashboard:read}`. Apply the same layering as
-        // production (`builder/handle.rs`): authz inside the session
-        // layer so session validation runs first.
-        .route_layer(axum::middleware::from_fn_with_state(
-            crate::dashboard::authz::AuthzState::new(
-                state.clone(),
-                &[crate::dashboard::permissions::Permission::DashboardRead],
-            ),
-            crate::dashboard::authz::enforce,
-        ))
-        .route_layer(axum::middleware::from_fn_with_state(
-            state.clone(),
-            crate::dashboard::require_dashboard_session,
-        ));
+    build_http_router(state, test_router_config())
+}
 
-    // FR-034: /session sits outside the dashboard:read authz layer.
-    let session_router = axum::Router::new()
-        .route(
-            "/session",
-            axum::routing::get(crate::api::dashboard::get_dashboard_session_handler),
-        )
-        .route_layer(axum::middleware::from_fn_with_state(
-            state.clone(),
-            crate::dashboard::require_dashboard_session,
-        ));
-    let dashboard_routes = dashboard_routes.merge(session_router);
-
-    // Feature 001-account-pausing: pause/unpause sit under the same
-    // session layer as the dashboard reads, but behind their own
-    // `accounts:pause` authz layer. Mirrors production wiring in
-    // `builder/handle.rs`.
-    let dashboard_routes = {
-        let accounts_pause_authz = crate::dashboard::authz::AuthzState::new(
-            state.clone(),
-            &[crate::dashboard::permissions::Permission::AccountsPause],
-        );
-        let pause_router = axum::Router::new()
-            .route(
-                "/accounts/{account_id}/pause",
-                axum::routing::post(crate::api::dashboard::pause_account_handler),
-            )
-            .route(
-                "/accounts/{account_id}/unpause",
-                axum::routing::post(crate::api::dashboard::unpause_account_handler),
-            )
-            .route_layer(axum::middleware::from_fn_with_state(
-                accounts_pause_authz,
-                crate::dashboard::authz::enforce,
-            ))
-            .route_layer(axum::middleware::from_fn_with_state(
-                state.clone(),
-                crate::dashboard::require_dashboard_session,
-            ));
-        dashboard_routes.merge(pause_router)
-    };
-
-    // Feature 006-operator-authz: probe route wired in test builds when
-    // the `authz-test-probe` Cargo feature is enabled. Mirrors production
-    // wiring in `builder/handle.rs`.
-    #[cfg(feature = "authz-test-probe")]
-    let dashboard_routes = {
-        let accounts_pause_authz = crate::dashboard::authz::AuthzState::new(
-            state.clone(),
-            &[crate::dashboard::permissions::Permission::AccountsPause],
-        );
-        let probe_router = axum::Router::new()
-            .route(
-                crate::dashboard::probe::PROBE_PATH,
-                axum::routing::post(crate::dashboard::probe::handle),
-            )
-            .route_layer(axum::middleware::from_fn_with_state(
-                accounts_pause_authz,
-                crate::dashboard::authz::enforce,
-            ))
-            .route_layer(axum::middleware::from_fn_with_state(
-                state.clone(),
-                crate::dashboard::require_dashboard_session,
-            ));
-        dashboard_routes.merge(probe_router)
-    };
-
-    let router = axum::Router::new()
-        .route("/", axum::routing::get(http::status_root))
-        .route("/configure", axum::routing::post(http::configure))
-        .route("/push_delta", axum::routing::post(http::push_delta))
-        .route("/get_delta", axum::routing::get(http::get_delta))
-        .route("/get_state", axum::routing::get(http::get_state))
-        .route("/state/lookup", axum::routing::get(http::lookup))
-        .route("/pubkey", axum::routing::get(http::get_pubkey))
-        .route("/status", axum::routing::get(http::status))
-        .route(
-            "/push_delta_proposal",
-            axum::routing::post(http::push_delta_proposal),
-        )
-        .route(
-            "/get_delta_proposals",
-            axum::routing::get(http::get_delta_proposals),
-        )
-        .route(
-            "/get_delta_proposal",
-            axum::routing::get(http::get_delta_proposal),
-        )
-        .route(
-            "/sign_delta_proposal",
-            axum::routing::post(http::sign_delta_proposal),
-        )
-        .route(
-            "/auth/challenge",
-            axum::routing::get(crate::api::dashboard::challenge_operator_login),
-        )
-        .route(
-            "/auth/verify",
-            axum::routing::post(crate::api::dashboard::verify_operator_login),
-        )
-        .route(
-            "/auth/logout",
-            axum::routing::post(crate::api::dashboard::logout_operator),
-        );
-
-    #[cfg(feature = "evm")]
-    let router = router
-        .route(
-            "/evm/auth/challenge",
-            axum::routing::get(crate::api::evm::challenge_evm_session),
-        )
-        .route(
-            "/evm/auth/verify",
-            axum::routing::post(crate::api::evm::verify_evm_session),
-        )
-        .route(
-            "/evm/auth/logout",
-            axum::routing::post(crate::api::evm::logout_evm_session),
-        )
-        .route(
-            "/evm/accounts",
-            axum::routing::post(crate::api::evm::register_evm_account),
-        )
-        .route(
-            "/evm/proposals",
-            axum::routing::post(crate::api::evm::create_evm_proposal)
-                .get(crate::api::evm::list_evm_proposals),
-        )
-        .route(
-            "/evm/proposals/{proposal_id}",
-            axum::routing::get(crate::api::evm::get_evm_proposal),
-        )
-        .route(
-            "/evm/proposals/{proposal_id}/approve",
-            axum::routing::post(crate::api::evm::approve_evm_proposal),
-        )
-        .route(
-            "/evm/proposals/{proposal_id}/executable",
-            axum::routing::get(crate::api::evm::get_executable_evm_proposal),
-        )
-        .route(
-            "/evm/proposals/{proposal_id}/cancel",
-            axum::routing::post(crate::api::evm::cancel_evm_proposal),
-        );
-
-    router
-        .nest("/dashboard", dashboard_routes)
-        .with_state(state)
+/// Permissive layer configuration: no CORS, rate limiting disabled, a body
+/// limit far above any fixture, and no metrics layer (tests never install a
+/// global recorder).
+pub(crate) fn test_router_config() -> HttpRouterConfig {
+    HttpRouterConfig {
+        cors_layer: None,
+        rate_limit_store: RateLimitStore::new(RateLimitConfig {
+            enabled: false,
+            burst_per_sec: u32::MAX,
+            per_min: u32::MAX,
+        }),
+        body_limit_config: Some(BodyLimitConfig {
+            max_bytes: 16 * 1024 * 1024,
+        }),
+        metrics_enabled: false,
+    }
 }
 
 pub fn load_fixture_account() -> (AccountId, String, serde_json::Value) {

--- a/crates/server/src/testing/integration/auth_http.rs
+++ b/crates/server/src/testing/integration/auth_http.rs
@@ -58,7 +58,7 @@ async fn test_configure_and_push_delta_with_auth() {
     let (signature_hex_2, timestamp_2) = signer.sign_json_payload(&account_id_hex, &delta_body);
 
     let push_request = Request::builder()
-        .uri("/push_delta")
+        .uri("/delta")
         .method("POST")
         .header(header::CONTENT_TYPE, "application/json")
         .header("x-pubkey", &signer.pubkey_hex)
@@ -128,7 +128,7 @@ async fn test_push_delta_unauthorized_cosigner() {
         unauthorized_signer.sign_json_payload(&account_id_hex, &delta_body);
 
     let push_request = Request::builder()
-        .uri("/push_delta")
+        .uri("/delta")
         .method("POST")
         .header(header::CONTENT_TYPE, "application/json")
         .header("x-pubkey", &unauthorized_signer.pubkey_hex)
@@ -193,7 +193,7 @@ async fn test_push_delta_missing_auth_headers() {
     });
 
     let push_request = Request::builder()
-        .uri("/push_delta")
+        .uri("/delta")
         .method("POST")
         .header(header::CONTENT_TYPE, "application/json")
         // NO auth headers!

--- a/crates/server/src/testing/integration/body_limit_http.rs
+++ b/crates/server/src/testing/integration/body_limit_http.rs
@@ -1,7 +1,8 @@
-use crate::testing::helpers::{create_router, create_test_app_state};
+use crate::builder::handle::{HttpRouterConfig, build_http_router};
+use crate::middleware::BodyLimitConfig;
+use crate::testing::helpers::{create_test_app_state, test_router_config};
 
 use axum::body::Body;
-use axum::extract::DefaultBodyLimit;
 use axum::http::{Request, StatusCode, header};
 use serde_json::json;
 use tower::ServiceExt;
@@ -21,7 +22,13 @@ fn build_configure_request(body: String, pubkey: &str) -> Request<Body> {
 #[tokio::test]
 async fn test_body_limit_rejects_large_payload() {
     let state = create_test_app_state().await;
-    let app = create_router(state).layer(DefaultBodyLimit::max(100));
+    let app = build_http_router(
+        state,
+        HttpRouterConfig {
+            body_limit_config: Some(BodyLimitConfig { max_bytes: 100 }),
+            ..test_router_config()
+        },
+    );
 
     let large_data = "x".repeat(200);
     let configure_body = json!({
@@ -39,7 +46,13 @@ async fn test_body_limit_rejects_large_payload() {
 #[tokio::test]
 async fn test_body_limit_allows_small_payload() {
     let state = create_test_app_state().await;
-    let app = create_router(state).layer(DefaultBodyLimit::max(1024));
+    let app = build_http_router(
+        state,
+        HttpRouterConfig {
+            body_limit_config: Some(BodyLimitConfig { max_bytes: 1024 }),
+            ..test_router_config()
+        },
+    );
 
     let configure_body = json!({
         "account_id": "0x01",

--- a/crates/server/src/testing/integration/error_envelope_http.rs
+++ b/crates/server/src/testing/integration/error_envelope_http.rs
@@ -88,7 +88,7 @@ async fn push_delta_proposal_error_uses_error_envelope() {
     });
 
     let request = Request::builder()
-        .uri("/push_delta_proposal")
+        .uri("/delta/proposal")
         .method("POST")
         .header(header::CONTENT_TYPE, "application/json")
         .header("x-pubkey", &signer.pubkey_hex)
@@ -120,7 +120,7 @@ async fn push_delta_error_uses_error_envelope() {
     let body = json!({ "account_id": "0xnope", "nonce": 1 });
 
     let request = Request::builder()
-        .uri("/push_delta")
+        .uri("/delta")
         .method("POST")
         .header(header::CONTENT_TYPE, "application/json")
         .header("x-pubkey", &signer.pubkey_hex)
@@ -142,7 +142,7 @@ async fn get_delta_error_uses_error_envelope() {
 
     let signer = TestSigner::new();
     let (_account_id, account_id_hex, _initial_state) = load_fixture_account();
-    let uri = format!("/get_delta?account_id={account_id_hex}&nonce=1");
+    let uri = format!("/delta?account_id={account_id_hex}&nonce=1");
 
     let request = Request::builder()
         .uri(uri)
@@ -166,7 +166,7 @@ async fn get_state_error_uses_error_envelope() {
 
     let signer = TestSigner::new();
     let (_account_id, account_id_hex, _initial_state) = load_fixture_account();
-    let uri = format!("/get_state?account_id={account_id_hex}");
+    let uri = format!("/state?account_id={account_id_hex}");
 
     let request = Request::builder()
         .uri(uri)
@@ -190,7 +190,7 @@ async fn get_delta_proposal_error_uses_error_envelope() {
 
     let signer = TestSigner::new();
     let (_account_id, account_id_hex, _initial_state) = load_fixture_account();
-    let uri = format!("/get_delta_proposal?account_id={account_id_hex}&commitment=0xmissing");
+    let uri = format!("/delta/proposal/single?account_id={account_id_hex}&commitment=0xmissing");
 
     let request = Request::builder()
         .uri(uri)
@@ -266,7 +266,7 @@ async fn push_delta_proposal_on_paused_account_returns_409_envelope() {
     });
     let (sig2, ts2) = signer.sign_json_payload(&account_id_hex, &proposal_body);
     let push_req = Request::builder()
-        .uri("/push_delta_proposal")
+        .uri("/delta/proposal")
         .method("POST")
         .header(header::CONTENT_TYPE, "application/json")
         .header("x-pubkey", &signer.pubkey_hex)
@@ -330,7 +330,7 @@ async fn get_delta_proposals_error_uses_error_envelope() {
 
     let signer = TestSigner::new();
     let (_account_id, account_id_hex, _initial_state) = load_fixture_account();
-    let uri = format!("/get_delta_proposals?account_id={account_id_hex}");
+    let uri = format!("/delta/proposal?account_id={account_id_hex}");
 
     let request = Request::builder()
         .uri(uri)
@@ -365,8 +365,8 @@ async fn sign_delta_proposal_error_uses_error_envelope() {
     });
 
     let request = Request::builder()
-        .uri("/sign_delta_proposal")
-        .method("POST")
+        .uri("/delta/proposal")
+        .method("PUT")
         .header(header::CONTENT_TYPE, "application/json")
         .header("x-pubkey", &signer.pubkey_hex)
         .header("x-signature", format!("0x{}", "ab".repeat(666)))

--- a/crates/server/src/testing/integration/metrics_http.rs
+++ b/crates/server/src/testing/integration/metrics_http.rs
@@ -8,13 +8,13 @@
 //! and never installed globally (the global recorder is process-wide
 //! and set-once; see `crate::metrics::recorder`).
 
+use crate::builder::handle::{HttpRouterConfig, build_http_router};
 use crate::metrics::config::MetricsConfig;
 use crate::metrics::recorder::build_recorder;
 use crate::metrics::refresher::{apply_snapshot, fetch_snapshot};
 use crate::metrics::router::metrics_router;
 use crate::metrics::storage::InstrumentedStorage;
-use crate::metrics::track_http;
-use crate::testing::helpers::{create_router, create_test_app_state};
+use crate::testing::helpers::{create_router, create_test_app_state, test_router_config};
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode, header};
@@ -45,14 +45,22 @@ fn run_scrape_scenario() -> String {
             let mut state = create_test_app_state().await;
             state.storage = Arc::new(InstrumentedStorage::new(state.storage));
 
-            let app = create_router(state.clone()).layer(axum::middleware::from_fn(track_http));
+            // `metrics_enabled` rather than a hand-stacked `track_http`,
+            // so the layer under test is the one production installs.
+            let app = build_http_router(
+                state.clone(),
+                HttpRouterConfig {
+                    metrics_enabled: true,
+                    ..test_router_config()
+                },
+            );
 
             // Known route, unmatched route, and a templated dashboard
             // route with a raw account id in the path.
             for uri in [
                 "/pubkey",
                 "/definitely-not-a-route",
-                "/state?account_id=0xabc123",
+                "/dashboard/accounts/0xabc123",
             ] {
                 let _ = app
                     .clone()
@@ -102,6 +110,16 @@ fn scrape_exposes_http_storage_and_aggregate_metrics() {
     assert!(
         !exposition.contains("definitely-not-a-route"),
         "raw unmatched path leaked into labels"
+    );
+    // Templated routes are labelled by their `MatchedPath`, so a raw
+    // account id never becomes its own series.
+    assert!(
+        exposition.contains("route=\"/dashboard/accounts/{account_id}\""),
+        "missing templated dashboard route label in:\n{exposition}"
+    );
+    assert!(
+        !exposition.contains("0xabc123"),
+        "raw account id leaked into labels"
     );
     assert!(exposition.contains("guardian_http_request_duration_seconds_bucket"));
 

--- a/crates/server/src/testing/integration/mod.rs
+++ b/crates/server/src/testing/integration/mod.rs
@@ -3,6 +3,7 @@
 
 mod auth_grpc;
 mod auth_http;
+mod body_limit_http;
 mod error_envelope_http;
 mod lookup_grpc;
 mod lookup_helpers;

--- a/crates/server/src/testing/integration/proposals_http.rs
+++ b/crates/server/src/testing/integration/proposals_http.rs
@@ -61,7 +61,7 @@ async fn test_push_delta_proposal_success() {
     let (signature_hex_2, timestamp_2) = signer.sign_json_payload(&account_id_hex, &proposal_body);
 
     let push_proposal_request = Request::builder()
-        .uri("/push_delta_proposal")
+        .uri("/delta/proposal")
         .method("POST")
         .header(header::CONTENT_TYPE, "application/json")
         .header("x-pubkey", &signer.pubkey_hex)
@@ -118,10 +118,7 @@ async fn test_get_delta_proposals_empty() {
     let query_payload = json!({ "account_id": account_id_hex.clone() });
     let (signature_hex_2, timestamp_2) = signer.sign_json_payload(&account_id_hex, &query_payload);
     let get_proposals_request = Request::builder()
-        .uri(format!(
-            "/get_delta_proposals?account_id={}",
-            account_id_hex
-        ))
+        .uri(format!("/delta/proposal?account_id={}", account_id_hex))
         .method("GET")
         .header("x-pubkey", &signer.pubkey_hex)
         .header("x-signature", &signature_hex_2)
@@ -186,7 +183,7 @@ async fn test_get_delta_proposals_with_proposals() {
     let (signature_hex_2, timestamp_2) = signer.sign_json_payload(&account_id_hex, &proposal_body);
 
     let push_proposal_request = Request::builder()
-        .uri("/push_delta_proposal")
+        .uri("/delta/proposal")
         .method("POST")
         .header(header::CONTENT_TYPE, "application/json")
         .header("x-pubkey", &signer.pubkey_hex)
@@ -202,10 +199,7 @@ async fn test_get_delta_proposals_with_proposals() {
     let query_payload = json!({ "account_id": account_id_hex.clone() });
     let (signature_hex_3, timestamp_3) = signer.sign_json_payload(&account_id_hex, &query_payload);
     let get_proposals_request = Request::builder()
-        .uri(format!(
-            "/get_delta_proposals?account_id={}",
-            account_id_hex
-        ))
+        .uri(format!("/delta/proposal?account_id={}", account_id_hex))
         .method("GET")
         .header("x-pubkey", &signer.pubkey_hex)
         .header("x-signature", &signature_hex_3)
@@ -264,7 +258,7 @@ async fn test_get_delta_proposal_by_commitment() {
     let (signature_hex_2, timestamp_2) = signer.sign_json_payload(&account_id_hex, &proposal_body);
 
     let push_proposal_request = Request::builder()
-        .uri("/push_delta_proposal")
+        .uri("/delta/proposal")
         .method("POST")
         .header(header::CONTENT_TYPE, "application/json")
         .header("x-pubkey", &signer.pubkey_hex)
@@ -289,7 +283,7 @@ async fn test_get_delta_proposal_by_commitment() {
     let (signature_hex_3, timestamp_3) = signer.sign_json_payload(&account_id_hex, &query_payload);
     let get_proposal_request = Request::builder()
         .uri(format!(
-            "/get_delta_proposal?account_id={}&commitment={}",
+            "/delta/proposal/single?account_id={}&commitment={}",
             account_id_hex, commitment
         ))
         .method("GET")
@@ -353,8 +347,8 @@ async fn test_sign_delta_proposal_not_found() {
         signer.sign_json_payload(&account_id_hex, &sign_body);
 
     let sign_proposal_request = Request::builder()
-        .uri("/sign_delta_proposal")
-        .method("POST")
+        .uri("/delta/proposal")
+        .method("PUT")
         .header(header::CONTENT_TYPE, "application/json")
         .header("x-pubkey", &signer.pubkey_hex)
         .header("x-signature", &signer_signature_2)
@@ -426,7 +420,7 @@ async fn test_push_delta_proposal_unauthorized() {
         unauthorized_signer.sign_json_payload(&account_id_hex, &proposal_body);
 
     let push_proposal_request = Request::builder()
-        .uri("/push_delta_proposal")
+        .uri("/delta/proposal")
         .method("POST")
         .header(header::CONTENT_TYPE, "application/json")
         .header("x-pubkey", &unauthorized_signer.pubkey_hex)

--- a/crates/server/src/testing/integration/rate_limit_http.rs
+++ b/crates/server/src/testing/integration/rate_limit_http.rs
@@ -1,5 +1,6 @@
-use crate::middleware::{RateLimitConfig, RateLimitLayer, RateLimitStore};
-use crate::testing::helpers::{create_router, create_test_app_state};
+use crate::builder::handle::{HttpRouterConfig, build_http_router};
+use crate::middleware::{RateLimitConfig, RateLimitStore};
+use crate::testing::helpers::{create_test_app_state, test_router_config};
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
@@ -24,9 +25,13 @@ fn build_get_request(uri: &str, ip: &str, pubkey: Option<&str>) -> Request<Body>
 #[tokio::test]
 async fn test_rate_limit_burst_per_endpoint() {
     let state = create_test_app_state().await;
-    let app = create_router(state).layer(RateLimitLayer::new(RateLimitStore::new(
-        RateLimitConfig::new(2, 1000),
-    )));
+    let app = build_http_router(
+        state,
+        HttpRouterConfig {
+            rate_limit_store: RateLimitStore::new(RateLimitConfig::new(2, 1000)),
+            ..test_router_config()
+        },
+    );
 
     let ip = "1.2.3.4";
     let req1 = build_get_request("/pubkey", ip, None);
@@ -44,7 +49,7 @@ async fn test_rate_limit_burst_per_endpoint() {
     let res_other = app
         .clone()
         .oneshot(build_get_request(
-            "/get_state?account_id=0x01",
+            "/state?account_id=0x01",
             ip,
             Some("pubkey-1"),
         ))
@@ -57,9 +62,13 @@ async fn test_rate_limit_burst_per_endpoint() {
 #[tokio::test]
 async fn test_rate_limit_sustained_per_ip_even_with_different_signers() {
     let state = create_test_app_state().await;
-    let app = create_router(state).layer(RateLimitLayer::new(RateLimitStore::new(
-        RateLimitConfig::new(100, 2),
-    )));
+    let app = build_http_router(
+        state,
+        HttpRouterConfig {
+            rate_limit_store: RateLimitStore::new(RateLimitConfig::new(100, 2)),
+            ..test_router_config()
+        },
+    );
 
     let ip = "5.6.7.8";
     let pubkeys = ["pubkey-a", "pubkey-b", "pubkey-c"];
@@ -67,7 +76,7 @@ async fn test_rate_limit_sustained_per_ip_even_with_different_signers() {
     let res1 = app
         .clone()
         .oneshot(build_get_request(
-            "/get_state?account_id=0x01",
+            "/state?account_id=0x01",
             ip,
             Some(pubkeys[0]),
         ))
@@ -76,7 +85,7 @@ async fn test_rate_limit_sustained_per_ip_even_with_different_signers() {
     let res2 = app
         .clone()
         .oneshot(build_get_request(
-            "/get_state?account_id=0x01",
+            "/state?account_id=0x01",
             ip,
             Some(pubkeys[1]),
         ))
@@ -85,7 +94,7 @@ async fn test_rate_limit_sustained_per_ip_even_with_different_signers() {
     let res3 = app
         .clone()
         .oneshot(build_get_request(
-            "/get_state?account_id=0x01",
+            "/state?account_id=0x01",
             ip,
             Some(pubkeys[2]),
         ))
@@ -100,9 +109,13 @@ async fn test_rate_limit_sustained_per_ip_even_with_different_signers() {
 #[tokio::test]
 async fn test_rate_limit_spoofed_forwarded_prefix_does_not_mint_a_budget() {
     let state = create_test_app_state().await;
-    let app = create_router(state).layer(RateLimitLayer::new(RateLimitStore::new(
-        RateLimitConfig::new(2, 1000),
-    )));
+    let app = build_http_router(
+        state,
+        HttpRouterConfig {
+            rate_limit_store: RateLimitStore::new(RateLimitConfig::new(2, 1000)),
+            ..test_router_config()
+        },
+    );
 
     let res1 = app
         .clone()

--- a/docs/LOCAL_DEV.md
+++ b/docs/LOCAL_DEV.md
@@ -172,7 +172,7 @@ The deploy script builds with `postgres,evm` when the EVM stack is requested
 ## Verifying the server is up
 
 ```bash
-curl http://localhost:3000/                   # liveness
+curl http://localhost:3000/                   # liveness (alias of /status)
 curl http://localhost:3000/pubkey             # ACK key commitment
 grpcurl -plaintext \
   -import-path crates/server/proto -proto guardian.proto \

--- a/docs/OPENAPI.md
+++ b/docs/OPENAPI.md
@@ -38,8 +38,8 @@ The specs declare security schemes so tools render auth correctly:
 
 - **Client API** — three required `apiKey` headers, `x-pubkey`,
   `x-signature`, `x-timestamp` (see [`spec/api.md`](../spec/api.md)
-  "Miden Request Signing"). Public endpoints (`/pubkey`) carry no
-  requirement.
+  "Miden Request Signing"). Public endpoints (`/pubkey`, `/status`, and
+  its root alias `/`) carry no requirement.
 - **Dashboard API** — the `guardian_operator_session` cookie
   (`operator_session`). The login challenge/verify endpoints are public.
 - **EVM API** — the `guardian_evm_session` cookie (`evm_session`). The

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -29,7 +29,7 @@ This launches the server with the filesystem backend. HTTP binds on
 ## Verify
 
 ```bash
-curl http://localhost:3000/                   # liveness — expect 200 OK
+curl http://localhost:3000/                   # liveness — same body as /status, expect 200 OK
 curl http://localhost:3000/pubkey             # expect { "commitment": "0x..." }
 ```
 

--- a/docs/openapi-client.json
+++ b/docs/openapi-client.json
@@ -10,6 +10,47 @@
     "version": "0.16.2"
   },
   "paths": {
+    "/": {
+      "get": {
+        "tags": [
+          "client"
+        ],
+        "summary": "Alias of `GET /status` mounted at the site root. Health checks and\nload balancers that probe `/` get the same machine-readable status\nbody, with the identical response shape and no authentication.",
+        "operationId": "status_root",
+        "responses": {
+          "200": {
+            "description": "Alias of `GET /status`: server liveness, version, and environment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Request body exceeds the configured size limit",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/configure": {
       "post": {
         "tags": [

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -10,6 +10,47 @@
     "version": "0.16.2"
   },
   "paths": {
+    "/": {
+      "get": {
+        "tags": [
+          "client"
+        ],
+        "summary": "Alias of `GET /status` mounted at the site root. Health checks and\nload balancers that probe `/` get the same machine-readable status\nbody, with the identical response shape and no authentication.",
+        "operationId": "status_root",
+        "responses": {
+          "200": {
+            "description": "Alias of `GET /status`: server liveness, version, and environment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Request body exceeds the configured size limit",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/auth/challenge": {
       "get": {
         "tags": [

--- a/spec/api.md
+++ b/spec/api.md
@@ -282,6 +282,8 @@ component schemas.
 | client | `GET /state` | signed headers | Latest canonical state |
 | client | `GET /state/lookup` | lookup signing (PoP) | Resolve a key commitment to account IDs |
 | client | `GET /pubkey` | public | ACK public key / commitment |
+| client | `GET /status` | public | Server liveness, version, environment, uptime |
+| client | `GET /` | public | Alias of `GET /status` |
 | client | `POST /delta/proposal` | signed headers | Create a multisig proposal |
 | client | `GET /delta/proposal` | signed headers | List pending proposals |
 | client | `GET /delta/proposal/single` | signed headers | Fetch one proposal by commitment |


### PR DESCRIPTION
Closes #403.

`GET /` returned a hard-coded `"Hello, World!"` while `GET /status` already served unauthenticated, machine-readable health information. Root probes now get the same status body: version, git commit, environment, start time, uptime.

## Changes

- `crates/server/src/api/http.rs` — new `status_root` handler delegating to `status`, so both routes return identical bodies by construction. It carries its own `#[utoipa::path(get, path = "/")]` annotation; routing `/` straight to `get(status)` would have left the root undocumented.
- `crates/server/src/builder/handle.rs` — `root()` and the `"Hello, World!"` literal removed; `.route("/", get(status_root))`.
- `crates/server/src/openapi.rs` — `status_root` registered on `ClientApiDoc`. The spec test now asserts `/` is present and carries no security requirement.
- `crates/server/src/testing/helpers.rs` — the test router mounts `/`, so the equivalence test exercises real axum routing rather than calling the handler directly.
- `docs/openapi.json`, `docs/openapi-client.json` — regenerated with `cargo run --features evm --bin gen-openapi -- docs`.
- `spec/api.md` — endpoint catalog gains `GET /` and `GET /status` (the latter was missing from the table entirely).
- `docs/QUICKSTART.md`, `docs/LOCAL_DEV.md` — the `curl http://localhost:3000/` liveness lines now say what comes back.

## Breaking change

`GET /` changes content type and body: `text/plain` `"Hello, World!"` becomes `application/json` `StatusResponse`. The status code is unchanged (200) and the route stays unauthenticated, so status-code-only health checks are unaffected.

Verified nothing consumes the old body:

- `infra/alb.tf` target group health-checks `path = "/"` with `matcher = "200"`, status code only.
- The Caddy health probe targets `/`, status code only.
- No code in `crates/`, `packages/`, or `examples/` requests the bare root, and no `Hello, World` string remains in the repo.

Anyone with an external monitor asserting on the response body will need to update it.

## Client parity (deliberate skip)

`packages/guardian-client` already exposes `getStatus()` against `/status` (`src/http.ts:243`, tested at `src/http.test.ts:135`). No client change is needed, and adding a second method pointing at `/` would be a redundant path to identical data, so none was added.

Noting a pre-existing asymmetry found while checking this: `crates/client` has no status method at all, while the TypeScript client does. Out of scope here.

## Testing

- `root_route_returns_the_status_body_without_auth` (`crates/server/src/api/http.rs`) asserts both routes return 200 unauthenticated with byte-identical JSON. `uptime_seconds` is asserted to be a number rather than compared for equality: it comes off the system clock, so two back-to-back requests can straddle a second boundary. Every other field is compared exactly.
- `openapi_spec_builds_and_serializes` asserts `/` is documented and public.
- `cargo test -p guardian-server --lib` — 855 passed, 0 failed.
- `cargo clippy -p guardian-server --all-targets --features evm` — clean.
- `cargo fmt --all -- --check` — clean.
- `cargo run --features evm --bin gen-openapi -- --check docs` — specs in sync (the `OpenAPI Spec Drift` CI job).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public `GET /` endpoint that returns the same status information as `GET /status`.
  * Documented the endpoint in the API catalog and OpenAPI specifications.
* **Documentation**
  * Updated local development and quickstart guides with the new liveness-check alias.
* **Tests**
  * Added coverage confirming both endpoints return equivalent successful responses.
  * Verified the endpoint is publicly accessible in the API specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->