### PR TITLE
chore: Add Postgres CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,13 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@4a44d353abec8bd780e47de38e5bc5ea77053391 # cargo-llvm-cov
 
+      # guardian-server/postgres is enabled so the ~50 tests behind that feature
+      # which need no database (TLS mode resolution, certificate verification,
+      # credential redaction, fail-closed store guards, the test-database name
+      # guard) actually execute. Clippy and Build compile them via --all-features
+      # but run nothing, and no other job enables the feature, so before this
+      # they ran in no job at all. The database-backed tests stay #[ignore] here
+      # and run in the postgres-test job, so this job needs no database.
       - name: Run tests with coverage
         run: >-
           cargo llvm-cov
@@ -78,6 +85,7 @@ jobs:
           --exclude guardian-server-bench-loadgen
           --exclude guardian-demo
           --exclude guardian-rust-example
+          --features guardian-server/postgres
           --lcov
           --output-path lcov.info
 
@@ -141,6 +149,60 @@ jobs:
           --lib
           --features authz-test-probe
           api::dashboard::tests::authz_probe::
+
+  postgres-test:
+    name: Postgres Test Suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    if: github.repository_owner == 'OpenZeppelin'
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: guardian
+          POSTGRES_PASSWORD: guardian
+          POSTGRES_DB: guardian_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U guardian -d guardian_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@351f82a4dc29e4159746a068ed925da17341219f # 1.89.0
+        with:
+          toolchain: 1.93.0
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libpq-dev
+
+      - name: Cache cargo
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-postgres-test-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-postgres-test-
+
+      - name: Run Postgres-backed tests
+        env:
+          DATABASE_URL: postgres://guardian:guardian@localhost:5432/guardian_test
+        run: ./scripts/test-postgres.sh
 
   npm-test:
     name: TypeScript Package Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,10 +247,10 @@ jobs:
           DATABASE_URL: postgres://guardian:guardian@localhost:5432/guardian_test
         run: ./scripts/test-postgres.sh
 
-      # The script runs only ignored database-backed tests. Run the remaining
-      # Postgres-feature tests here, reusing the binary compiled above.
-      - name: Run Postgres feature tests
-        run: cargo test -p guardian-server --lib --features postgres
+      # Cover tests compiled only with the Postgres feature without rerunning
+      # the full default-feature suite already exercised by the coverage job.
+      - name: Run Postgres feature unit tests
+        run: cargo test -p guardian-server --lib --features postgres -- postgres
 
   npm-test:
     name: TypeScript Package Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,13 +70,6 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@4a44d353abec8bd780e47de38e5bc5ea77053391 # cargo-llvm-cov
 
-      # guardian-server/postgres is enabled so the ~50 tests behind that feature
-      # which need no database (TLS mode resolution, certificate verification,
-      # credential redaction, fail-closed store guards, the test-database name
-      # guard) actually execute. Clippy and Build compile them via --all-features
-      # but run nothing, and no other job enables the feature, so before this
-      # they ran in no job at all. The database-backed tests stay #[ignore] here
-      # and run in the postgres-test job, so this job needs no database.
       - name: Run tests with coverage
         run: >-
           cargo llvm-cov
@@ -85,9 +78,13 @@ jobs:
           --exclude guardian-server-bench-loadgen
           --exclude guardian-demo
           --exclude guardian-rust-example
-          --features guardian-server/postgres
           --lcov
           --output-path lcov.info
+
+      # Run the non-database tests behind guardian-server/postgres separately.
+      # Database-backed tests stay ignored here and run in postgres-test.
+      - name: Run Postgres feature tests
+        run: cargo test -p guardian-server --lib --features postgres
 
       # llvm-cov doctest coverage requires nightly, so doctests run as a
       # separate uninstrumented step.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,11 +81,6 @@ jobs:
           --lcov
           --output-path lcov.info
 
-      # Run the non-database tests behind guardian-server/postgres separately.
-      # Database-backed tests stay ignored here and run in postgres-test.
-      - name: Run Postgres feature tests
-        run: cargo test -p guardian-server --lib --features postgres
-
       # llvm-cov doctest coverage requires nightly, so doctests run as a
       # separate uninstrumented step.
       - name: Run doctests
@@ -251,6 +246,11 @@ jobs:
         env:
           DATABASE_URL: postgres://guardian:guardian@localhost:5432/guardian_test
         run: ./scripts/test-postgres.sh
+
+      # The script runs only ignored database-backed tests. Run the remaining
+      # Postgres-feature tests here, reusing the binary compiled above.
+      - name: Run Postgres feature tests
+        run: cargo test -p guardian-server --lib --features postgres
 
   npm-test:
     name: TypeScript Package Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,57 @@ jobs:
           --features authz-test-probe
           api::dashboard::tests::authz_probe::
 
+  server-feature-tests:
+    name: Server Integration and E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    if: github.repository_owner == 'OpenZeppelin'
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@351f82a4dc29e4159746a068ed925da17341219f # 1.89.0
+        with:
+          toolchain: 1.93.0
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libpq-dev
+
+      - name: Cache cargo
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-server-feature-tests-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-server-feature-tests-
+
+      - name: Run server integration tests
+        run: >-
+          cargo test
+          -p guardian-server
+          --lib
+          --features integration,e2e
+          testing::integration::
+
+      - name: Run server E2E tests
+        run: >-
+          cargo test
+          -p guardian-server
+          --lib
+          --features integration,e2e
+          testing::e2e::
+
   postgres-test:
     name: Postgres Test Suite
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ Use this when changing endpoints, payloads, status enums, signatures, or auth be
 - Maintain storage/metadata backend parity (filesystem/postgres where applicable).
 - Preserve canonicalization semantics (pending/candidate/canonical/discarded lifecycle).
 - Default local development/test backend is `filesystem` unless a task explicitly requires Postgres.
-- Put database-backed ignored tests under a module path containing `postgres`; `scripts/test-postgres.sh` discovers them using that module-path filter.
+- Put tests compiled only with the `postgres` feature under a module path containing `postgres`. Mark live-database tests ignored; `scripts/test-postgres.sh` discovers the ignored tests using that module-path filter.
 - Keep shared server layers network-agnostic. Put Miden/EVM-specific logic in `src/network/*`, and dispatch from services/builders via account network config rather than embedding network-specific assumptions in shared modules.
 - Secret-bearing fields (keys, tokens, credential URLs, DB/RPC URLs) must use a wrapper from `src/secret/` (`FixedKey<N>`, `SecretBytes`, `SecretString`, `CredentialUrl`) — never bind a raw `String`/`Vec<u8>` to a config field or struct. Read-and-wrap in one expression. See `CONTRIBUTING.md` ("Secrets in server memory").
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,7 @@ Use this when changing endpoints, payloads, status enums, signatures, or auth be
 - Maintain storage/metadata backend parity (filesystem/postgres where applicable).
 - Preserve canonicalization semantics (pending/candidate/canonical/discarded lifecycle).
 - Default local development/test backend is `filesystem` unless a task explicitly requires Postgres.
+- Put database-backed ignored tests under a module path containing `postgres`; `scripts/test-postgres.sh` discovers them using that module-path filter.
 - Keep shared server layers network-agnostic. Put Miden/EVM-specific logic in `src/network/*`, and dispatch from services/builders via account network config rather than embedding network-specific assumptions in shared modules.
 - Secret-bearing fields (keys, tokens, credential URLs, DB/RPC URLs) must use a wrapper from `src/secret/` (`FixedKey<N>`, `SecretBytes`, `SecretString`, `CredentialUrl`) — never bind a raw `String`/`Vec<u8>` to a config field or struct. Read-and-wrap in one expression. See `CONTRIBUTING.md` ("Secrets in server memory").
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,7 +124,9 @@ The Postgres-backed server tests stay `#[ignore]`, so `cargo test --workspace`
 skips them; `scripts/test-postgres.sh` is what opts in. Each run starts by
 dropping and recreating the schema, so no run inherits state from an earlier
 one, and it refuses any database whose name does not end in `_test` so it cannot
-destroy your development data. See
+destroy your development data. Database-backed ignored tests must live under a
+module path containing `postgres`; the script discovers them using that module
+path filter. See
 [LOCAL_DEV.md](./docs/LOCAL_DEV.md#postgres-backed-tests).
 
 CI enforces tests and doctests for the core Rust workspace crates, excluding

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,10 @@ cargo test --workspace
 cargo test -p guardian-server --features integration
 cargo test -p guardian-server --features e2e
 
+# Postgres-backed server tests (needs a running Postgres, see LOCAL_DEV.md)
+POSTGRES_PASSWORD=guardian docker compose -f docker-compose.postgres.yml up -d postgres
+./scripts/test-postgres.sh
+
 # TypeScript (per package)
 cd packages/guardian-client && npm install && npm test
 cd packages/miden-multisig-client && npm install && npm test
@@ -116,9 +120,17 @@ cd examples/demo && cargo run --release   # Rust TUI multisig flow
 # smoke-web / operator-smoke-web / evm-smoke-web have their own READMEs
 ```
 
+The Postgres-backed server tests stay `#[ignore]`, so `cargo test --workspace`
+skips them; `scripts/test-postgres.sh` is what opts in. Each run starts by
+dropping and recreating the schema, so no run inherits state from an earlier
+one, and it refuses any database whose name does not end in `_test` so it cannot
+destroy your development data. See
+[LOCAL_DEV.md](./docs/LOCAL_DEV.md#postgres-backed-tests).
+
 CI enforces tests and doctests for the core Rust workspace crates, excluding
 benchmark and example members, plus formatting, clippy, and the build and test
-scripts for all TypeScript packages. Run the matching checks locally before
+scripts for all TypeScript packages. The Postgres-backed tests run in their own
+job against a service container. Run the matching checks locally before
 pushing when you touch a package or browser example.
 
 For UI / SDK changes you cannot fully verify with `cargo test` alone,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,9 +124,9 @@ The Postgres-backed server tests stay `#[ignore]`, so `cargo test --workspace`
 skips them; `scripts/test-postgres.sh` is what opts in. Each run starts by
 dropping and recreating the schema, so no run inherits state from an earlier
 one, and it refuses any database whose name does not end in `_test` so it cannot
-destroy your development data. Database-backed ignored tests must live under a
-module path containing `postgres`; the script discovers them using that module
-path filter. See
+destroy your development data. Tests compiled only with the `postgres` feature
+must live under a module path containing `postgres`. Live-database tests must
+also be ignored; the script discovers them using that module-path filter. See
 [LOCAL_DEV.md](./docs/LOCAL_DEV.md#postgres-backed-tests).
 
 CI enforces tests and doctests for the core Rust workspace crates, excluding

--- a/README.md
+++ b/README.md
@@ -156,6 +156,17 @@ cargo test -p guardian-server --features integration
 cargo test -p guardian-server --features e2e
 ```
 
+Postgres-backed tests stay `#[ignore]` and need a live database, so they run
+through their own script:
+
+```bash
+POSTGRES_PASSWORD=guardian docker compose -f docker-compose.postgres.yml up -d postgres
+./scripts/test-postgres.sh
+```
+
+See [LOCAL_DEV.md](./docs/LOCAL_DEV.md#postgres-backed-tests) for the reset and
+safety behaviour.
+
 #### TypeScript Tests
 
 ```bash

--- a/crates/server/src/audit/postgres.rs
+++ b/crates/server/src/audit/postgres.rs
@@ -204,7 +204,7 @@ mod tests {
     #[tokio::test]
     async fn postgres_write_failure_emits_log_fallback() {
         let pool = build_postgres_pool_lazy(
-            "postgresql://127.0.0.1:1/__guardian_fault_injection_test__",
+            "postgresql://127.0.0.1:1/__guardian_fault_injection_test__?connect_timeout=1",
             1,
         )
         .expect("lazy pool builds even with bad URL");
@@ -219,18 +219,10 @@ mod tests {
             .with_ansi(false)
             .finish();
 
-        // tokio-spawned work inherits the calling task's subscriber
-        // context when we set it as the default for the duration of
-        // the spawn. Use `with_default` to scope.
         let _registry_pin = crate::testing::log_capture::dispatcher_registry_pin();
-        tracing::subscriber::with_default(subscriber, || {
-            // Spawn + await synchronously inside the scope so all
-            // tracing events from the spawned task land in `writer`.
-            futures::executor::block_on(async {
-                let handle = auditor.record_with_handle(sample_event());
-                handle.await.expect("spawned task should not panic");
-            });
-        });
+        let _subscriber_guard = tracing::subscriber::set_default(subscriber);
+        let handle = auditor.record_with_handle(sample_event());
+        handle.await.expect("spawned task should not panic");
 
         let captured = writer.contents();
         // The fallback path emits two events: the db_error breadcrumb

--- a/crates/server/src/audit/postgres.rs
+++ b/crates/server/src/audit/postgres.rs
@@ -249,23 +249,18 @@ mod tests {
         );
     }
 
-    /// T040 (FR-026 / SC-009): the Postgres append-only trigger
-    /// `admin_actions_no_update` MUST block UPDATE and DELETE on a
-    /// persisted row. Marked `#[ignore]` because it requires a live
-    /// Postgres reachable at `DATABASE_URL` with the migration
-    /// applied — run via `cargo test -p guardian-server --lib
-    /// --features authz-test-probe -- --ignored postgres_trigger`.
+    /// The Postgres append-only trigger `admin_actions_no_update` must block
+    /// UPDATE and DELETE on a persisted row. Run via
+    /// `./scripts/test-postgres.sh`.
     #[tokio::test]
-    #[ignore = "requires DATABASE_URL with migrations applied"]
+    #[ignore = "requires Postgres; run ./scripts/test-postgres.sh"]
     async fn postgres_trigger_blocks_update_and_delete() {
         use diesel::ExpressionMethods;
         use diesel::QueryDsl;
         use diesel_async::RunQueryDsl;
 
-        let database_url = crate::secret::CredentialUrl::new(
-            std::env::var("DATABASE_URL")
-                .expect("DATABASE_URL must be set; this test is marked #[ignore] by default"),
-        );
+        let database_url =
+            crate::secret::CredentialUrl::new(crate::testing::pg::test_database_url().await);
         let raw_url = database_url.expose_secret();
         crate::storage::postgres::run_migrations(raw_url)
             .await

--- a/crates/server/src/audit/postgres.rs
+++ b/crates/server/src/audit/postgres.rs
@@ -262,9 +262,6 @@ mod tests {
         let database_url =
             crate::secret::CredentialUrl::new(crate::testing::pg::test_database_url().await);
         let raw_url = database_url.expose_secret();
-        crate::storage::postgres::run_migrations(raw_url)
-            .await
-            .expect("migrations run");
         let pool = build_postgres_pool_lazy(raw_url, 1).expect("pool builds");
         // Sanity: prove the pool is reachable; if not, abort early
         // with a clear error rather than a confusing trigger failure.

--- a/crates/server/src/audit/postgres.rs
+++ b/crates/server/src/audit/postgres.rs
@@ -241,9 +241,9 @@ mod tests {
         );
     }
 
-    /// The Postgres append-only trigger `admin_actions_no_update` must block
-    /// UPDATE and DELETE on a persisted row. Run via
-    /// `./scripts/test-postgres.sh`.
+    /// FR-026 / SC-009: the Postgres append-only trigger
+    /// `admin_actions_no_update` must block UPDATE and DELETE on a persisted
+    /// row. Run via `./scripts/test-postgres.sh`.
     #[tokio::test]
     #[ignore = "requires Postgres; run ./scripts/test-postgres.sh"]
     async fn postgres_trigger_blocks_update_and_delete() {

--- a/crates/server/src/builder/storage.rs
+++ b/crates/server/src/builder/storage.rs
@@ -286,8 +286,6 @@ mod tests {
     use base64::engine::general_purpose::STANDARD as BASE64;
 
     static ENCRYPTION_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
-    #[cfg(feature = "postgres")]
-    static POOL_SIZE_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     struct EncEnvGuard;
 
@@ -588,76 +586,77 @@ mod tests {
     }
 
     #[cfg(feature = "postgres")]
-    #[tokio::test]
-    async fn test_build_without_database_url_fails() {
-        let builder = StorageMetadataBuilder::new();
+    mod postgres {
+        use super::*;
 
-        let result = builder.build().await;
-        assert!(result.is_err());
-        assert_eq!(
-            result.err().unwrap(),
-            "DATABASE_URL environment variable is required"
-        );
-    }
+        static POOL_SIZE_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-    #[cfg(feature = "postgres")]
-    #[tokio::test]
-    async fn test_build_with_empty_database_url_fails() {
-        let builder =
-            StorageMetadataBuilder::new().database_url(Some(CredentialUrl::new(String::new())));
+        #[tokio::test]
+        async fn test_build_without_database_url_fails() {
+            let builder = StorageMetadataBuilder::new();
 
-        let result = builder.build().await;
-        assert!(result.is_err());
-        assert_eq!(
-            result.err().unwrap(),
-            "DATABASE_URL environment variable is required"
-        );
-    }
+            let result = builder.build().await;
+            assert!(result.is_err());
+            assert_eq!(
+                result.err().unwrap(),
+                "DATABASE_URL environment variable is required"
+            );
+        }
 
-    #[cfg(feature = "postgres")]
-    #[test]
-    fn test_resolve_pool_size_uses_default_when_env_missing() {
-        let _lock = POOL_SIZE_ENV_LOCK
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
-        // SAFETY: serialized by POOL_SIZE_ENV_LOCK; this variable is private to this module.
-        unsafe { std::env::remove_var(ENV_DB_POOL_MAX_SIZE) };
-        let result = resolve_pool_size(None, ENV_DB_POOL_MAX_SIZE, 16).unwrap();
-        assert_eq!(result, 16);
-    }
+        #[tokio::test]
+        async fn test_build_with_empty_database_url_fails() {
+            let builder =
+                StorageMetadataBuilder::new().database_url(Some(CredentialUrl::new(String::new())));
 
-    #[cfg(feature = "postgres")]
-    #[test]
-    fn test_resolve_pool_size_uses_explicit_value() {
-        let result = resolve_pool_size(Some(24), ENV_DB_POOL_MAX_SIZE, 16).unwrap();
-        assert_eq!(result, 24);
-    }
+            let result = builder.build().await;
+            assert!(result.is_err());
+            assert_eq!(
+                result.err().unwrap(),
+                "DATABASE_URL environment variable is required"
+            );
+        }
 
-    #[cfg(feature = "postgres")]
-    #[test]
-    fn test_resolve_pool_size_reads_env_override() {
-        let _lock = POOL_SIZE_ENV_LOCK
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
-        // SAFETY: serialized by POOL_SIZE_ENV_LOCK; this variable is private to this module.
-        unsafe { std::env::set_var(ENV_DB_POOL_MAX_SIZE, "32") };
-        let result = resolve_pool_size(None, ENV_DB_POOL_MAX_SIZE, 16).unwrap();
-        // SAFETY: serialized by POOL_SIZE_ENV_LOCK; this variable is private to this module.
-        unsafe { std::env::remove_var(ENV_DB_POOL_MAX_SIZE) };
-        assert_eq!(result, 32);
-    }
+        #[test]
+        fn test_resolve_pool_size_uses_default_when_env_missing() {
+            let _lock = POOL_SIZE_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner());
+            // SAFETY: serialized by POOL_SIZE_ENV_LOCK; this variable is private to this module.
+            unsafe { std::env::remove_var(ENV_DB_POOL_MAX_SIZE) };
+            let result = resolve_pool_size(None, ENV_DB_POOL_MAX_SIZE, 16).unwrap();
+            assert_eq!(result, 16);
+        }
 
-    #[cfg(feature = "postgres")]
-    #[test]
-    fn test_resolve_pool_size_rejects_invalid_env_override() {
-        let _lock = POOL_SIZE_ENV_LOCK
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
-        // SAFETY: serialized by POOL_SIZE_ENV_LOCK; this variable is private to this module.
-        unsafe { std::env::set_var(ENV_DB_POOL_MAX_SIZE, "nope") };
-        let result = resolve_pool_size(None, ENV_DB_POOL_MAX_SIZE, 16);
-        // SAFETY: serialized by POOL_SIZE_ENV_LOCK; this variable is private to this module.
-        unsafe { std::env::remove_var(ENV_DB_POOL_MAX_SIZE) };
-        assert!(result.is_err());
+        #[test]
+        fn test_resolve_pool_size_uses_explicit_value() {
+            let result = resolve_pool_size(Some(24), ENV_DB_POOL_MAX_SIZE, 16).unwrap();
+            assert_eq!(result, 24);
+        }
+
+        #[test]
+        fn test_resolve_pool_size_reads_env_override() {
+            let _lock = POOL_SIZE_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner());
+            // SAFETY: serialized by POOL_SIZE_ENV_LOCK; this variable is private to this module.
+            unsafe { std::env::set_var(ENV_DB_POOL_MAX_SIZE, "32") };
+            let result = resolve_pool_size(None, ENV_DB_POOL_MAX_SIZE, 16).unwrap();
+            // SAFETY: serialized by POOL_SIZE_ENV_LOCK; this variable is private to this module.
+            unsafe { std::env::remove_var(ENV_DB_POOL_MAX_SIZE) };
+            assert_eq!(result, 32);
+        }
+
+        #[test]
+        fn test_resolve_pool_size_rejects_invalid_env_override() {
+            let _lock = POOL_SIZE_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner());
+            // SAFETY: serialized by POOL_SIZE_ENV_LOCK; this variable is private to this module.
+            unsafe { std::env::set_var(ENV_DB_POOL_MAX_SIZE, "nope") };
+            let result = resolve_pool_size(None, ENV_DB_POOL_MAX_SIZE, 16);
+            // SAFETY: serialized by POOL_SIZE_ENV_LOCK; this variable is private to this module.
+            unsafe { std::env::remove_var(ENV_DB_POOL_MAX_SIZE) };
+            assert!(result.is_err());
+        }
     }
 }

--- a/crates/server/src/builder/storage.rs
+++ b/crates/server/src/builder/storage.rs
@@ -286,6 +286,8 @@ mod tests {
     use base64::engine::general_purpose::STANDARD as BASE64;
 
     static ENCRYPTION_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+    #[cfg(feature = "postgres")]
+    static POOL_SIZE_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     struct EncEnvGuard;
 
@@ -615,9 +617,11 @@ mod tests {
     #[cfg(feature = "postgres")]
     #[test]
     fn test_resolve_pool_size_uses_default_when_env_missing() {
-        unsafe {
-            std::env::remove_var(ENV_DB_POOL_MAX_SIZE);
-        }
+        let _lock = POOL_SIZE_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        // SAFETY: serialized by POOL_SIZE_ENV_LOCK; this variable is private to this module.
+        unsafe { std::env::remove_var(ENV_DB_POOL_MAX_SIZE) };
         let result = resolve_pool_size(None, ENV_DB_POOL_MAX_SIZE, 16).unwrap();
         assert_eq!(result, 16);
     }
@@ -632,26 +636,28 @@ mod tests {
     #[cfg(feature = "postgres")]
     #[test]
     fn test_resolve_pool_size_reads_env_override() {
-        unsafe {
-            std::env::set_var(ENV_DB_POOL_MAX_SIZE, "32");
-        }
+        let _lock = POOL_SIZE_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        // SAFETY: serialized by POOL_SIZE_ENV_LOCK; this variable is private to this module.
+        unsafe { std::env::set_var(ENV_DB_POOL_MAX_SIZE, "32") };
         let result = resolve_pool_size(None, ENV_DB_POOL_MAX_SIZE, 16).unwrap();
-        unsafe {
-            std::env::remove_var(ENV_DB_POOL_MAX_SIZE);
-        }
+        // SAFETY: serialized by POOL_SIZE_ENV_LOCK; this variable is private to this module.
+        unsafe { std::env::remove_var(ENV_DB_POOL_MAX_SIZE) };
         assert_eq!(result, 32);
     }
 
     #[cfg(feature = "postgres")]
     #[test]
     fn test_resolve_pool_size_rejects_invalid_env_override() {
-        unsafe {
-            std::env::set_var(ENV_DB_POOL_MAX_SIZE, "nope");
-        }
+        let _lock = POOL_SIZE_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        // SAFETY: serialized by POOL_SIZE_ENV_LOCK; this variable is private to this module.
+        unsafe { std::env::set_var(ENV_DB_POOL_MAX_SIZE, "nope") };
         let result = resolve_pool_size(None, ENV_DB_POOL_MAX_SIZE, 16);
-        unsafe {
-            std::env::remove_var(ENV_DB_POOL_MAX_SIZE);
-        }
+        // SAFETY: serialized by POOL_SIZE_ENV_LOCK; this variable is private to this module.
+        unsafe { std::env::remove_var(ENV_DB_POOL_MAX_SIZE) };
         assert!(result.is_err());
     }
 }

--- a/crates/server/src/coordination/postgres/challenge_store.rs
+++ b/crates/server/src/coordination/postgres/challenge_store.rs
@@ -199,13 +199,8 @@ impl ChallengeStore for PgChallengeStore {
 mod tests {
     use super::*;
     use crate::storage::postgres::{build_postgres_pool_lazy, run_migrations};
+    use crate::testing::pg::test_database_url;
     use chrono::Duration;
-
-    fn database_url() -> Option<String> {
-        std::env::var("DATABASE_URL")
-            .ok()
-            .filter(|url| !url.trim().is_empty())
-    }
 
     #[tokio::test]
     async fn active_for_fails_closed_when_store_unreachable() {
@@ -219,9 +214,9 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "requires DATABASE_URL with migrations applied"]
+    #[ignore = "requires Postgres; run ./scripts/test-postgres.sh"]
     async fn challenge_is_single_use_across_replicas() {
-        let url = database_url().expect("DATABASE_URL must be set for this #[ignore] test");
+        let url = test_database_url().await;
         run_migrations(&url).await.expect("migrations apply");
         let replica_a = PgChallengeStore::new(
             build_postgres_pool_lazy(&url, 2).expect("pool a"),

--- a/crates/server/src/coordination/postgres/challenge_store.rs
+++ b/crates/server/src/coordination/postgres/challenge_store.rs
@@ -198,7 +198,7 @@ impl ChallengeStore for PgChallengeStore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::postgres::{build_postgres_pool_lazy, run_migrations};
+    use crate::storage::postgres::build_postgres_pool_lazy;
     use crate::testing::pg::test_database_url;
     use chrono::Duration;
 
@@ -217,7 +217,6 @@ mod tests {
     #[ignore = "requires Postgres; run ./scripts/test-postgres.sh"]
     async fn challenge_is_single_use_across_replicas() {
         let url = test_database_url().await;
-        run_migrations(&url).await.expect("migrations apply");
         let replica_a = PgChallengeStore::new(
             build_postgres_pool_lazy(&url, 2).expect("pool a"),
             Realm::Evm,

--- a/crates/server/src/coordination/postgres/challenge_store.rs
+++ b/crates/server/src/coordination/postgres/challenge_store.rs
@@ -204,8 +204,11 @@ mod tests {
 
     #[tokio::test]
     async fn active_for_fails_closed_when_store_unreachable() {
-        let pool = build_postgres_pool_lazy("postgresql://127.0.0.1:1/__guardian_coord_fault__", 1)
-            .expect("lazy pool builds even with an unreachable address");
+        let pool = build_postgres_pool_lazy(
+            "postgresql://127.0.0.1:1/__guardian_coord_fault__?connect_timeout=1",
+            1,
+        )
+        .expect("lazy pool builds even with an unreachable address");
         let store = PgChallengeStore::new(pool, Realm::Operator);
         assert!(
             store.active_for("0xprincipal", Utc::now()).await.is_err(),

--- a/crates/server/src/coordination/postgres/lease.rs
+++ b/crates/server/src/coordination/postgres/lease.rs
@@ -144,7 +144,7 @@ impl LeaderElector for PgLeaseElector {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::postgres::{build_postgres_pool_lazy, run_migrations};
+    use crate::storage::postgres::build_postgres_pool_lazy;
     use crate::testing::pg::test_database_url;
 
     #[tokio::test]
@@ -162,7 +162,6 @@ mod tests {
     #[ignore = "requires Postgres; run ./scripts/test-postgres.sh"]
     async fn single_owner_failover_fences_the_old_holder() {
         let url = test_database_url().await;
-        run_migrations(&url).await.expect("migrations apply");
         let name = format!("canon-test-{}", Utc::now().timestamp_micros());
         let short_ttl = Duration::from_secs(1);
         let ttl = Duration::from_secs(60);

--- a/crates/server/src/coordination/postgres/lease.rs
+++ b/crates/server/src/coordination/postgres/lease.rs
@@ -145,12 +145,7 @@ impl LeaderElector for PgLeaseElector {
 mod tests {
     use super::*;
     use crate::storage::postgres::{build_postgres_pool_lazy, run_migrations};
-
-    fn database_url() -> Option<String> {
-        std::env::var("DATABASE_URL")
-            .ok()
-            .filter(|url| !url.trim().is_empty())
-    }
+    use crate::testing::pg::test_database_url;
 
     #[tokio::test]
     async fn try_acquire_fails_closed_when_unreachable() {
@@ -164,9 +159,9 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "requires DATABASE_URL with migrations applied"]
+    #[ignore = "requires Postgres; run ./scripts/test-postgres.sh"]
     async fn single_owner_failover_fences_the_old_holder() {
-        let url = database_url().expect("DATABASE_URL must be set for this #[ignore] test");
+        let url = test_database_url().await;
         run_migrations(&url).await.expect("migrations apply");
         let name = format!("canon-test-{}", Utc::now().timestamp_micros());
         let short_ttl = Duration::from_secs(1);

--- a/crates/server/src/coordination/postgres/lease.rs
+++ b/crates/server/src/coordination/postgres/lease.rs
@@ -149,8 +149,11 @@ mod tests {
 
     #[tokio::test]
     async fn try_acquire_fails_closed_when_unreachable() {
-        let pool = build_postgres_pool_lazy("postgresql://127.0.0.1:1/__guardian_lease_fault__", 1)
-            .expect("lazy pool builds even with an unreachable address");
+        let pool = build_postgres_pool_lazy(
+            "postgresql://127.0.0.1:1/__guardian_lease_fault__?connect_timeout=1",
+            1,
+        )
+        .expect("lazy pool builds even with an unreachable address");
         let elector = PgLeaseElector::new(pool, "canonicalization", "replica-a");
         assert!(
             elector.try_acquire(Duration::from_secs(30)).await.is_err(),

--- a/crates/server/src/coordination/postgres/session_store.rs
+++ b/crates/server/src/coordination/postgres/session_store.rs
@@ -139,13 +139,8 @@ impl SessionStore for PgSessionStore {
 mod tests {
     use super::*;
     use crate::storage::postgres::{build_postgres_pool_lazy, run_migrations};
+    use crate::testing::pg::test_database_url;
     use chrono::Duration;
-
-    fn database_url() -> Option<String> {
-        std::env::var("DATABASE_URL")
-            .ok()
-            .filter(|url| !url.trim().is_empty())
-    }
 
     fn unique_key(now: DateTime<Utc>) -> SessionKey {
         let mut key = [0u8; 32];
@@ -165,9 +160,9 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "requires DATABASE_URL with migrations applied"]
+    #[ignore = "requires Postgres; run ./scripts/test-postgres.sh"]
     async fn session_visible_across_replicas_and_revoke_propagates() {
-        let url = database_url().expect("DATABASE_URL must be set for this #[ignore] test");
+        let url = test_database_url().await;
         run_migrations(&url).await.expect("migrations apply");
         let replica_a = PgSessionStore::new(
             build_postgres_pool_lazy(&url, 2).expect("pool a"),

--- a/crates/server/src/coordination/postgres/session_store.rs
+++ b/crates/server/src/coordination/postgres/session_store.rs
@@ -138,7 +138,7 @@ impl SessionStore for PgSessionStore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::postgres::{build_postgres_pool_lazy, run_migrations};
+    use crate::storage::postgres::build_postgres_pool_lazy;
     use crate::testing::pg::test_database_url;
     use chrono::Duration;
 
@@ -163,7 +163,6 @@ mod tests {
     #[ignore = "requires Postgres; run ./scripts/test-postgres.sh"]
     async fn session_visible_across_replicas_and_revoke_propagates() {
         let url = test_database_url().await;
-        run_migrations(&url).await.expect("migrations apply");
         let replica_a = PgSessionStore::new(
             build_postgres_pool_lazy(&url, 2).expect("pool a"),
             Realm::Operator,

--- a/crates/server/src/coordination/postgres/session_store.rs
+++ b/crates/server/src/coordination/postgres/session_store.rs
@@ -150,8 +150,11 @@ mod tests {
 
     #[tokio::test]
     async fn get_fails_closed_when_store_unreachable() {
-        let pool = build_postgres_pool_lazy("postgresql://127.0.0.1:1/__guardian_coord_fault__", 1)
-            .expect("lazy pool builds even with an unreachable address");
+        let pool = build_postgres_pool_lazy(
+            "postgresql://127.0.0.1:1/__guardian_coord_fault__?connect_timeout=1",
+            1,
+        )
+        .expect("lazy pool builds even with an unreachable address");
         let store = PgSessionStore::new(pool, Realm::Operator);
         assert!(
             store.get(&[7u8; 32], Utc::now()).await.is_err(),

--- a/crates/server/src/metadata/postgres.rs
+++ b/crates/server/src/metadata/postgres.rs
@@ -570,6 +570,53 @@ mod tests {
         LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
     }
 
+    /// Re-applies the newest migration if the reverting test does not reach its
+    /// own re-apply, so a panic mid-revert cannot leave the shared test schema
+    /// one migration behind for the rest of the run. `Drop` reports a failed
+    /// re-apply instead of panicking: unwinding out of `Drop` during another
+    /// panic aborts the whole test binary.
+    struct RevertedMigration {
+        url: String,
+        reapplied: bool,
+    }
+
+    impl RevertedMigration {
+        fn new(url: String) -> Self {
+            Self {
+                url,
+                reapplied: false,
+            }
+        }
+
+        fn defuse(mut self) {
+            self.reapplied = true;
+        }
+    }
+
+    impl Drop for RevertedMigration {
+        fn drop(&mut self) {
+            if self.reapplied {
+                return;
+            }
+            use diesel::Connection;
+            use diesel_migrations::MigrationHarness;
+            let outcome = diesel::PgConnection::establish(&self.url)
+                .map_err(|error| error.to_string())
+                .and_then(|mut conn| {
+                    conn.run_pending_migrations(crate::storage::postgres::MIGRATIONS)
+                        .map(|_| ())
+                        .map_err(|error| error.to_string())
+                });
+            match outcome {
+                Ok(()) => {}
+                Err(error) => eprintln!(
+                    "failed to re-apply the reverted migration ({error}); the test schema is one \
+                     migration behind and the remaining Postgres tests will fail"
+                ),
+            }
+        }
+    }
+
     async fn insert_account_row(store: &PostgresMetadataStore, account_id: &str) {
         let mut conn = store.pool.get().await.expect("conn");
         diesel::sql_query(
@@ -721,6 +768,7 @@ mod tests {
         let _guard = pg_serial_lock().lock().await;
 
         let account_id = format!("0xbackfill{}", Utc::now().timestamp_micros());
+        let reverted = RevertedMigration::new(url.clone());
         {
             let url = url.clone();
             let account_id = account_id.clone();
@@ -748,6 +796,7 @@ mod tests {
         }
 
         run_migrations(&url).await.expect("migration reapplies");
+        reverted.defuse();
 
         let store = PostgresMetadataStore::new(&url, 2).await.expect("store");
         assert_eq!(

--- a/crates/server/src/metadata/postgres.rs
+++ b/crates/server/src/metadata/postgres.rs
@@ -608,7 +608,6 @@ mod tests {
     async fn cas_does_not_advance_metadata_updated_at() {
         let url = test_database_url().await;
         let _guard = pg_serial_lock().lock().await;
-        run_migrations(&url).await.expect("migrations apply");
         let store = PostgresMetadataStore::new(&url, 2).await.expect("store");
         let account_id = format!("0xfrozen{}", Utc::now().timestamp_micros());
         insert_account_row(&store, &account_id).await;
@@ -632,7 +631,6 @@ mod tests {
     async fn cas_records_only_strictly_increasing_timestamps() {
         let url = test_database_url().await;
         let _guard = pg_serial_lock().lock().await;
-        run_migrations(&url).await.expect("migrations apply");
         let store = PostgresMetadataStore::new(&url, 2).await.expect("store");
         let account_id = format!("0xcas{}", Utc::now().timestamp_micros());
         insert_account_row(&store, &account_id).await;
@@ -677,7 +675,6 @@ mod tests {
     async fn cas_for_unknown_account_is_a_storage_error_not_a_replay() {
         let url = test_database_url().await;
         let _guard = pg_serial_lock().lock().await;
-        run_migrations(&url).await.expect("migrations apply");
         let store = PostgresMetadataStore::new(&url, 2).await.expect("store");
         let account_id = format!("0xghost{}", Utc::now().timestamp_micros());
 
@@ -692,7 +689,6 @@ mod tests {
     async fn concurrent_identical_timestamps_admit_exactly_one_winner() {
         let url = test_database_url().await;
         let _guard = pg_serial_lock().lock().await;
-        run_migrations(&url).await.expect("migrations apply");
         let store = Arc::new(PostgresMetadataStore::new(&url, 8).await.expect("store"));
         let account_id = format!("0xrace{}", Utc::now().timestamp_micros());
         insert_account_row(&store, &account_id).await;
@@ -723,7 +719,6 @@ mod tests {
     async fn migration_backfills_legacy_timestamps_into_account_auth_state() {
         let url = test_database_url().await;
         let _guard = pg_serial_lock().lock().await;
-        run_migrations(&url).await.expect("migrations apply");
 
         let account_id = format!("0xbackfill{}", Utc::now().timestamp_micros());
         {
@@ -789,7 +784,6 @@ mod tests {
     #[ignore = "requires Postgres; run ./scripts/test-postgres.sh"]
     async fn generic_set_preserves_pending_candidate_flag() {
         let url = test_database_url().await;
-        run_migrations(&url).await.expect("migrations apply");
         let store = PostgresMetadataStore::new(&url, 2).await.expect("store");
         let account_id = format!("0xsetrace{}", Utc::now().timestamp_micros());
         let now = Utc::now().to_rfc3339();
@@ -841,7 +835,6 @@ mod tests {
     #[ignore = "requires Postgres; run ./scripts/test-postgres.sh"]
     async fn clear_pending_candidate_is_conditional_on_candidate_rows() {
         let url = test_database_url().await;
-        run_migrations(&url).await.expect("migrations apply");
         let store = PostgresMetadataStore::new(&url, 2).await.expect("store");
         let account_id = format!("0xwedge{}", Utc::now().timestamp_micros());
         let now = Utc::now().to_rfc3339();

--- a/crates/server/src/metadata/postgres.rs
+++ b/crates/server/src/metadata/postgres.rs
@@ -562,13 +562,8 @@ mod tests {
     use super::*;
     use crate::schema::account_auth_state;
     use crate::storage::postgres::run_migrations;
+    use crate::testing::pg::test_database_url;
     use std::sync::Arc;
-
-    fn database_url() -> Option<String> {
-        std::env::var("DATABASE_URL")
-            .ok()
-            .filter(|url| !url.trim().is_empty())
-    }
 
     fn pg_serial_lock() -> &'static tokio::sync::Mutex<()> {
         static LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
@@ -609,9 +604,9 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "requires DATABASE_URL with migrations applied"]
+    #[ignore = "requires Postgres; run ./scripts/test-postgres.sh"]
     async fn cas_does_not_advance_metadata_updated_at() {
-        let url = database_url().expect("DATABASE_URL must be set for this #[ignore] test");
+        let url = test_database_url().await;
         let _guard = pg_serial_lock().lock().await;
         run_migrations(&url).await.expect("migrations apply");
         let store = PostgresMetadataStore::new(&url, 2).await.expect("store");
@@ -633,9 +628,9 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "requires DATABASE_URL with migrations applied"]
+    #[ignore = "requires Postgres; run ./scripts/test-postgres.sh"]
     async fn cas_records_only_strictly_increasing_timestamps() {
-        let url = database_url().expect("DATABASE_URL must be set for this #[ignore] test");
+        let url = test_database_url().await;
         let _guard = pg_serial_lock().lock().await;
         run_migrations(&url).await.expect("migrations apply");
         let store = PostgresMetadataStore::new(&url, 2).await.expect("store");
@@ -678,9 +673,9 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "requires DATABASE_URL with migrations applied"]
+    #[ignore = "requires Postgres; run ./scripts/test-postgres.sh"]
     async fn cas_for_unknown_account_is_a_storage_error_not_a_replay() {
-        let url = database_url().expect("DATABASE_URL must be set for this #[ignore] test");
+        let url = test_database_url().await;
         let _guard = pg_serial_lock().lock().await;
         run_migrations(&url).await.expect("migrations apply");
         let store = PostgresMetadataStore::new(&url, 2).await.expect("store");
@@ -693,9 +688,9 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "requires DATABASE_URL with migrations applied"]
+    #[ignore = "requires Postgres; run ./scripts/test-postgres.sh"]
     async fn concurrent_identical_timestamps_admit_exactly_one_winner() {
-        let url = database_url().expect("DATABASE_URL must be set for this #[ignore] test");
+        let url = test_database_url().await;
         let _guard = pg_serial_lock().lock().await;
         run_migrations(&url).await.expect("migrations apply");
         let store = Arc::new(PostgresMetadataStore::new(&url, 8).await.expect("store"));
@@ -724,9 +719,9 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "requires DATABASE_URL; reverts and re-applies the newest migration"]
+    #[ignore = "requires Postgres; reverts and re-applies the newest migration; run ./scripts/test-postgres.sh"]
     async fn migration_backfills_legacy_timestamps_into_account_auth_state() {
-        let url = database_url().expect("DATABASE_URL must be set for this #[ignore] test");
+        let url = test_database_url().await;
         let _guard = pg_serial_lock().lock().await;
         run_migrations(&url).await.expect("migrations apply");
 
@@ -791,9 +786,9 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "requires DATABASE_URL with migrations applied"]
+    #[ignore = "requires Postgres; run ./scripts/test-postgres.sh"]
     async fn generic_set_preserves_pending_candidate_flag() {
-        let url = database_url().expect("DATABASE_URL must be set for this #[ignore] test");
+        let url = test_database_url().await;
         run_migrations(&url).await.expect("migrations apply");
         let store = PostgresMetadataStore::new(&url, 2).await.expect("store");
         let account_id = format!("0xsetrace{}", Utc::now().timestamp_micros());
@@ -843,9 +838,9 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "requires DATABASE_URL with migrations applied"]
+    #[ignore = "requires Postgres; run ./scripts/test-postgres.sh"]
     async fn clear_pending_candidate_is_conditional_on_candidate_rows() {
-        let url = database_url().expect("DATABASE_URL must be set for this #[ignore] test");
+        let url = test_database_url().await;
         run_migrations(&url).await.expect("migrations apply");
         let store = PostgresMetadataStore::new(&url, 2).await.expect("store");
         let account_id = format!("0xwedge{}", Utc::now().timestamp_micros());

--- a/crates/server/src/storage/postgres.rs
+++ b/crates/server/src/storage/postgres.rs
@@ -456,6 +456,46 @@ async fn establish_tls_connection(
     AsyncPgConnection::try_from_client_and_connection(client, connection).await
 }
 
+#[cfg(test)]
+pub(crate) enum TestPostgresConnectionError {
+    Configuration(String),
+    Connection(tokio_postgres::Error),
+}
+
+#[cfg(test)]
+pub(crate) async fn connect_test_postgres_client(
+    database_url: &str,
+) -> Result<tokio_postgres::Client, TestPostgresConnectionError> {
+    let plan = parse_tls_plan(database_url).map_err(TestPostgresConnectionError::Configuration)?;
+    let connect_url = sanitized_async_url(database_url, &plan)
+        .map_err(TestPostgresConnectionError::Configuration)?;
+    let tls = build_tls_client_config(&plan).map_err(TestPostgresConnectionError::Configuration)?;
+
+    let client = match tls {
+        None => {
+            let (client, connection) = tokio_postgres::connect(&connect_url, tokio_postgres::NoTls)
+                .await
+                .map_err(TestPostgresConnectionError::Connection)?;
+            tokio::spawn(async move {
+                let _ = connection.await;
+            });
+            client
+        }
+        Some(config) => {
+            let tls = MakeRustlsConnect::new((*config).clone());
+            let (client, connection) = tokio_postgres::connect(&connect_url, tls)
+                .await
+                .map_err(TestPostgresConnectionError::Connection)?;
+            tokio::spawn(async move {
+                let _ = connection.await;
+            });
+            client
+        }
+    };
+
+    Ok(client)
+}
+
 fn make_connection_manager(
     database_url: &str,
 ) -> Result<AsyncDieselConnectionManager<AsyncPgConnection>, String> {
@@ -2799,7 +2839,6 @@ mod tests {
         use diesel::sql_types::Text;
 
         let url = crate::testing::pg::test_database_url().await;
-        run_migrations(&url).await.expect("migrations apply");
 
         let service = PostgresService::new(&url, 4).await.expect("storage");
         let stamp = chrono::Utc::now().timestamp_micros();
@@ -2894,7 +2933,6 @@ mod tests {
         const DISCARDED_ROWS: i64 = 2_000;
 
         let url = crate::testing::pg::test_database_url().await;
-        run_migrations(&url).await.expect("migrations apply");
 
         let service = PostgresService::new(&url, 4).await.expect("storage");
         let stamp = chrono::Utc::now().timestamp_micros();
@@ -3030,7 +3068,6 @@ mod tests {
         use std::time::Duration;
 
         let url = crate::testing::pg::test_database_url().await;
-        run_migrations(&url).await.expect("migrations apply");
 
         let service = PostgresService::new(&url, 4).await.expect("storage");
         let metadata_store = crate::metadata::postgres::PostgresMetadataStore::new(&url, 2)
@@ -3321,7 +3358,6 @@ mod tests {
         use std::time::Duration;
 
         let url = crate::testing::pg::test_database_url().await;
-        run_migrations(&url).await.expect("migrations apply");
 
         let service = PostgresService::new(&url, 4).await.expect("storage");
         let metadata_store = crate::metadata::postgres::PostgresMetadataStore::new(&url, 2)
@@ -3634,7 +3670,6 @@ mod tests {
         use tokio::sync::oneshot;
 
         let url = crate::testing::pg::test_database_url().await;
-        run_migrations(&url).await.expect("migrations apply");
 
         let service = PostgresService::new(&url, 4).await.expect("storage");
         let metadata_store = crate::metadata::postgres::PostgresMetadataStore::new(&url, 2)

--- a/crates/server/src/storage/postgres.rs
+++ b/crates/server/src/storage/postgres.rs
@@ -2793,15 +2793,12 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "requires DATABASE_URL with migrations applied"]
+    #[ignore = "requires Postgres; run ./scripts/test-postgres.sh"]
     async fn pull_candidate_deltas_filters_in_the_store() {
         use crate::delta_object::DeltaStatus;
         use diesel::sql_types::Text;
 
-        let url = std::env::var("DATABASE_URL")
-            .ok()
-            .filter(|url| !url.trim().is_empty())
-            .expect("DATABASE_URL must be set for this #[ignore] test");
+        let url = crate::testing::pg::test_database_url().await;
         run_migrations(&url).await.expect("migrations apply");
 
         let service = PostgresService::new(&url, 4).await.expect("storage");
@@ -2888,7 +2885,7 @@ mod tests {
     /// faster than the full-history read (the real ratio is orders of
     /// magnitude; the margin absorbs timer jitter).
     #[tokio::test]
-    #[ignore = "requires DATABASE_URL with migrations applied"]
+    #[ignore = "requires Postgres; run ./scripts/test-postgres.sh"]
     async fn pull_candidate_deltas_stays_flat_under_deep_history() {
         use crate::delta_object::DeltaStatus;
         use diesel::sql_types::{BigInt, Text};
@@ -2896,10 +2893,7 @@ mod tests {
         const CANONICAL_ROWS: i64 = 5_000;
         const DISCARDED_ROWS: i64 = 2_000;
 
-        let url = std::env::var("DATABASE_URL")
-            .ok()
-            .filter(|url| !url.trim().is_empty())
-            .expect("DATABASE_URL must be set for this #[ignore] test");
+        let url = crate::testing::pg::test_database_url().await;
         run_migrations(&url).await.expect("migrations apply");
 
         let service = PostgresService::new(&url, 4).await.expect("storage");
@@ -3026,7 +3020,7 @@ mod tests {
     /// `update_candidate_status`. These behaviors live in Postgres
     /// predicates the filesystem tests cannot exercise.
     #[tokio::test]
-    #[ignore = "requires DATABASE_URL with migrations applied"]
+    #[ignore = "requires Postgres; run ./scripts/test-postgres.sh"]
     async fn retain_and_reconcile_writes_are_kind_exact() {
         use crate::coordination::LeaderElector;
         use crate::coordination::postgres::PgLeaseElector;
@@ -3035,10 +3029,7 @@ mod tests {
         use diesel::sql_types::Text;
         use std::time::Duration;
 
-        let url = std::env::var("DATABASE_URL")
-            .ok()
-            .filter(|url| !url.trim().is_empty())
-            .expect("DATABASE_URL must be set for this #[ignore] test");
+        let url = crate::testing::pg::test_database_url().await;
         run_migrations(&url).await.expect("migrations apply");
 
         let service = PostgresService::new(&url, 4).await.expect("storage");
@@ -3321,7 +3312,7 @@ mod tests {
     /// mutated; the current holder promotes atomically; and once canonical,
     /// the delta survives both a repeated promotion and a discard attempt.
     #[tokio::test]
-    #[ignore = "requires DATABASE_URL with migrations applied"]
+    #[ignore = "requires Postgres; run ./scripts/test-postgres.sh"]
     async fn fenced_canonicalization_writes_reject_stale_owners() {
         use crate::coordination::LeaderElector;
         use crate::coordination::postgres::PgLeaseElector;
@@ -3329,10 +3320,7 @@ mod tests {
         use diesel::sql_types::Text;
         use std::time::Duration;
 
-        let url = std::env::var("DATABASE_URL")
-            .ok()
-            .filter(|url| !url.trim().is_empty())
-            .expect("DATABASE_URL must be set for this #[ignore] test");
+        let url = crate::testing::pg::test_database_url().await;
         run_migrations(&url).await.expect("migrations apply");
 
         let service = PostgresService::new(&url, 4).await.expect("storage");
@@ -3636,7 +3624,7 @@ mod tests {
     /// neutralized by the candidate conditional (NotCandidate), so the delta is
     /// promoted exactly once with no double-apply.
     #[tokio::test]
-    #[ignore = "requires DATABASE_URL with migrations applied"]
+    #[ignore = "requires Postgres; run ./scripts/test-postgres.sh"]
     async fn lease_transfer_does_not_wait_for_a_validated_write_transaction() {
         use crate::coordination::LeaderElector;
         use crate::coordination::postgres::PgLeaseElector;
@@ -3645,10 +3633,7 @@ mod tests {
         use std::time::Duration;
         use tokio::sync::oneshot;
 
-        let url = std::env::var("DATABASE_URL")
-            .ok()
-            .filter(|url| !url.trim().is_empty())
-            .expect("DATABASE_URL must be set for this #[ignore] test");
+        let url = crate::testing::pg::test_database_url().await;
         run_migrations(&url).await.expect("migrations apply");
 
         let service = PostgresService::new(&url, 4).await.expect("storage");

--- a/crates/server/src/testing/integration/miden_rpc_integration.rs
+++ b/crates/server/src/testing/integration/miden_rpc_integration.rs
@@ -1,9 +1,11 @@
 use crate::network::NetworkType;
 use crate::network::miden::MidenNetworkClient;
 
-/// Integration test for verifying we can connect to Miden devnet
-/// To run: cargo test --package guardian-server --test miden_rpc_integration_test
+/// Integration test for verifying we can connect to Miden devnet.
+///
+/// Run this ignored test with `GUARDIAN_NETWORK_TESTS=1`.
 #[tokio::test]
+#[ignore = "requires live Miden devnet access; run with GUARDIAN_NETWORK_TESTS=1"]
 async fn test_fetch_account_commitment_from_devnet() {
     if std::env::var("GUARDIAN_NETWORK_TESTS").as_deref() != Ok("1") {
         return;

--- a/crates/server/src/testing/integration/mod.rs
+++ b/crates/server/src/testing/integration/mod.rs
@@ -3,6 +3,7 @@
 
 mod auth_grpc;
 mod auth_http;
+mod body_limit_http;
 mod error_envelope_http;
 mod lookup_grpc;
 mod lookup_helpers;

--- a/crates/server/src/testing/mod.rs
+++ b/crates/server/src/testing/mod.rs
@@ -8,3 +8,5 @@ pub mod helpers;
 pub mod integration;
 pub mod log_capture;
 pub mod mocks;
+#[cfg(feature = "postgres")]
+pub mod pg;

--- a/crates/server/src/testing/pg.rs
+++ b/crates/server/src/testing/pg.rs
@@ -1,0 +1,244 @@
+use diesel::sql_types::Text;
+use diesel::{Connection, PgConnection, QueryableByName, RunQueryDsl};
+use std::time::{Duration, Instant};
+use tokio::sync::OnceCell;
+use url::Url;
+
+use crate::storage::postgres::run_migrations;
+
+static PREPARED: OnceCell<String> = OnceCell::const_new();
+
+const READINESS_TIMEOUT: Duration = Duration::from_secs(30);
+const PROBE_INTERVAL: Duration = Duration::from_millis(250);
+const CONNECT_TIMEOUT_SECONDS: &str = "5";
+const RESET_LOCK_TIMEOUT: &str = "10s";
+
+/// Return the connection URL for the Postgres-backed tests, resetting the
+/// database to an empty schema on first use so no run inherits state from an
+/// earlier one.
+pub async fn test_database_url() -> String {
+    PREPARED.get_or_init(prepare).await.clone()
+}
+
+#[derive(QueryableByName)]
+struct ConnectedDatabase {
+    #[diesel(sql_type = Text)]
+    current_database: String,
+}
+
+enum Probe {
+    Ready,
+    Missing,
+    Retryable(String),
+    Fatal(String),
+}
+
+async fn prepare() -> String {
+    let url = std::env::var("DATABASE_URL")
+        .ok()
+        .filter(|url| !url.trim().is_empty())
+        .expect("DATABASE_URL must be set; run ./scripts/test-postgres.sh");
+
+    let parsed = Url::parse(&url).expect("DATABASE_URL must be a postgres:// or postgresql:// URL");
+    let declared = database_name(&parsed);
+    assert!(
+        is_test_database_name(declared),
+        "{}",
+        refusal_message(declared)
+    );
+
+    ensure_database_exists(&parsed, declared).await;
+    reset_public_schema(&url).await;
+    run_migrations(&url).await.expect("migrations apply");
+
+    url
+}
+
+fn database_name(url: &Url) -> &str {
+    url.path().trim_start_matches('/')
+}
+
+fn is_test_database_name(name: &str) -> bool {
+    name.ends_with("_test")
+        && name
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || character == '_')
+}
+
+fn refusal_message(name: &str) -> String {
+    format!(
+        "refusing to reset database {name:?}: the Postgres-backed test suite drops and recreates \
+         the public schema, and will only do so on a database whose name ends in \"_test\" and \
+         contains only letters, digits, and underscores"
+    )
+}
+
+/// libpq accepts the database as a `dbname` query parameter as well as a path
+/// segment, and the query parameter wins, so the name in the URL is not proof
+/// of which database a connection landed on. Ask the server instead.
+fn assert_connected_to_test_database(conn: &mut PgConnection) {
+    let connected = diesel::sql_query("SELECT current_database()")
+        .get_result::<ConnectedDatabase>(conn)
+        .expect("read current database")
+        .current_database;
+    assert!(
+        is_test_database_name(&connected),
+        "{}",
+        refusal_message(&connected)
+    );
+}
+
+fn probe_url(url: &Url) -> String {
+    let mut probe = url.clone();
+    probe
+        .query_pairs_mut()
+        .append_pair("connect_timeout", CONNECT_TIMEOUT_SECONDS);
+    probe.to_string()
+}
+
+async fn ensure_database_exists(url: &Url, name: &str) {
+    let deadline = Instant::now() + READINESS_TIMEOUT;
+    loop {
+        match probe(probe_url(url), name.to_string()).await {
+            Probe::Ready => return,
+            Probe::Missing => return create_database(url, name).await,
+            Probe::Fatal(error) => panic!("cannot reach {}: {error}", endpoint(url)),
+            Probe::Retryable(error) if Instant::now() >= deadline => panic!(
+                "Postgres at {} did not accept connections within {}s: {error}",
+                endpoint(url),
+                READINESS_TIMEOUT.as_secs()
+            ),
+            Probe::Retryable(_) => tokio::time::sleep(PROBE_INTERVAL).await,
+        }
+    }
+}
+
+/// `docker compose up -d` returns before Postgres accepts connections, so a
+/// cold server has to be waited out rather than reported as broken. Only an
+/// undefined database means "create it"; auth and host-level failures are the
+/// operator's problem and must surface as themselves.
+async fn probe(url: String, name: String) -> Probe {
+    tokio::task::spawn_blocking(move || match PgConnection::establish(&url) {
+        Ok(_) => Probe::Ready,
+        Err(error) => {
+            let message = error.to_string();
+            if message.contains(&format!("database \"{name}\" does not exist")) {
+                Probe::Missing
+            } else if message.contains("authentication failed") || message.contains("pg_hba.conf") {
+                Probe::Fatal(message)
+            } else {
+                Probe::Retryable(message)
+            }
+        }
+    })
+    .await
+    .expect("connection probe task")
+}
+
+async fn create_database(url: &Url, name: &str) {
+    let mut maintenance = url.clone();
+    maintenance.set_path("/postgres");
+    let maintenance_url = maintenance.to_string();
+    let name = name.to_string();
+    let hint = format!(
+        "createdb -h {} -U {} {name}",
+        url.host_str().unwrap_or("localhost"),
+        url.username()
+    );
+
+    tokio::task::spawn_blocking(move || {
+        let mut conn = PgConnection::establish(&maintenance_url).unwrap_or_else(|error| {
+            panic!(
+                "database {name:?} does not exist and the maintenance database could not be \
+                 opened to create it ({error}); create it manually with: {hint}"
+            )
+        });
+        diesel::sql_query(format!("CREATE DATABASE \"{name}\""))
+            .execute(&mut conn)
+            .unwrap_or_else(|error| {
+                panic!(
+                    "failed to create database {name:?} ({error}); create it manually with: {hint}"
+                )
+            });
+    })
+    .await
+    .expect("database creation task");
+}
+
+async fn reset_public_schema(url: &str) {
+    let url = url.to_string();
+    tokio::task::spawn_blocking(move || {
+        let mut conn = PgConnection::establish(&url).unwrap_or_else(|error| {
+            panic!("DATABASE_URL must point at a reachable Postgres: {error}")
+        });
+        assert_connected_to_test_database(&mut conn);
+
+        // An idle-in-transaction backend from an interrupted run would
+        // otherwise block the drop indefinitely.
+        diesel::sql_query(format!("SET lock_timeout = '{RESET_LOCK_TIMEOUT}'"))
+            .execute(&mut conn)
+            .expect("set lock timeout");
+        // IF EXISTS: a run killed between the drop and the create leaves no
+        // public schema, and the next run must still be able to reset.
+        diesel::sql_query("DROP SCHEMA IF EXISTS public CASCADE")
+            .execute(&mut conn)
+            .expect("drop public schema");
+        diesel::sql_query("CREATE SCHEMA public")
+            .execute(&mut conn)
+            .expect("create public schema");
+    })
+    .await
+    .expect("schema reset task");
+}
+
+fn endpoint(url: &Url) -> String {
+    format!(
+        "{}:{}",
+        url.host_str().unwrap_or("localhost"),
+        url.port().unwrap_or(5432)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{database_name, is_test_database_name};
+    use url::Url;
+
+    #[test]
+    fn only_names_ending_in_test_may_be_reset() {
+        assert!(is_test_database_name("guardian_test"));
+        assert!(is_test_database_name("guardian_365_test"));
+
+        assert!(!is_test_database_name("guardian"));
+        assert!(!is_test_database_name("guardian_test_backup"));
+        assert!(!is_test_database_name("testing"));
+        assert!(!is_test_database_name(""));
+    }
+
+    #[test]
+    fn names_needing_quoting_are_rejected() {
+        assert!(!is_test_database_name(
+            "guardian\"; DROP DATABASE guardian; --_test"
+        ));
+        assert!(!is_test_database_name("guardian test"));
+        assert!(!is_test_database_name("guardian-test"));
+    }
+
+    #[test]
+    fn declared_name_comes_from_the_url_path() {
+        let url = Url::parse("postgres://guardian:guardian@localhost:5432/guardian_test").unwrap();
+        assert_eq!(database_name(&url), "guardian_test");
+    }
+
+    #[test]
+    fn a_dbname_parameter_hides_the_real_target_from_the_path() {
+        let url =
+            Url::parse("postgres://u:p@localhost:5432/guardian_test?dbname=guardian").unwrap();
+        assert_eq!(database_name(&url), "guardian_test");
+        assert!(
+            is_test_database_name(database_name(&url)),
+            "the path alone cannot prove the target, which is why the reset re-checks \
+             current_database() against the server"
+        );
+    }
+}

--- a/crates/server/src/testing/pg.rs
+++ b/crates/server/src/testing/pg.rs
@@ -258,7 +258,7 @@ fn endpoint(url: &Url) -> String {
 }
 
 #[cfg(test)]
-mod tests {
+mod postgres {
     use super::{database_name, ensure_database_exists, is_test_database_name, maintenance_url};
     use url::Url;
 

--- a/crates/server/src/testing/pg.rs
+++ b/crates/server/src/testing/pg.rs
@@ -33,6 +33,7 @@ enum Probe {
     Ready,
     Missing,
     Retryable(String),
+    Configuration(String),
     Fatal(String),
 }
 
@@ -131,6 +132,9 @@ async fn ensure_database_exists(url: &Url, name: &str) {
         match probe(probe_url(&maintenance), name).await {
             Probe::Ready => return,
             Probe::Missing => return create_database(url, name).await,
+            Probe::Configuration(error) => {
+                panic!("invalid DATABASE_URL configuration: {error}")
+            }
             Probe::Fatal(error) => panic!("cannot reach {}: {error}", endpoint(url)),
             Probe::Retryable(error) if Instant::now() >= deadline => panic!(
                 "Postgres at {} did not accept connections within {}s: {error}",
@@ -171,7 +175,9 @@ fn classify_postgres_error(error: tokio_postgres::Error) -> Probe {
 async fn probe(url: String, name: &str) -> Probe {
     let client = match connect_test_postgres_client(&url).await {
         Ok(client) => client,
-        Err(TestPostgresConnectionError::Configuration(error)) => return Probe::Fatal(error),
+        Err(TestPostgresConnectionError::Configuration(error)) => {
+            return Probe::Configuration(error);
+        }
         Err(TestPostgresConnectionError::Connection(error)) => {
             return classify_postgres_error(error);
         }
@@ -253,7 +259,7 @@ fn endpoint(url: &Url) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{database_name, is_test_database_name, maintenance_url};
+    use super::{database_name, ensure_database_exists, is_test_database_name, maintenance_url};
     use url::Url;
 
     #[test]
@@ -310,5 +316,15 @@ mod tests {
         .unwrap();
 
         assert!(database_name(&url).is_err());
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "invalid DATABASE_URL configuration: sslmode 'allow'/'prefer'")]
+    async fn invalid_connection_options_are_reported_as_configuration_errors() {
+        let url =
+            Url::parse("postgres://guardian:guardian@localhost:5432/guardian_test?sslmode=prefer")
+                .unwrap();
+
+        ensure_database_exists(&url, "guardian_test").await;
     }
 }

--- a/crates/server/src/testing/pg.rs
+++ b/crates/server/src/testing/pg.rs
@@ -2,9 +2,12 @@ use diesel::sql_types::Text;
 use diesel::{Connection, PgConnection, QueryableByName, RunQueryDsl};
 use std::time::{Duration, Instant};
 use tokio::sync::OnceCell;
+use tokio_postgres::error::SqlState;
 use url::Url;
 
-use crate::storage::postgres::run_migrations;
+use crate::storage::postgres::{
+    TestPostgresConnectionError, connect_test_postgres_client, run_migrations,
+};
 
 static PREPARED: OnceCell<String> = OnceCell::const_new();
 
@@ -40,22 +43,31 @@ async fn prepare() -> String {
         .expect("DATABASE_URL must be set; run ./scripts/test-postgres.sh");
 
     let parsed = Url::parse(&url).expect("DATABASE_URL must be a postgres:// or postgresql:// URL");
-    let declared = database_name(&parsed);
+    let declared = database_name(&parsed).unwrap_or_else(|error| panic!("{error}"));
     assert!(
-        is_test_database_name(declared),
+        is_test_database_name(&declared),
         "{}",
-        refusal_message(declared)
+        refusal_message(&declared)
     );
 
-    ensure_database_exists(&parsed, declared).await;
+    ensure_database_exists(&parsed, &declared).await;
     reset_public_schema(&url).await;
     run_migrations(&url).await.expect("migrations apply");
 
     url
 }
 
-fn database_name(url: &Url) -> &str {
-    url.path().trim_start_matches('/')
+fn database_name(url: &Url) -> Result<String, String> {
+    let names: Vec<String> = url
+        .query_pairs()
+        .filter(|(key, _)| key == "dbname")
+        .map(|(_, value)| value.into_owned())
+        .collect();
+    match names.as_slice() {
+        [] => Ok(url.path().trim_start_matches('/').to_string()),
+        [name] => Ok(name.clone()),
+        _ => Err("DATABASE_URL must not contain duplicate 'dbname' parameters".to_string()),
+    }
 }
 
 fn is_test_database_name(name: &str) -> bool {
@@ -96,10 +108,27 @@ fn probe_url(url: &Url) -> String {
     probe.to_string()
 }
 
+fn maintenance_url(url: &Url) -> Url {
+    let mut maintenance = url.clone();
+    maintenance.set_path("/postgres");
+    let preserved: Vec<(String, String)> = maintenance
+        .query_pairs()
+        .filter(|(key, _)| key != "dbname")
+        .map(|(key, value)| (key.into_owned(), value.into_owned()))
+        .collect();
+    {
+        let mut pairs = maintenance.query_pairs_mut();
+        pairs.clear();
+        pairs.extend_pairs(preserved);
+    }
+    maintenance
+}
+
 async fn ensure_database_exists(url: &Url, name: &str) {
+    let maintenance = maintenance_url(url);
     let deadline = Instant::now() + READINESS_TIMEOUT;
     loop {
-        match probe(probe_url(url), name.to_string()).await {
+        match probe(probe_url(&maintenance), name).await {
             Probe::Ready => return,
             Probe::Missing => return create_database(url, name).await,
             Probe::Fatal(error) => panic!("cannot reach {}: {error}", endpoint(url)),
@@ -113,32 +142,55 @@ async fn ensure_database_exists(url: &Url, name: &str) {
     }
 }
 
+fn is_retryable_postgres_error(error: &tokio_postgres::Error) -> bool {
+    let Some(database_error) = error.as_db_error() else {
+        return true;
+    };
+    matches!(
+        *database_error.code(),
+        SqlState::ADMIN_SHUTDOWN
+            | SqlState::CRASH_SHUTDOWN
+            | SqlState::CANNOT_CONNECT_NOW
+            | SqlState::TOO_MANY_CONNECTIONS
+    )
+}
+
+fn classify_postgres_error(error: tokio_postgres::Error) -> Probe {
+    let message = error.to_string();
+    if is_retryable_postgres_error(&error) {
+        Probe::Retryable(message)
+    } else {
+        Probe::Fatal(message)
+    }
+}
+
 /// `docker compose up -d` returns before Postgres accepts connections, so a
-/// cold server has to be waited out rather than reported as broken. Only an
-/// undefined database means "create it"; auth and host-level failures are the
-/// operator's problem and must surface as themselves.
-async fn probe(url: String, name: String) -> Probe {
-    tokio::task::spawn_blocking(move || match PgConnection::establish(&url) {
-        Ok(_) => Probe::Ready,
-        Err(error) => {
-            let message = error.to_string();
-            if message.contains(&format!("database \"{name}\" does not exist")) {
-                Probe::Missing
-            } else if message.contains("authentication failed") || message.contains("pg_hba.conf") {
-                Probe::Fatal(message)
-            } else {
-                Probe::Retryable(message)
-            }
+/// cold server has to be waited out rather than reported as broken. The probe
+/// uses the maintenance database so a missing target can be detected without
+/// parsing connection error text.
+async fn probe(url: String, name: &str) -> Probe {
+    let client = match connect_test_postgres_client(&url).await {
+        Ok(client) => client,
+        Err(TestPostgresConnectionError::Configuration(error)) => return Probe::Fatal(error),
+        Err(TestPostgresConnectionError::Connection(error)) => {
+            return classify_postgres_error(error);
         }
-    })
-    .await
-    .expect("connection probe task")
+    };
+    match client
+        .query_one(
+            "SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname = $1)",
+            &[&name],
+        )
+        .await
+    {
+        Ok(row) if row.get::<_, bool>(0) => Probe::Ready,
+        Ok(_) => Probe::Missing,
+        Err(error) => classify_postgres_error(error),
+    }
 }
 
 async fn create_database(url: &Url, name: &str) {
-    let mut maintenance = url.clone();
-    maintenance.set_path("/postgres");
-    let maintenance_url = maintenance.to_string();
+    let maintenance_url = maintenance_url(url).to_string();
     let name = name.to_string();
     let hint = format!(
         "createdb -h {} -U {} {name}",
@@ -201,7 +253,7 @@ fn endpoint(url: &Url) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{database_name, is_test_database_name};
+    use super::{database_name, is_test_database_name, maintenance_url};
     use url::Url;
 
     #[test]
@@ -227,18 +279,36 @@ mod tests {
     #[test]
     fn declared_name_comes_from_the_url_path() {
         let url = Url::parse("postgres://guardian:guardian@localhost:5432/guardian_test").unwrap();
-        assert_eq!(database_name(&url), "guardian_test");
+        assert_eq!(database_name(&url).unwrap(), "guardian_test");
     }
 
     #[test]
-    fn a_dbname_parameter_hides_the_real_target_from_the_path() {
+    fn dbname_parameter_overrides_the_url_path() {
         let url =
-            Url::parse("postgres://u:p@localhost:5432/guardian_test?dbname=guardian").unwrap();
-        assert_eq!(database_name(&url), "guardian_test");
-        assert!(
-            is_test_database_name(database_name(&url)),
-            "the path alone cannot prove the target, which is why the reset re-checks \
-             current_database() against the server"
+            Url::parse("postgres://u:p@localhost:5432/guardian_test?dbname=other_test").unwrap();
+        assert_eq!(database_name(&url).unwrap(), "other_test");
+    }
+
+    #[test]
+    fn maintenance_url_removes_dbname_and_preserves_other_parameters() {
+        let url = Url::parse(
+            "postgres://u:p@localhost:5432/guardian_test?dbname=other_test&sslmode=require",
+        )
+        .unwrap();
+
+        assert_eq!(
+            maintenance_url(&url).as_str(),
+            "postgres://u:p@localhost:5432/postgres?sslmode=require"
         );
+    }
+
+    #[test]
+    fn duplicate_dbname_parameters_are_rejected() {
+        let url = Url::parse(
+            "postgres://u:p@localhost:5432/guardian_test?dbname=one_test&dbname=two_test",
+        )
+        .unwrap();
+
+        assert!(database_name(&url).is_err());
     }
 }

--- a/docs/LOCAL_DEV.md
+++ b/docs/LOCAL_DEV.md
@@ -103,6 +103,39 @@ wires `PostgresAuditor` so admin actions land in the `admin_actions` table.
 Pool sizing is controlled by `GUARDIAN_DB_POOL_MAX_SIZE` and
 `GUARDIAN_METADATA_DB_POOL_MAX_SIZE`.
 
+### Postgres-backed tests
+
+The `guardian-server` tests that need a live database (metadata replay state,
+delta storage fencing, the audit append-only trigger, and the lease, session,
+and challenge coordination stores) stay `#[ignore]` and run through one script:
+
+```bash
+POSTGRES_PASSWORD=guardian docker compose -f docker-compose.postgres.yml up -d postgres
+./scripts/test-postgres.sh
+```
+
+Name the `postgres` service explicitly: an unqualified `up -d` also builds and
+starts the server image, which these tests do not use. `POSTGRES_PASSWORD` is
+required even when only the database service is selected, because Compose
+interpolates the whole file; the script's default connection URL expects
+`guardian`. If your Compose volume was initialised with a different password,
+pass a matching `DATABASE_URL` instead of relying on the default.
+
+The suite drops and recreates the `public` schema before the first test and
+re-applies every migration from empty, so no run inherits state from an earlier
+one and there is no cleanup step. It creates `guardian_test` if it is missing,
+and it refuses to run against a database whose name does not end in `_test`, so
+a `DATABASE_URL` still exported from a Path B session cannot lose your
+development data. Point it elsewhere with:
+
+```bash
+DATABASE_URL=postgres://user:pass@host:5432/guardian_test ./scripts/test-postgres.sh
+```
+
+Run one suite at a time per server: the reset wipes the shared test database.
+Execution is serial because one test reverts the newest migration for the
+duration of its own run.
+
 The local compose Postgres uses no TLS, so omit `sslmode` (plaintext). To
 exercise certificate verification locally, run a TLS-enabled Postgres with a
 self-signed CA and point the server at it:

--- a/scripts/test-postgres.sh
+++ b/scripts/test-postgres.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -euo pipefail
+
+# Run the Postgres-backed guardian-server tests.
+#
+# The suite resets its own database before the first test, so runs leave no
+# state behind that can affect the next one. The database name must end in
+# "_test"; the suite refuses to reset anything else.
+#
+# Usage: ./scripts/test-postgres.sh
+#
+# Optional environment variables:
+#   DATABASE_URL - Postgres connection URL
+#                  (default: postgres://guardian:guardian@localhost:5432/guardian_test)
+
+DATABASE_URL="${DATABASE_URL:-postgres://guardian:guardian@localhost:5432/guardian_test}"
+export DATABASE_URL
+
+# The filter is a substring match on the test path, so a database-backed test
+# must live under a `postgres` module segment to be selected, and an ignored
+# test that does not need a database must not. A filter that matches nothing
+# would otherwise report success while running no tests.
+if ! LISTED=$(cargo test -p guardian-server --lib --features postgres -- \
+  --ignored postgres --list); then
+  echo "error: listing the Postgres-backed tests failed; see the cargo output above" >&2
+  exit 1
+fi
+
+SELECTED=$(printf '%s\n' "${LISTED}" | grep -c ': test$' || true)
+
+if [ "${SELECTED}" -eq 0 ]; then
+  echo "error: the 'postgres' filter matched no ignored tests" >&2
+  exit 1
+fi
+
+echo "Running ${SELECTED} Postgres-backed tests"
+
+# Serialised: the tests share one database, and the migration test reverts the
+# newest migration for the duration of its own run.
+cargo test -p guardian-server --lib --features postgres -- \
+  --ignored postgres --test-threads=1


### PR DESCRIPTION
This PR improves CI workflow to run additional tests that required dependencies like postgres db.

## CI notes

The Postgres job newly makes two timing-sensitive regression tests required in CI:

- `pull_candidate_deltas_stays_flat_under_deep_history` requires the filtered read to be at least 5x faster.
- `lease_transfer_does_not_wait_for_a_validated_write_transaction` uses a 1,200 ms transaction hold.

If this job flakes under shared-runner load, check these tests first before treating the failure as a Postgres setup problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated PostgreSQL-backed integration and end-to-end test coverage.
  * Added safeguards for test database setup, schema resets, migrations, and readiness checks.
  * Added a dedicated script for running PostgreSQL tests locally.

* **Documentation**
  * Documented PostgreSQL test setup, configuration, execution, and safety requirements.
  * Clarified how to run live network integration tests.

* **Tests**
  * Added HTTP body-limit integration test coverage.
  * Improved consistency and reliability of PostgreSQL test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->