### PR TITLE
feat(sdk): private-note transport backlog drain recovery primitive (#414)

### DIFF
--- a/crates/miden-multisig-client/README.md
+++ b/crates/miden-multisig-client/README.md
@@ -179,6 +179,35 @@ client.sign_proposal(&to_sign.id).await?;
 client.execute_proposal(&proposal.id).await?;
 ```
 
+### Draining the Private-Note Transport Backlog
+
+After recovery on a fresh device the local store has no note-transport
+cursor — and in a store shared with other accounts, sync may have advanced
+the cursor past private notes addressed to the newly recovered account.
+`drain_private_note_backlog` rescans the full transport backlog for every
+tracked note tag, regardless of the stored cursor. Run it after
+`pull_account`: the drain only sees tags tracked in the store, and
+`pull_account` inserting the account is what tracks its tag.
+
+```rust
+client.pull_account(account_id).await?;
+
+let report = client.drain_private_note_backlog().await?;
+// report.status: Completed | Unavailable | Failed
+// report.imported: number of newly imported note records
+```
+
+Transport problems are reported in the result, never returned as errors:
+`Unavailable` means no transport endpoint is configured or the transport
+could not be reached; `Failed` with `retryable: true` keeps any partial
+progress and rerunning the drain continues it. The drain is idempotent and
+never regresses the stored transport cursor.
+
+Transport recovery is **not a backup**: it is bounded by the transport
+service's retention. Senders may deliver private notes out-of-band without
+using the transport, and relayed blobs are pruned after the retention
+window.
+
 ### Recovering From a Dead Transaction (Abandon)
 
 If `execute_proposal` dies after guardian approval (RPC submit failure,

--- a/crates/miden-multisig-client/README.md
+++ b/crates/miden-multisig-client/README.md
@@ -199,9 +199,10 @@ let report = client.drain_private_note_backlog().await?;
 
 Transport problems are reported in the result, never returned as errors:
 `Unavailable` means no transport endpoint is configured or the transport
-could not be reached; `Failed` with `retryable: true` keeps any partial
-progress and rerunning the drain continues it. The drain is idempotent and
-never regresses the stored transport cursor.
+could not be reached before anything was imported; `Failed` with
+`retryable: true` keeps any partial progress and rerunning the drain
+continues it. The drain is idempotent and never regresses the stored
+transport cursor.
 
 Transport recovery is **not a backup**: it is bounded by the transport
 service's retention. Senders may deliver private notes out-of-band without

--- a/crates/miden-multisig-client/src/client/helpers.rs
+++ b/crates/miden-multisig-client/src/client/helpers.rs
@@ -455,10 +455,14 @@ impl MultisigClient {
     }
 
     /// Adds an account to miden-client if it doesn't exist, or updates it if it does.
+    ///
+    /// `overwrite` is forwarded to miden-client's `add_account` on the
+    /// insert path (its parameter of the same name); the update path always
+    /// overwrites.
     pub(crate) async fn add_or_update_account(
         &mut self,
         account: &Account,
-        imported: bool,
+        overwrite: bool,
     ) -> Result<()> {
         let account_id = account.id();
 
@@ -482,7 +486,7 @@ impl MultisigClient {
                 })?;
         } else {
             self.miden_client
-                .add_account(account, imported)
+                .add_account(account, overwrite)
                 .await
                 .map_err(|e| {
                     MultisigError::MidenClient(format!(

--- a/crates/miden-multisig-client/src/client/helpers.rs
+++ b/crates/miden-multisig-client/src/client/helpers.rs
@@ -456,9 +456,12 @@ impl MultisigClient {
 
     /// Adds an account to miden-client if it doesn't exist, or updates it if it does.
     ///
-    /// `overwrite` is forwarded to miden-client's `add_account` on the
-    /// insert path (its parameter of the same name); the update path always
-    /// overwrites.
+    /// `overwrite` is forwarded to miden-client's `add_account` (its
+    /// parameter of the same name), but is currently inert: upstream only
+    /// consults it for already-tracked accounts, and the existence pre-check
+    /// here routes those through the update path, which always overwrites.
+    /// This helper never surfaces upstream's `overwrite: false` protection
+    /// (`AccountAlreadyTracked`).
     pub(crate) async fn add_or_update_account(
         &mut self,
         account: &Account,

--- a/crates/miden-multisig-client/src/client/mod.rs
+++ b/crates/miden-multisig-client/src/client/mod.rs
@@ -7,6 +7,7 @@
 //! - `proposals` - Proposal workflow (list, sign, execute, propose)
 //! - `offline` - Offline proposal operations
 //! - `notes` - Note filtering and listing
+//! - `recovery` - Recovery primitives (transport backlog drain)
 //! - `io` - Export/import functionality
 //! - `helpers` - Internal GUARDIAN client helpers
 
@@ -17,11 +18,13 @@ mod io;
 mod notes;
 mod offline;
 mod proposals;
+mod recovery;
 pub use delta_history::{
     HistoryAssetKind, HistoryDecodeSection, HistoryDecodeWarning, HistoryEntry, HistoryEntryStatus,
     HistoryNote, HistoryNoteAsset, HistoryNoteTag, HistoryNoteVisibility, HistoryPage,
 };
 pub use proposals::{AbandonRequestState, AbandonStatus};
+pub use recovery::{TransportRecoveryReport, TransportRecoveryStatus};
 
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/crates/miden-multisig-client/src/client/recovery.rs
+++ b/crates/miden-multisig-client/src/client/recovery.rs
@@ -6,14 +6,12 @@
 //! The primitives here rescan sources that normal forward sync would skip
 //! (issue #414, sub-issue of #357).
 
-use std::collections::BTreeSet;
-
 use miden_client::ClientError;
 use miden_client::note_transport::NoteTransportError;
-use miden_protocol::note::NoteDetailsCommitment;
 
 use super::MultisigClient;
 use crate::error::{Result, error_chain};
+use crate::rpc::{is_transient_note_transport_error, is_transient_rpc_error};
 
 /// Outcome class of a private-note transport backlog drain.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -22,8 +20,10 @@ pub enum TransportRecoveryStatus {
     /// holds for the tracked tags is now in the local store.
     Completed,
     /// The transport could not be consulted at all: it is disabled for this
-    /// client (no endpoint configured) or unreachable. Nothing was scanned;
-    /// the rest of a recovery flow should proceed without transport notes.
+    /// client (no endpoint configured) or unreachable before anything was
+    /// imported (`imported` is always 0 — a connection lost mid-drain after
+    /// partial progress reports `Failed` instead). The rest of a recovery
+    /// flow should proceed without transport notes.
     Unavailable,
     /// The drain started but did not finish; the backlog may be partially
     /// imported. `retryable` distinguishes transient failures (rerun the
@@ -83,12 +83,15 @@ impl MultisigClient {
             });
         }
 
-        let before = self.input_note_commitments().await?;
+        let before = self.input_note_count().await?;
         let drain_result = self.miden_client.fetch_all_private_notes().await;
         // Count even when the drain failed: each fetched batch is imported as
         // it arrives, so notes recovered before the failure stay in the store.
-        let after = self.input_note_commitments().await?;
-        let imported = after.difference(&before).count();
+        // A drain never removes records (and `&mut self` excludes concurrent
+        // client operations), so the length delta is the count of newly
+        // imported records.
+        let after = self.input_note_count().await?;
+        let imported = after.saturating_sub(before);
 
         match drain_result {
             Ok(()) => Ok(TransportRecoveryReport {
@@ -97,8 +100,25 @@ impl MultisigClient {
                 retryable: false,
                 reason: None,
             }),
+            // A broken local store is an environment failure, not a transport
+            // outcome: the whole recovery flow needs to know, so it
+            // propagates instead of being folded into the report.
+            Err(err @ ClientError::StoreError(_)) => {
+                Err(crate::error::MultisigError::miden_client_with_context(
+                    "local store failed during the transport drain",
+                    err,
+                ))
+            }
             Err(err) => {
                 let (status, retryable) = classify_drain_failure(&err);
+                // `Unavailable` promises "nothing was imported"; a connection
+                // lost mid-drain after partial progress is an interrupted
+                // drain, so report it as a retryable failure instead.
+                let status = if imported > 0 && status == TransportRecoveryStatus::Unavailable {
+                    TransportRecoveryStatus::Failed
+                } else {
+                    status
+                };
                 Ok(TransportRecoveryReport {
                     status,
                     imported,
@@ -109,10 +129,8 @@ impl MultisigClient {
         }
     }
 
-    /// Details commitments of every input note currently in the local store.
-    /// Keyed by details commitment because transport-imported records start
-    /// without metadata (`Expected` state) and so may not have a note ID yet.
-    async fn input_note_commitments(&mut self) -> Result<BTreeSet<NoteDetailsCommitment>> {
+    /// Number of input note records currently in the local store.
+    async fn input_note_count(&mut self) -> Result<usize> {
         let records = self
             .miden_client
             .get_input_notes(miden_client::store::NoteFilter::All)
@@ -123,10 +141,7 @@ impl MultisigClient {
                     e,
                 )
             })?;
-        Ok(records
-            .iter()
-            .map(|record| record.details_commitment())
-            .collect())
+        Ok(records.len())
     }
 }
 
@@ -134,31 +149,42 @@ impl MultisigClient {
 /// `(status, retryable)`.
 fn classify_drain_failure(err: &ClientError) -> (TransportRecoveryStatus, bool) {
     match err {
+        // The match is deliberately exhaustive so a new upstream variant is a
+        // compile error here rather than a silently wrong classification.
         ClientError::NoteTransportError(transport_err) => match transport_err {
             // No transport configured — retrying cannot help until the client
             // is rebuilt with an endpoint.
             NoteTransportError::Disabled => (TransportRecoveryStatus::Unavailable, false),
-            // The transport exists but could not be reached — same class as
-            // disabled for a recovery flow (nothing was scanned), but worth
-            // retrying once connectivity returns.
-            NoteTransportError::Connection(_) | NoteTransportError::Network(_) => {
-                (TransportRecoveryStatus::Unavailable, true)
-            }
+            // `Connection` wraps endpoint parsing, TLS configuration, and
+            // actual connect failures indiscriminately; the shared classifier
+            // inspects the cause chain to tell a retry-worthy dropped
+            // connection from a permanently misconfigured endpoint.
+            NoteTransportError::Connection(_) => (
+                TransportRecoveryStatus::Unavailable,
+                is_transient_note_transport_error(transport_err),
+            ),
+            // The transport answered with an error — worth retrying once the
+            // service recovers.
+            NoteTransportError::Network(_) => (TransportRecoveryStatus::Unavailable, true),
             // The upstream convergence guard tripped (the server cursor kept
-            // advancing for 1000 iterations without an empty batch). The
-            // backlog is partially imported; a rerun continues making
-            // progress because imports are idempotent.
+            // advancing for 1000 iterations without an empty batch) — a
+            // server-side bug, not an honest backlog. Retryable in the sense
+            // that a rerun is safe (imports are idempotent) and succeeds once
+            // the server recovers; while the server misbehaves, each rerun
+            // repeats the same full scan and trips the same guard.
             NoteTransportError::PaginationDidNotTerminate(_) => {
                 (TransportRecoveryStatus::Failed, true)
             }
-            // Undecodable payloads and any future variants: a rerun would hit
-            // the same bytes again.
-            _ => (TransportRecoveryStatus::Failed, false),
+            // Undecodable payloads: a rerun would hit the same bytes again.
+            NoteTransportError::Deserialization(_) => (TransportRecoveryStatus::Failed, false),
         },
         // Each fetched batch is imported through the node (inclusion-proof
-        // lookup), so a node RPC failure mid-drain is transient-connectivity
-        // shaped: the transport itself was fine, retry later.
-        ClientError::RpcError(_) => (TransportRecoveryStatus::Failed, true),
+        // lookup), so a node RPC failure interrupts the drain mid-way; the
+        // shared gRPC classifier decides whether a rerun can help.
+        ClientError::RpcError(rpc_err) => (
+            TransportRecoveryStatus::Failed,
+            is_transient_rpc_error(rpc_err),
+        ),
         _ => (TransportRecoveryStatus::Failed, false),
     }
 }
@@ -222,6 +248,19 @@ mod tests {
         assert!(retryable);
     }
 
+    /// `Connection` also wraps endpoint-parse/TLS misconfiguration; the
+    /// shared cause-chain classifier marks those permanent so a recovery
+    /// flow does not loop retrying a client that can never connect.
+    #[test]
+    fn misconfigured_transport_endpoint_is_unavailable_and_not_retryable() {
+        let connection = NoteTransportError::Connection(Box::new(std::io::Error::other(
+            "invalid uri: missing scheme",
+        )));
+        let (status, retryable) = classify_drain_failure(&transport_error(connection));
+        assert_eq!(status, TransportRecoveryStatus::Unavailable);
+        assert!(!retryable);
+    }
+
     #[test]
     fn pagination_convergence_guard_is_a_retryable_failure() {
         let (status, retryable) = classify_drain_failure(&transport_error(
@@ -243,6 +282,23 @@ mod tests {
         let (status, retryable) = classify_drain_failure(&err);
         assert_eq!(status, TransportRecoveryStatus::Failed);
         assert!(retryable);
+    }
+
+    /// The shared gRPC classifier decides retryability for node failures:
+    /// a permanent status (bad request, wrong node version) must not tell
+    /// callers to rerun the drain.
+    #[test]
+    fn permanent_node_rpc_failure_mid_drain_is_not_retryable() {
+        let err: ClientError = miden_client::rpc::RpcError::RequestError {
+            endpoint: miden_client::rpc::RpcEndpoint::SyncChainMmr,
+            error_kind: miden_client::rpc::GrpcError::InvalidArgument,
+            endpoint_error: None,
+            source: None,
+        }
+        .into();
+        let (status, retryable) = classify_drain_failure(&err);
+        assert_eq!(status, TransportRecoveryStatus::Failed);
+        assert!(!retryable);
     }
 
     #[test]
@@ -321,10 +377,9 @@ mod tests {
             .expect("test wallet builds")
     }
 
-    /// A private P2ID note addressed at `target`, in the transport wire form:
-    /// `(header, serialized NoteDetails)`.
-    fn private_note_for(target: &Account) -> Note {
-        let mut rng = RandomCoin::new(Word::default());
+    /// A distinct (per `seed`) private P2ID note addressed at `target`.
+    fn private_note_for(target: &Account, seed: u32) -> Note {
+        let mut rng = RandomCoin::new(Word::from(&[seed, 0, 0, 0]));
         P2idNote::create(
             target.id(),
             target.id(),
@@ -368,7 +423,7 @@ mod tests {
         // its standard note tag is tracked.
         let account = test_wallet(1);
         client.add_or_update_account(&account, false).await.unwrap();
-        add_to_transport(&node, private_note_for(&account));
+        add_to_transport(&node, private_note_for(&account, 1));
 
         let report = client.drain_private_note_backlog().await.unwrap();
         assert_eq!(report.status, TransportRecoveryStatus::Completed);
@@ -391,7 +446,7 @@ mod tests {
 
         // A note is waiting on the transport, but no account is in the store,
         // so no tag is tracked.
-        add_to_transport(&node, private_note_for(&test_wallet(2)));
+        add_to_transport(&node, private_note_for(&test_wallet(2), 1));
 
         let report = client.drain_private_note_backlog().await.unwrap();
         assert_eq!(report.status, TransportRecoveryStatus::Completed);
@@ -408,7 +463,7 @@ mod tests {
 
         let account = test_wallet(3);
         client.add_or_update_account(&account, false).await.unwrap();
-        add_to_transport(&node, private_note_for(&account));
+        add_to_transport(&node, private_note_for(&account, 1));
 
         // Simulate a store whose cursor another account's sync has already
         // advanced far past this backlog. The store encodes the cursor as raw
@@ -438,6 +493,95 @@ mod tests {
             .unwrap()
             .expect("cursor setting exists");
         assert_eq!(u64::from_be_bytes(stored), advanced);
+    }
+
+    /// Transport that serves a limited number of successful fetches, then
+    /// fails with a connection-shaped error — a connection dropped mid-drain.
+    struct InterruptibleTransport {
+        inner: MockNoteTransportApi,
+        fetches_before_failure: std::sync::atomic::AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl NoteTransportClient for InterruptibleTransport {
+        async fn send_note(
+            &self,
+            header: miden_protocol::note::NoteHeader,
+            details: Vec<u8>,
+        ) -> std::result::Result<(), NoteTransportError> {
+            self.inner.send_note(header, details);
+            Ok(())
+        }
+
+        async fn fetch_notes(
+            &self,
+            tags: &[NoteTag],
+            cursor: miden_client::note_transport::NoteTransportCursor,
+        ) -> std::result::Result<
+            (
+                Vec<miden_client::note_transport::NoteInfo>,
+                miden_client::note_transport::NoteTransportCursor,
+            ),
+            NoteTransportError,
+        > {
+            let allowed = self
+                .fetches_before_failure
+                .fetch_update(
+                    std::sync::atomic::Ordering::SeqCst,
+                    std::sync::atomic::Ordering::SeqCst,
+                    |n| n.checked_sub(1),
+                )
+                .is_ok();
+            if !allowed {
+                return Err(NoteTransportError::Network(
+                    "connection dropped mid-drain".to_string(),
+                ));
+            }
+            Ok(self.inner.fetch_notes(tags, cursor))
+        }
+
+        async fn stream_notes(
+            &self,
+            _tag: NoteTag,
+            _cursor: miden_client::note_transport::NoteTransportCursor,
+        ) -> std::result::Result<
+            Box<dyn miden_client::note_transport::NoteStream>,
+            NoteTransportError,
+        > {
+            Ok(Box::new(
+                miden_client::testing::note_transport::DummyNoteStream {},
+            ))
+        }
+    }
+
+    /// A connection lost mid-drain after partial progress must not report
+    /// `Unavailable` ("nothing was imported"): it is an interrupted,
+    /// retryable drain and the partial count is kept.
+    #[tokio::test]
+    async fn interrupted_drain_with_partial_progress_reports_a_retryable_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        // Cap each response at one note so the two-note backlog needs two
+        // fetches; the transport dies after the first.
+        let node = Arc::new(RwLock::new(MockNoteTransportNode::with_max_batch(1)));
+        let api: Arc<dyn NoteTransportClient> = Arc::new(InterruptibleTransport {
+            inner: MockNoteTransportApi::new(node.clone()),
+            fetches_before_failure: std::sync::atomic::AtomicUsize::new(1),
+        });
+        let mut client = offline_client(dir.path(), Some(api)).await;
+
+        let account = test_wallet(6);
+        client.add_or_update_account(&account, false).await.unwrap();
+        add_to_transport(&node, private_note_for(&account, 1));
+        // Distinct cursor values require distinct insertion timestamps.
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        add_to_transport(&node, private_note_for(&account, 2));
+
+        let report = client.drain_private_note_backlog().await.unwrap();
+
+        assert_eq!(report.status, TransportRecoveryStatus::Failed);
+        assert!(report.retryable);
+        assert_eq!(report.imported, 1);
+        assert!(report.reason.unwrap().contains("connection dropped"));
     }
 
     // ---------------------------------------------------------------------

--- a/crates/miden-multisig-client/src/client/recovery.rs
+++ b/crates/miden-multisig-client/src/client/recovery.rs
@@ -632,4 +632,82 @@ mod tests {
                 .is_some()
         );
     }
+
+    // ---------------------------------------------------------------------
+    // live smoke (real testnet transport) — run explicitly:
+    //   cargo test -p miden-multisig-client --lib live_testnet -- --ignored
+    // ---------------------------------------------------------------------
+
+    async fn live_client(dir: &Path, with_transport: bool) -> MultisigClient {
+        use miden_client::note_transport::NOTE_TRANSPORT_TESTNET_ENDPOINT;
+
+        let mut builder = MultisigClient::builder()
+            .miden_endpoint(Endpoint::testnet())
+            .guardian_endpoint("http://localhost:1")
+            .account_dir(dir)
+            .generate_key();
+        if with_transport {
+            builder = builder.note_transport_endpoint(NOTE_TRANSPORT_TESTNET_ENDPOINT);
+        }
+        builder.build().await.expect("live client builds")
+    }
+
+    /// The full device-loss round trip over the real testnet transport (the
+    /// scenario spike #412 validated): relay a private note, recover it into
+    /// a fresh store via the drain, and check idempotence plus the
+    /// disabled-transport report. Network-dependent, hence ignored in CI.
+    #[tokio::test]
+    #[ignore = "requires network access to the Miden testnet"]
+    async fn live_testnet_transport_drain_round_trip() {
+        use miden_protocol::address::Address;
+
+        let dir = tempfile::tempdir().unwrap();
+        let account = test_wallet(9);
+
+        // "Old device": relay a private note addressed at the account.
+        // Transport delivery needs no on-chain transaction.
+        let mut sender = live_client(&dir.path().join("sender"), true).await;
+        sender
+            .miden_client
+            .send_private_note(private_note_for(&account, 77), &Address::new(account.id()))
+            .await
+            .expect("transport send succeeds");
+
+        // "New device": fresh store; pulling the account tracks its tag.
+        let mut recovered = live_client(&dir.path().join("recovered"), true).await;
+        recovered
+            .add_or_update_account(&account, false)
+            .await
+            .unwrap();
+
+        let report = recovered.drain_private_note_backlog().await.unwrap();
+        assert_eq!(report.status, TransportRecoveryStatus::Completed);
+        assert!(
+            report.imported >= 1,
+            "the relayed note must be recovered, got {report:?}"
+        );
+
+        let report = recovered.drain_private_note_backlog().await.unwrap();
+        assert_eq!(report.status, TransportRecoveryStatus::Completed);
+        assert_eq!(report.imported, 0, "re-drain must be idempotent");
+
+        // A custom node endpoint derives no transport service (the testnet
+        // preset keeps the upstream default transport), so the drain reports
+        // Unavailable without touching the network.
+        let mut no_transport = MultisigClient::builder()
+            .miden_endpoint(Endpoint::new(
+                "http".to_string(),
+                "node".to_string(),
+                Some(1),
+            ))
+            .guardian_endpoint("http://localhost:1")
+            .account_dir(dir.path().join("no-transport"))
+            .generate_key()
+            .build()
+            .await
+            .expect("custom-endpoint client builds");
+        let report = no_transport.drain_private_note_backlog().await.unwrap();
+        assert_eq!(report.status, TransportRecoveryStatus::Unavailable);
+        assert!(!report.retryable);
+    }
 }

--- a/crates/miden-multisig-client/src/client/recovery.rs
+++ b/crates/miden-multisig-client/src/client/recovery.rs
@@ -1,0 +1,491 @@
+//! Recovery primitives for restoring note state after device loss.
+//!
+//! After recovery on a fresh device the local store has no note-transport
+//! cursor — and in a shared dirty store another account's sync may have
+//! advanced the cursor past notes belonging to the newly recovered account.
+//! The primitives here rescan sources that normal forward sync would skip
+//! (issue #414, sub-issue of #357).
+
+use std::collections::BTreeSet;
+
+use miden_client::ClientError;
+use miden_client::note_transport::NoteTransportError;
+use miden_protocol::note::NoteDetailsCommitment;
+
+use super::MultisigClient;
+use crate::error::{Result, error_chain};
+
+/// Outcome class of a private-note transport backlog drain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransportRecoveryStatus {
+    /// The full transport backlog was scanned; every note the transport still
+    /// holds for the tracked tags is now in the local store.
+    Completed,
+    /// The transport could not be consulted at all: it is disabled for this
+    /// client (no endpoint configured) or unreachable. Nothing was scanned;
+    /// the rest of a recovery flow should proceed without transport notes.
+    Unavailable,
+    /// The drain started but did not finish; the backlog may be partially
+    /// imported. `retryable` distinguishes transient failures (rerun the
+    /// drain) from permanent ones.
+    Failed,
+}
+
+/// Result of [`MultisigClient::drain_private_note_backlog`].
+///
+/// Transport problems are reported here rather than returned as errors so a
+/// transport failure never aborts the rest of a recovery flow.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransportRecoveryReport {
+    /// Outcome class of the drain.
+    pub status: TransportRecoveryStatus,
+    /// Number of note records newly imported into the local store by this
+    /// drain. Can be non-zero even on `Failed`: batches imported before the
+    /// failure stay imported.
+    pub imported: usize,
+    /// Whether rerunning the drain can plausibly succeed (transient
+    /// connectivity failures, the upstream pagination convergence guard).
+    /// Always `false` on `Completed`.
+    pub retryable: bool,
+    /// Human-readable cause when the drain did not complete.
+    pub reason: Option<String>,
+}
+
+impl MultisigClient {
+    /// Rescans the full private-note transport backlog for every tracked note
+    /// tag and imports what it finds, regardless of the stored transport
+    /// cursor (issue #414).
+    ///
+    /// Use after account recovery: a fresh store has no transport cursor, and
+    /// in a shared store another account's sync may have advanced the cursor
+    /// past this account's notes. The drain is idempotent, tag-scoped (the
+    /// recovered account must already be in the store so its note tag is
+    /// tracked — [`MultisigClient::pull_account`] does this), and never
+    /// regresses an already-advanced cursor.
+    ///
+    /// Transport recovery is bounded by the transport service's retention:
+    /// senders may bypass the transport entirely and relayed blobs are pruned
+    /// after the retention window, so this is a best-effort rescan, **not** a
+    /// backup. Transport-disabled and transport-unreachable outcomes are
+    /// reported in the [`TransportRecoveryReport`] rather than returned as
+    /// errors; an `Err` from this method means the local store itself failed.
+    pub async fn drain_private_note_backlog(&mut self) -> Result<TransportRecoveryReport> {
+        if !self.miden_client.is_note_transport_enabled() {
+            return Ok(TransportRecoveryReport {
+                status: TransportRecoveryStatus::Unavailable,
+                imported: 0,
+                retryable: false,
+                reason: Some(
+                    "note transport is not configured for this client; \
+                     set a transport endpoint to relay private notes"
+                        .to_string(),
+                ),
+            });
+        }
+
+        let before = self.input_note_commitments().await?;
+        let drain_result = self.miden_client.fetch_all_private_notes().await;
+        // Count even when the drain failed: each fetched batch is imported as
+        // it arrives, so notes recovered before the failure stay in the store.
+        let after = self.input_note_commitments().await?;
+        let imported = after.difference(&before).count();
+
+        match drain_result {
+            Ok(()) => Ok(TransportRecoveryReport {
+                status: TransportRecoveryStatus::Completed,
+                imported,
+                retryable: false,
+                reason: None,
+            }),
+            Err(err) => {
+                let (status, retryable) = classify_drain_failure(&err);
+                Ok(TransportRecoveryReport {
+                    status,
+                    imported,
+                    retryable,
+                    reason: Some(error_chain(&err)),
+                })
+            }
+        }
+    }
+
+    /// Details commitments of every input note currently in the local store.
+    /// Keyed by details commitment because transport-imported records start
+    /// without metadata (`Expected` state) and so may not have a note ID yet.
+    async fn input_note_commitments(&mut self) -> Result<BTreeSet<NoteDetailsCommitment>> {
+        let records = self
+            .miden_client
+            .get_input_notes(miden_client::store::NoteFilter::All)
+            .await
+            .map_err(|e| {
+                crate::error::MultisigError::miden_client_with_context(
+                    "failed to list input notes",
+                    e,
+                )
+            })?;
+        Ok(records
+            .iter()
+            .map(|record| record.details_commitment())
+            .collect())
+    }
+}
+
+/// Maps a `fetch_all_private_notes` failure onto a report class:
+/// `(status, retryable)`.
+fn classify_drain_failure(err: &ClientError) -> (TransportRecoveryStatus, bool) {
+    match err {
+        ClientError::NoteTransportError(transport_err) => match transport_err {
+            // No transport configured — retrying cannot help until the client
+            // is rebuilt with an endpoint.
+            NoteTransportError::Disabled => (TransportRecoveryStatus::Unavailable, false),
+            // The transport exists but could not be reached — same class as
+            // disabled for a recovery flow (nothing was scanned), but worth
+            // retrying once connectivity returns.
+            NoteTransportError::Connection(_) | NoteTransportError::Network(_) => {
+                (TransportRecoveryStatus::Unavailable, true)
+            }
+            // The upstream convergence guard tripped (the server cursor kept
+            // advancing for 1000 iterations without an empty batch). The
+            // backlog is partially imported; a rerun continues making
+            // progress because imports are idempotent.
+            NoteTransportError::PaginationDidNotTerminate(_) => {
+                (TransportRecoveryStatus::Failed, true)
+            }
+            // Undecodable payloads and any future variants: a rerun would hit
+            // the same bytes again.
+            _ => (TransportRecoveryStatus::Failed, false),
+        },
+        // Each fetched batch is imported through the node (inclusion-proof
+        // lookup), so a node RPC failure mid-drain is transient-connectivity
+        // shaped: the transport itself was fine, retry later.
+        ClientError::RpcError(_) => (TransportRecoveryStatus::Failed, true),
+        _ => (TransportRecoveryStatus::Failed, false),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+    use std::sync::Arc;
+
+    use miden_client::builder::ClientBuilder;
+    use miden_client::keystore::FilesystemKeyStore;
+    use miden_client::note_transport::{NoteTransportClient, NoteTransportError};
+    use miden_client::rpc::Endpoint;
+    use miden_client::testing::mock::MockRpcApi;
+    use miden_client::testing::note_transport::{MockNoteTransportApi, MockNoteTransportNode};
+    use miden_client::{ClientError, Serializable};
+    use miden_client_sqlite_store::SqliteStore;
+    use miden_protocol::Word;
+    use miden_protocol::account::Account;
+    use miden_protocol::account::auth::AuthSecretKey;
+    use miden_protocol::crypto::rand::RandomCoin;
+    use miden_protocol::note::{Note, NoteDetails, NoteTag, NoteType};
+    use miden_standards::account::auth::AuthSingleSig;
+    use miden_standards::note::P2idNote;
+    use miden_tx::utils::sync::RwLock;
+
+    use super::*;
+    use crate::keystore::GuardianKeyStore;
+    use crate::prover::ProverConfig;
+    use crate::rpc::RpcConfig;
+
+    // ---------------------------------------------------------------------
+    // classification
+    // ---------------------------------------------------------------------
+
+    fn transport_error(err: NoteTransportError) -> ClientError {
+        ClientError::NoteTransportError(err)
+    }
+
+    #[test]
+    fn disabled_transport_is_unavailable_and_not_retryable() {
+        let (status, retryable) =
+            classify_drain_failure(&transport_error(NoteTransportError::Disabled));
+        assert_eq!(status, TransportRecoveryStatus::Unavailable);
+        assert!(!retryable);
+    }
+
+    #[test]
+    fn unreachable_transport_is_unavailable_and_retryable() {
+        let connection = NoteTransportError::Connection(Box::new(std::io::Error::new(
+            std::io::ErrorKind::ConnectionRefused,
+            "connection refused",
+        )));
+        let (status, retryable) = classify_drain_failure(&transport_error(connection));
+        assert_eq!(status, TransportRecoveryStatus::Unavailable);
+        assert!(retryable);
+
+        let network = NoteTransportError::Network("transport 503".to_string());
+        let (status, retryable) = classify_drain_failure(&transport_error(network));
+        assert_eq!(status, TransportRecoveryStatus::Unavailable);
+        assert!(retryable);
+    }
+
+    #[test]
+    fn pagination_convergence_guard_is_a_retryable_failure() {
+        let (status, retryable) = classify_drain_failure(&transport_error(
+            NoteTransportError::PaginationDidNotTerminate(1_000),
+        ));
+        assert_eq!(status, TransportRecoveryStatus::Failed);
+        assert!(retryable);
+    }
+
+    #[test]
+    fn node_rpc_failure_mid_drain_is_a_retryable_failure() {
+        let err: ClientError = miden_client::rpc::RpcError::RequestError {
+            endpoint: miden_client::rpc::RpcEndpoint::SyncChainMmr,
+            error_kind: miden_client::rpc::GrpcError::Unavailable,
+            endpoint_error: None,
+            source: None,
+        }
+        .into();
+        let (status, retryable) = classify_drain_failure(&err);
+        assert_eq!(status, TransportRecoveryStatus::Failed);
+        assert!(retryable);
+    }
+
+    #[test]
+    fn other_client_errors_are_permanent_failures() {
+        let (status, retryable) = classify_drain_failure(&ClientError::AddNewAccountWithoutSeed);
+        assert_eq!(status, TransportRecoveryStatus::Failed);
+        assert!(!retryable);
+    }
+
+    // ---------------------------------------------------------------------
+    // offline behavioral tests (mock chain + mock transport)
+    // ---------------------------------------------------------------------
+
+    /// Fully offline MultisigClient: mock chain RPC, SQLite store in a temp
+    /// dir, and (optionally) the upstream mock note transport.
+    async fn offline_client(
+        dir: &Path,
+        transport: Option<Arc<dyn NoteTransportClient>>,
+    ) -> MultisigClient {
+        let store = SqliteStore::new(dir.join("store.sqlite3"))
+            .await
+            .expect("sqlite store opens");
+        let keystore_dir = dir.join("keys");
+        std::fs::create_dir_all(&keystore_dir).expect("keystore dir");
+
+        let mut builder = ClientBuilder::<FilesystemKeyStore>::new()
+            .rpc(Arc::new(MockRpcApi::default()))
+            .store(Arc::new(store))
+            .filesystem_keystore(keystore_dir)
+            .expect("keystore opens");
+        if let Some(transport) = transport {
+            builder = builder.note_transport(transport);
+        }
+        let miden_client = builder.build().await.expect("miden client builds");
+
+        MultisigClient::new(
+            miden_client,
+            Arc::new(GuardianKeyStore::generate()),
+            "http://localhost:1".to_string(),
+            dir.to_path_buf(),
+            Endpoint::localhost(),
+            None,
+            ProverConfig::new(),
+            RpcConfig::new(),
+        )
+    }
+
+    fn mock_transport() -> (
+        Arc<RwLock<MockNoteTransportNode>>,
+        Arc<dyn NoteTransportClient>,
+    ) {
+        let node = Arc::new(RwLock::new(MockNoteTransportNode::new()));
+        let api: Arc<dyn NoteTransportClient> = Arc::new(MockNoteTransportApi::new(node.clone()));
+        (node, api)
+    }
+
+    /// A plain wallet account with a fresh seed; enough for the store-side
+    /// account/tag behavior under test (no multisig components needed).
+    fn test_wallet(seed: u8) -> Account {
+        use miden_client::account::component::BasicWallet;
+        use miden_client::account::{
+            AccountBuilder, AccountBuilderSchemaCommitmentExt, AccountType,
+        };
+        use miden_client::auth::AuthSchemeId;
+
+        let key_pair = AuthSecretKey::new_falcon512_poseidon2();
+        let auth_component = AuthSingleSig::new(
+            key_pair.public_key().to_commitment(),
+            AuthSchemeId::Falcon512Poseidon2,
+        );
+        AccountBuilder::new([seed; 32])
+            .account_type(AccountType::Private)
+            .with_auth_component(auth_component)
+            .with_component(BasicWallet)
+            .build_with_schema_commitment()
+            .expect("test wallet builds")
+    }
+
+    /// A private P2ID note addressed at `target`, in the transport wire form:
+    /// `(header, serialized NoteDetails)`.
+    fn private_note_for(target: &Account) -> Note {
+        let mut rng = RandomCoin::new(Word::default());
+        P2idNote::create(
+            target.id(),
+            target.id(),
+            vec![],
+            NoteType::Private,
+            Default::default(),
+            &mut rng,
+        )
+        .expect("p2id note builds")
+    }
+
+    fn add_to_transport(node: &Arc<RwLock<MockNoteTransportNode>>, note: Note) {
+        let header = *note.header();
+        let details_bytes = NoteDetails::from(note).to_bytes();
+        node.write().add_note(header, details_bytes);
+    }
+
+    #[tokio::test]
+    async fn drain_reports_unavailable_when_transport_is_not_configured() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut client = offline_client(dir.path(), None).await;
+
+        let report = client
+            .drain_private_note_backlog()
+            .await
+            .expect("disabled transport is reported, not thrown");
+
+        assert_eq!(report.status, TransportRecoveryStatus::Unavailable);
+        assert_eq!(report.imported, 0);
+        assert!(!report.retryable);
+        assert!(report.reason.unwrap().contains("not configured"));
+    }
+
+    #[tokio::test]
+    async fn drain_recovers_the_backlog_for_a_tracked_account_and_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let (node, api) = mock_transport();
+        let mut client = offline_client(dir.path(), Some(api)).await;
+
+        // The recovered account is in the store (as after pull_account), so
+        // its standard note tag is tracked.
+        let account = test_wallet(1);
+        client.add_or_update_account(&account, false).await.unwrap();
+        add_to_transport(&node, private_note_for(&account));
+
+        let report = client.drain_private_note_backlog().await.unwrap();
+        assert_eq!(report.status, TransportRecoveryStatus::Completed);
+        assert_eq!(report.imported, 1);
+        assert!(!report.retryable);
+        assert_eq!(report.reason, None);
+
+        // Idempotence: draining again re-fetches the same backlog but imports
+        // nothing new.
+        let report = client.drain_private_note_backlog().await.unwrap();
+        assert_eq!(report.status, TransportRecoveryStatus::Completed);
+        assert_eq!(report.imported, 0);
+    }
+
+    #[tokio::test]
+    async fn drain_is_tag_scoped_a_store_with_no_tracked_tags_imports_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let (node, api) = mock_transport();
+        let mut client = offline_client(dir.path(), Some(api)).await;
+
+        // A note is waiting on the transport, but no account is in the store,
+        // so no tag is tracked.
+        add_to_transport(&node, private_note_for(&test_wallet(2)));
+
+        let report = client.drain_private_note_backlog().await.unwrap();
+        assert_eq!(report.status, TransportRecoveryStatus::Completed);
+        assert_eq!(report.imported, 0);
+    }
+
+    #[tokio::test]
+    async fn drain_never_regresses_an_advanced_transport_cursor() {
+        use miden_client::note_transport::NOTE_TRANSPORT_CURSOR_STORE_SETTING;
+
+        let dir = tempfile::tempdir().unwrap();
+        let (node, api) = mock_transport();
+        let mut client = offline_client(dir.path(), Some(api)).await;
+
+        let account = test_wallet(3);
+        client.add_or_update_account(&account, false).await.unwrap();
+        add_to_transport(&node, private_note_for(&account));
+
+        // Simulate a store whose cursor another account's sync has already
+        // advanced far past this backlog. The store encodes the cursor as raw
+        // big-endian u64 bytes.
+        let advanced: u64 = u64::MAX;
+        client
+            .miden_client
+            .set_setting(
+                NOTE_TRANSPORT_CURSOR_STORE_SETTING.to_string(),
+                advanced.to_be_bytes(),
+            )
+            .await
+            .unwrap();
+
+        // The drain ignores the stored cursor for scanning (the backlogged
+        // note is still recovered)...
+        let report = client.drain_private_note_backlog().await.unwrap();
+        assert_eq!(report.status, TransportRecoveryStatus::Completed);
+        assert_eq!(report.imported, 1);
+
+        // ...but persists max(drain_cursor, stored_cursor): the advanced
+        // cursor survives.
+        let stored: [u8; 8] = client
+            .miden_client
+            .get_setting(NOTE_TRANSPORT_CURSOR_STORE_SETTING.to_string())
+            .await
+            .unwrap()
+            .expect("cursor setting exists");
+        assert_eq!(u64::from_be_bytes(stored), advanced);
+    }
+
+    // ---------------------------------------------------------------------
+    // load/tag regression suite: the store-side behavior pull_account relies
+    // on, which gates whether a drain sees the recovered account at all.
+    // ---------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn adding_an_account_tracks_its_standard_note_tag() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut client = offline_client(dir.path(), None).await;
+
+        let account = test_wallet(4);
+        client.add_or_update_account(&account, false).await.unwrap();
+
+        let expected = NoteTag::with_account_target(account.id());
+        let tags = client.miden_client.get_note_tags().await.unwrap();
+        assert!(
+            tags.iter().any(|record| record.tag == expected),
+            "the recovered account's standard note tag must be tracked after insert"
+        );
+    }
+
+    #[tokio::test]
+    async fn re_adding_an_existing_account_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut client = offline_client(dir.path(), None).await;
+
+        let account = test_wallet(5);
+        client.add_or_update_account(&account, false).await.unwrap();
+        // Reload path: pull_account calls add_or_update_account(_, true) on
+        // an account that is already present.
+        client.add_or_update_account(&account, true).await.unwrap();
+
+        let expected = NoteTag::with_account_target(account.id());
+        let tags = client.miden_client.get_note_tags().await.unwrap();
+        assert_eq!(
+            tags.iter().filter(|record| record.tag == expected).count(),
+            1,
+            "reload must not duplicate or drop the account's note tag"
+        );
+        assert!(
+            client
+                .miden_client
+                .get_account(account.id())
+                .await
+                .unwrap()
+                .is_some()
+        );
+    }
+}

--- a/crates/miden-multisig-client/src/lib.rs
+++ b/crates/miden-multisig-client/src/lib.rs
@@ -67,7 +67,7 @@ pub use client::{
     ConsumableNote, HistoryAssetKind, HistoryDecodeSection, HistoryDecodeWarning, HistoryEntry,
     HistoryEntryStatus, HistoryNote, HistoryNoteAsset, HistoryNoteTag, HistoryNoteVisibility,
     HistoryPage, MultisigClient, NoteFilter, ProposalResult, RecoveredAccount,
-    StateVerificationResult,
+    StateVerificationResult, TransportRecoveryReport, TransportRecoveryStatus,
 };
 
 // Procedures

--- a/docs/MULTISIG_SDK.md
+++ b/docs/MULTISIG_SDK.md
@@ -572,6 +572,44 @@ account executed elsewhere is not included. Output notes whose full
 details are not in the stored summary (e.g. private notes carried as
 partial notes) appear with `tag: 'custom'` and no recipient.
 
+### Draining the Private-Note Transport Backlog
+
+After recovery on a fresh device the local store has no note-transport
+cursor — and in a store shared with other accounts, sync may have advanced
+the cursor past private notes addressed to the newly recovered account.
+Normal sync then never revisits them. `drainPrivateNoteBacklog` rescans the
+full transport backlog for every tracked note tag, regardless of the stored
+cursor (issue #414):
+
+```typescript
+import { drainPrivateNoteBacklog } from '@openzeppelin/miden-multisig-client';
+
+// Run after load(): the drain only sees note tags tracked in the store,
+// and load() inserting the account is what tracks its tag.
+const multisig = await client.load(accountId, signer);
+
+const report = await drainPrivateNoteBacklog(midenClient);
+if (report.status === 'completed') {
+  console.log(`Recovered ${report.imported} private note(s) from the transport`);
+} else if (report.status === 'unavailable') {
+  // Transport disabled or unreachable — reported, never thrown, so the rest
+  // of the recovery flow proceeds without transport notes.
+  console.warn('Note transport unavailable:', report.reason);
+} else if (report.retryable) {
+  // 'failed' with retryable: partial progress is kept (already-imported
+  // batches stay imported); rerunning the drain continues where it got to.
+}
+```
+
+The drain is idempotent and never regresses the stored transport cursor, so
+it is safe to run repeatedly and to combine with normal sync.
+
+**Not a backup:** transport recovery is bounded by the transport service's
+retention. Senders may deliver private notes out-of-band without using the
+transport, and relayed blobs are pruned after the retention window. Notes
+outside both are recoverable only from their sender (see the note
+export/import helpers).
+
 ### Proposal Operations
 
 Every `create*Proposal` method takes a single trailing options object (issue
@@ -751,6 +789,12 @@ await multisig.executeProposal(signedProposal.id);
 | `load(accountId, signer)` | Load existing account from GUARDIAN |
 | `recoverByKey(signer)` | Discover accounts that authorize the signer's key and fetch each current state |
 | `guardianClient` | Access to underlying GUARDIAN HTTP client |
+
+Standalone functions:
+
+| Function | Description |
+|----------|-------------|
+| `drainPrivateNoteBacklog(midenClient)` | Rescan the full private-note transport backlog for tracked tags after recovery; returns a `TransportRecoveryReport` (`completed` / `unavailable` / `failed`) instead of throwing on transport problems |
 
 #### Multisig
 
@@ -935,6 +979,50 @@ Output notes whose full details are not in the stored summary (e.g.
 private notes carried as partial notes) appear with tag `custom` and no
 recipient.
 
+### Draining the Private-Note Transport Backlog
+
+After recovery on a fresh device the local store has no note-transport
+cursor — and in a store shared with other accounts, sync may have advanced
+the cursor past private notes addressed to the newly recovered account.
+Normal sync then never revisits them. `drain_private_note_backlog` rescans
+the full transport backlog for every tracked note tag, regardless of the
+stored cursor (issue #414):
+
+```rust
+use miden_multisig_client::TransportRecoveryStatus;
+
+// Run after pull_account(): the drain only sees note tags tracked in the
+// store, and pull_account() inserting the account is what tracks its tag.
+client.pull_account(account_id).await?;
+
+let report = client.drain_private_note_backlog().await?;
+match report.status {
+    TransportRecoveryStatus::Completed => {
+        println!("Recovered {} private note(s) from the transport", report.imported);
+    }
+    TransportRecoveryStatus::Unavailable => {
+        // Transport disabled or unreachable — reported, never returned as an
+        // error, so the rest of the recovery flow proceeds without it.
+        eprintln!("Note transport unavailable: {:?}", report.reason);
+    }
+    TransportRecoveryStatus::Failed if report.retryable => {
+        // Partial progress is kept (already-imported batches stay imported);
+        // rerunning the drain continues where it got to.
+    }
+    TransportRecoveryStatus::Failed => {}
+}
+```
+
+The drain is idempotent and never regresses the stored transport cursor, so
+it is safe to run repeatedly and to combine with normal sync. An `Err` from
+the method means the local store itself failed, not the transport.
+
+**Not a backup:** transport recovery is bounded by the transport service's
+retention. Senders may deliver private notes out-of-band without using the
+transport, and relayed blobs are pruned after the retention window. Notes
+outside both are recoverable only from their sender (see
+`import_note_from_file`).
+
 ### Transaction Types
 
 ```rust
@@ -1115,6 +1203,7 @@ full note, so a post-commit sync is enough.
 | `user_commitment()` | Get user's key commitment |
 | `user_commitment_hex()` | Get commitment as hex |
 | `recover_by_key()` | Discover accounts that authorize the configured signer and fetch each current state |
+| `drain_private_note_backlog()` | Rescan the full private-note transport backlog for tracked tags after recovery; returns a `TransportRecoveryReport` (`Completed` / `Unavailable` / `Failed`) instead of erroring on transport problems |
 | `propose_transaction(tx)` | Create and submit proposal |
 | `propose_with_fallback(tx)` | Online or offline proposal |
 | `list_proposals()` | List pending proposals |

--- a/docs/MULTISIG_SDK.md
+++ b/docs/MULTISIG_SDK.md
@@ -588,6 +588,8 @@ import { drainPrivateNoteBacklog } from '@openzeppelin/miden-multisig-client';
 // and load() inserting the account is what tracks its tag.
 const multisig = await client.load(accountId, signer);
 
+// Pass the SAME MidenClient instance that was injected into MultisigClient —
+// a different instance has a different store, without the tracked tag.
 const report = await drainPrivateNoteBacklog(midenClient);
 if (report.status === 'completed') {
   console.log(`Recovered ${report.imported} private note(s) from the transport`);
@@ -602,7 +604,10 @@ if (report.status === 'completed') {
 ```
 
 The drain is idempotent and never regresses the stored transport cursor, so
-it is safe to run repeatedly and to combine with normal sync.
+it is safe to run repeatedly and to combine with normal sync. `unavailable`
+always means nothing was imported; a drain interrupted mid-way (connection
+lost after some batches landed) reports `failed` with the partial count
+kept, and rerunning continues it.
 
 **Not a backup:** transport recovery is bounded by the transport service's
 retention. Senders may deliver private notes out-of-band without using the
@@ -1014,8 +1019,11 @@ match report.status {
 ```
 
 The drain is idempotent and never regresses the stored transport cursor, so
-it is safe to run repeatedly and to combine with normal sync. An `Err` from
-the method means the local store itself failed, not the transport.
+it is safe to run repeatedly and to combine with normal sync. `Unavailable`
+always means nothing was imported; a drain interrupted mid-way (connection
+lost after some batches landed) reports `Failed` with the partial count
+kept, and rerunning continues it. An `Err` from the method means the local
+store itself failed, not the transport.
 
 **Not a backup:** transport recovery is bounded by the transport service's
 retention. Senders may deliver private notes out-of-band without using the

--- a/packages/miden-multisig-client/README.md
+++ b/packages/miden-multisig-client/README.md
@@ -185,6 +185,7 @@ account is what tracks its tag.
 import { drainPrivateNoteBacklog } from '@openzeppelin/miden-multisig-client';
 
 const multisig = await client.load(accountId, signer);
+// Pass the SAME MidenClient instance that was injected into MultisigClient.
 const report = await drainPrivateNoteBacklog(midenClient);
 // report.status: 'completed' | 'unavailable' | 'failed'
 // report.imported: number of newly imported note records
@@ -192,9 +193,10 @@ const report = await drainPrivateNoteBacklog(midenClient);
 
 Transport problems are reported in the result, never thrown: `unavailable`
 means the injected `MidenClient` has no `noteTransportUrl` configured or the
-transport could not be reached; `failed` with `retryable: true` keeps any
-partial progress and rerunning the drain continues it. The drain is
-idempotent and never regresses the stored transport cursor.
+transport could not be reached before anything was imported; `failed` with
+`retryable: true` keeps any partial progress and rerunning the drain
+continues it. The drain is idempotent and never regresses the stored
+transport cursor.
 
 Transport recovery is **not a backup**: it is bounded by the transport
 service's retention. Senders may deliver private notes out-of-band without

--- a/packages/miden-multisig-client/README.md
+++ b/packages/miden-multisig-client/README.md
@@ -171,6 +171,36 @@ several accounts, and the helper surfaces all of them rather than silently
 picking one. The returned list is empty (not an error) when no account
 authorizes the queried commitment.
 
+### Drain The Private-Note Transport Backlog
+
+After recovery on a fresh device the local store has no note-transport
+cursor — and in a store shared with other accounts, sync may have advanced
+the cursor past private notes addressed to the newly recovered account.
+`drainPrivateNoteBacklog` rescans the full transport backlog for every
+tracked note tag, regardless of the stored cursor. Run it after `load()`:
+the drain only sees tags tracked in the store, and `load()` inserting the
+account is what tracks its tag.
+
+```typescript
+import { drainPrivateNoteBacklog } from '@openzeppelin/miden-multisig-client';
+
+const multisig = await client.load(accountId, signer);
+const report = await drainPrivateNoteBacklog(midenClient);
+// report.status: 'completed' | 'unavailable' | 'failed'
+// report.imported: number of newly imported note records
+```
+
+Transport problems are reported in the result, never thrown: `unavailable`
+means the injected `MidenClient` has no `noteTransportUrl` configured or the
+transport could not be reached; `failed` with `retryable: true` keeps any
+partial progress and rerunning the drain continues it. The drain is
+idempotent and never regresses the stored transport cursor.
+
+Transport recovery is **not a backup**: it is bounded by the transport
+service's retention. Senders may deliver private notes out-of-band without
+using the transport, and relayed blobs are pruned after the retention
+window.
+
 ### Fetch Account State
 
 ```typescript

--- a/packages/miden-multisig-client/package-lock.json
+++ b/packages/miden-multisig-client/package-lock.json
@@ -15,6 +15,7 @@
         "@openzeppelin/guardian-client": "^0.16.2"
       },
       "devDependencies": {
+        "fake-indexeddb": "^6.2.5",
         "typescript": "^5.7.2",
         "vitest": "^2.1.8"
       },
@@ -1200,6 +1201,15 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -1710,7 +1720,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/packages/miden-multisig-client/package.json
+++ b/packages/miden-multisig-client/package.json
@@ -42,6 +42,7 @@
     "@openzeppelin/guardian-client": "^0.16.2"
   },
   "devDependencies": {
+    "fake-indexeddb": "^6.2.5",
     "typescript": "^5.7.2",
     "vitest": "^2.1.8"
   },

--- a/packages/miden-multisig-client/package.json
+++ b/packages/miden-multisig-client/package.json
@@ -24,7 +24,9 @@
   "files": [
     "dist",
     "src",
-    "masm"
+    "masm",
+    "!dist/testing",
+    "!src/testing"
   ],
   "scripts": {
     "generate:masm": "node ./scripts/generate-masm.mjs",

--- a/packages/miden-multisig-client/src/connectivity.ts
+++ b/packages/miden-multisig-client/src/connectivity.ts
@@ -41,11 +41,15 @@ function isDefinitelyOffline(): boolean {
   return navigator.onLine === false;
 }
 
+/** Best-effort human-readable message from an unknown thrown value. */
+export function errorMessage(err: unknown): string {
+  return (err as { message?: string } | null | undefined)?.message ?? String(err ?? '');
+}
+
 /** Classify a codeless transport failure into a {@link ConnectivityCategory}. */
 function classifyTransportError(err: unknown): ConnectivityCategory {
   if (isDefinitelyOffline()) return 'network';
-  const message = (err as { message?: string } | null | undefined)?.message ?? String(err ?? '');
-  const lower = message.toLowerCase();
+  const lower = errorMessage(err).toLowerCase();
   if (lower.includes('timeout') || lower.includes('timed out') || lower.includes('abort')) {
     return 'timeout';
   }
@@ -57,8 +61,7 @@ function classifyTransportError(err: unknown): ConnectivityCategory {
  * semantic Guardian error)? String heuristic — see module docs.
  */
 export function isLikelyNetworkError(err: unknown): boolean {
-  const message = (err as { message?: string } | null | undefined)?.message ?? String(err ?? '');
-  const lower = message.toLowerCase();
+  const lower = errorMessage(err).toLowerCase();
   if (lower.includes('failed to fetch')) return true;
   if (lower.includes('networkerror')) return true;
   if (lower.includes('network error')) return true;

--- a/packages/miden-multisig-client/src/connectivity.ts
+++ b/packages/miden-multisig-client/src/connectivity.ts
@@ -43,7 +43,9 @@ function isDefinitelyOffline(): boolean {
 
 /** Best-effort human-readable message from an unknown thrown value. */
 export function errorMessage(err: unknown): string {
-  return (err as { message?: string } | null | undefined)?.message ?? String(err ?? '');
+  const message =
+    typeof err === 'object' && err !== null && 'message' in err ? err.message : undefined;
+  return typeof message === 'string' ? message : String(message ?? err ?? '');
 }
 
 /** Classify a codeless transport failure into a {@link ConnectivityCategory}. */

--- a/packages/miden-multisig-client/src/index.ts
+++ b/packages/miden-multisig-client/src/index.ts
@@ -49,6 +49,11 @@ export {
   type MultisigClientConfig,
   type RecoveredAccount,
 } from './client.js';
+export {
+  drainPrivateNoteBacklog,
+  type TransportRecoveryReport,
+  type TransportRecoveryStatus,
+} from './recovery.js';
 export type { ProverConfig, ProverRetryPolicy } from './prover/config.js';
 export type { RpcConfig, RpcRetryPolicy } from './rpc/config.js';
 export { lookupAuthDigest } from './lookupAuth.js';

--- a/packages/miden-multisig-client/src/recovery.test.ts
+++ b/packages/miden-multisig-client/src/recovery.test.ts
@@ -175,7 +175,108 @@ describe('drainPrivateNoteBacklog', () => {
 
     await expect(drainPrivateNoteBacklog(client)).rejects.toThrow('store is corrupted');
   });
+
+  it('rethrows a WASM storage error raised inside the drain', async () => {
+    const { client } = stubClient({
+      before: 0,
+      after: 0,
+      fetchPrivate: async () => {
+        throw new Error('failed fetching all private notes: storage error: Indexdb error');
+      },
+    });
+
+    await expect(drainPrivateNoteBacklog(client)).rejects.toThrow('storage error');
+  });
+
+  it('rethrows an IndexedDB transaction abort raised inside the drain', async () => {
+    const abort = new Error('Transaction aborted');
+    abort.name = 'AbortError';
+    const { client } = stubClient({
+      before: 0,
+      after: 0,
+      fetchPrivate: async () => {
+        throw abort;
+      },
+    });
+
+    await expect(drainPrivateNoteBacklog(client)).rejects.toThrow('Transaction aborted');
+  });
+
+  it('keeps a generic request abort as a transport report, not a store failure', async () => {
+    const abort = new Error('The operation was aborted');
+    abort.name = 'AbortError';
+    const { client } = stubClient({
+      before: 0,
+      after: 0,
+      fetchPrivate: async () => {
+        throw abort;
+      },
+    });
+
+    const report = await drainPrivateNoteBacklog(client);
+
+    expect(report.status).toBe('unavailable');
+    expect(report.retryable).toBe(true);
+  });
+
+  it('classifies throws with a non-string message without crashing', async () => {
+    const { client } = stubClient({
+      before: 0,
+      after: 0,
+      fetchPrivate: async () => {
+        // eslint-disable-next-line @typescript-eslint/only-throw-error
+        throw { message: 42 };
+      },
+    });
+
+    const report = await drainPrivateNoteBacklog(client);
+
+    expect(report.status).toBe('failed');
+    expect(report.retryable).toBe(false);
+    expect(report.reason).toBe('42');
+  });
 });
+
+/**
+ * Raw access to the WASM store's note-transport cursor. The public
+ * `settings` API runs values through the JS<->WASM serde codec, which is NOT
+ * the store's raw encoding (seeding through it corrupts the cursor), so the
+ * cursor tests read/write the IndexedDB row directly. Schema coupling, kept
+ * minimal: store `settings`, keyPath `key`, `value` holds the raw big-endian
+ * u64 bytes — the same representation the Rust cursor test pins.
+ */
+const CURSOR_KEY = 'note_transport_cursor';
+
+async function withSettingsStore<T>(
+  mode: IDBTransactionMode,
+  operation: (store: IDBObjectStore) => IDBRequest<T>,
+): Promise<T> {
+  const db: IDBDatabase = await new Promise((resolve, reject) => {
+    const request = indexedDB.open('mock_client_db');
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+  try {
+    return await new Promise((resolve, reject) => {
+      const request = operation(db.transaction('settings', mode).objectStore('settings'));
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+  } finally {
+    db.close();
+  }
+}
+
+async function seedRawCursor(bytes: Uint8Array): Promise<void> {
+  await withSettingsStore('readwrite', (store) => store.put({ key: CURSOR_KEY, value: bytes }));
+}
+
+async function readRawCursor(): Promise<Uint8Array | undefined> {
+  const row = await withSettingsStore<{ value?: Uint8Array } | undefined>('readonly', (store) =>
+    store.get(CURSOR_KEY),
+  );
+  return row?.value;
+}
 
 /**
  * Behavioral tests against the real WASM mock client: the full device-loss
@@ -203,17 +304,26 @@ describe('drainPrivateNoteBacklog (wasm mock client)', () => {
     const transportState = await deviceA.serializeMockNoteTransportNode();
 
     // Device B ("new device after loss"): fresh store sharing the same
-    // transport backlog. Loading the recovered account tracks its note tag
-    // (the load/tag invariant the drain depends on).
+    // transport backlog. Inserting the recovered account tracks its note tag
+    // (the store invariant the drain depends on).
     freshDevice();
     const deviceB = await MidenClient.createMock({ serializedNoteTransport: transportState });
     expect(await deviceB.notes.list()).toHaveLength(0);
     await deviceB.accounts.insert({ account: Account.deserialize(accountBytes), overwrite: true });
 
+    // Simulate a store whose cursor another account's sync already advanced
+    // far past this backlog.
+    const advancedCursor = new Uint8Array(8).fill(0xff);
+    await seedRawCursor(advancedCursor);
+
     const first = await drainPrivateNoteBacklog(deviceB);
     expect(first.status).toBe('completed');
     expect(first.imported).toBe(1);
     expect(first.retryable).toBe(false);
+
+    // The drain ignored the advanced cursor for scanning (the note above was
+    // still recovered) and did not regress it afterward.
+    expect(await readRawCursor()).toEqual(advancedCursor);
 
     // Idempotence: draining again re-fetches the same backlog but imports
     // nothing new.
@@ -234,7 +344,7 @@ describe('drainPrivateNoteBacklog (wasm mock client)', () => {
     expect(blind.imported).toBe(0);
   }, 120_000);
 
-  it('tracks the standard note tag when a recovered account is inserted (load path)', async () => {
+  it('tracks the standard note tag when a recovered account is inserted', async () => {
     const { MidenClient, Account, NoteTag, AccountId } = await import('@miden-sdk/miden-sdk');
 
     freshDevice();

--- a/packages/miden-multisig-client/src/recovery.test.ts
+++ b/packages/miden-multisig-client/src/recovery.test.ts
@@ -9,28 +9,32 @@ import { drainPrivateNoteBacklog } from './recovery.js';
  * tests (further down) run against the real WASM mock client.
  */
 function stubClient(options: {
-  listLengths: number[];
+  /** Note count before the drain (first `notes.list()` call). */
+  before: number;
+  /** Note count after the drain (subsequent `notes.list()` calls). */
+  after: number;
   fetchPrivate: (opts?: { mode?: string }) => Promise<void>;
-}): { client: MidenClient; fetchPrivate: ReturnType<typeof vi.fn> } {
+}): {
+  client: MidenClient;
+  fetchPrivate: ReturnType<typeof vi.fn>;
+  list: ReturnType<typeof vi.fn>;
+} {
   let call = 0;
   const fetchPrivate = vi.fn(options.fetchPrivate);
-  const client = {
-    notes: {
-      list: vi.fn(async () => {
-        const length = options.listLengths[Math.min(call, options.listLengths.length - 1)];
-        call += 1;
-        return new Array(length).fill({});
-      }),
-      fetchPrivate,
-    },
-  } as unknown as MidenClient;
-  return { client, fetchPrivate };
+  const list = vi.fn(async () => {
+    const length = call === 0 ? options.before : options.after;
+    call += 1;
+    return new Array(length).fill({});
+  });
+  const client = { notes: { list, fetchPrivate } } as unknown as MidenClient;
+  return { client, fetchPrivate, list };
 }
 
 describe('drainPrivateNoteBacklog', () => {
   it('reports completed with the count of newly imported records', async () => {
     const { client, fetchPrivate } = stubClient({
-      listLengths: [1, 3],
+      before: 1,
+      after: 3,
       fetchPrivate: async () => {},
     });
 
@@ -42,7 +46,8 @@ describe('drainPrivateNoteBacklog', () => {
 
   it('reports a disabled transport as unavailable, not retryable, without throwing', async () => {
     const { client } = stubClient({
-      listLengths: [0, 0],
+      before: 0,
+      after: 0,
       fetchPrivate: async () => {
         throw new Error(
           'note transport is disabled; enable it in the client configuration to send or receive notes via P2P',
@@ -58,9 +63,44 @@ describe('drainPrivateNoteBacklog', () => {
     expect(report.reason).toContain('note transport is disabled');
   });
 
+  it('skips the post-drain store re-count when the transport is disabled', async () => {
+    const { client, list } = stubClient({
+      before: 0,
+      after: 0,
+      fetchPrivate: async () => {
+        throw new Error('note transport is disabled');
+      },
+    });
+
+    await drainPrivateNoteBacklog(client);
+
+    // A disabled transport throws before fetching anything, so only the
+    // initial count runs.
+    expect(list).toHaveBeenCalledTimes(1);
+  });
+
+  it('escalates a connection lost mid-drain with partial progress to a retryable failure', async () => {
+    const { client } = stubClient({
+      before: 0,
+      after: 3,
+      fetchPrivate: async () => {
+        throw new TypeError('Failed to fetch');
+      },
+    });
+
+    const report = await drainPrivateNoteBacklog(client);
+
+    // `unavailable` promises "nothing was imported"; with partial progress
+    // the honest class is an interrupted, retryable drain.
+    expect(report.status).toBe('failed');
+    expect(report.retryable).toBe(true);
+    expect(report.imported).toBe(3);
+  });
+
   it('reports an unreachable transport as unavailable and retryable', async () => {
     const { client } = stubClient({
-      listLengths: [0, 0],
+      before: 0,
+      after: 0,
       fetchPrivate: async () => {
         throw new TypeError('Failed to fetch');
       },
@@ -74,7 +114,8 @@ describe('drainPrivateNoteBacklog', () => {
 
   it('reports the pagination convergence guard as a retryable failure, keeping the partial count', async () => {
     const { client } = stubClient({
-      listLengths: [0, 5],
+      before: 0,
+      after: 5,
       fetchPrivate: async () => {
         throw new Error(
           'fetch_all_private_notes did not converge after 1000 iterations — the server cursor is advancing but never returns an empty batch',
@@ -92,7 +133,8 @@ describe('drainPrivateNoteBacklog', () => {
 
   it('reports unrecognized errors as a permanent failure', async () => {
     const { client } = stubClient({
-      listLengths: [0, 0],
+      before: 0,
+      after: 0,
       fetchPrivate: async () => {
         throw new Error('deserialization error: invalid note details');
       },
@@ -107,7 +149,8 @@ describe('drainPrivateNoteBacklog', () => {
 
   it('classifies non-Error throws without crashing', async () => {
     const { client } = stubClient({
-      listLengths: [0, 0],
+      before: 0,
+      after: 0,
       fetchPrivate: async () => {
         // eslint-disable-next-line @typescript-eslint/only-throw-error
         throw 'note transport is disabled';

--- a/packages/miden-multisig-client/src/recovery.test.ts
+++ b/packages/miden-multisig-client/src/recovery.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { MidenClient } from '@miden-sdk/miden-sdk';
+import { freshDeviceStore as freshDevice } from './testing/fake-indexeddb-device.js';
+import { drainPrivateNoteBacklog } from './recovery.js';
+
+/**
+ * Classification tests use hand-rolled stub clients — the primitive takes the
+ * `MidenClient` as an argument, so no module mocking is needed. Behavioral
+ * tests (further down) run against the real WASM mock client.
+ */
+function stubClient(options: {
+  listLengths: number[];
+  fetchPrivate: (opts?: { mode?: string }) => Promise<void>;
+}): { client: MidenClient; fetchPrivate: ReturnType<typeof vi.fn> } {
+  let call = 0;
+  const fetchPrivate = vi.fn(options.fetchPrivate);
+  const client = {
+    notes: {
+      list: vi.fn(async () => {
+        const length = options.listLengths[Math.min(call, options.listLengths.length - 1)];
+        call += 1;
+        return new Array(length).fill({});
+      }),
+      fetchPrivate,
+    },
+  } as unknown as MidenClient;
+  return { client, fetchPrivate };
+}
+
+describe('drainPrivateNoteBacklog', () => {
+  it('reports completed with the count of newly imported records', async () => {
+    const { client, fetchPrivate } = stubClient({
+      listLengths: [1, 3],
+      fetchPrivate: async () => {},
+    });
+
+    const report = await drainPrivateNoteBacklog(client);
+
+    expect(fetchPrivate).toHaveBeenCalledWith({ mode: 'all' });
+    expect(report).toEqual({ status: 'completed', imported: 2, retryable: false });
+  });
+
+  it('reports a disabled transport as unavailable, not retryable, without throwing', async () => {
+    const { client } = stubClient({
+      listLengths: [0, 0],
+      fetchPrivate: async () => {
+        throw new Error(
+          'note transport is disabled; enable it in the client configuration to send or receive notes via P2P',
+        );
+      },
+    });
+
+    const report = await drainPrivateNoteBacklog(client);
+
+    expect(report.status).toBe('unavailable');
+    expect(report.imported).toBe(0);
+    expect(report.retryable).toBe(false);
+    expect(report.reason).toContain('note transport is disabled');
+  });
+
+  it('reports an unreachable transport as unavailable and retryable', async () => {
+    const { client } = stubClient({
+      listLengths: [0, 0],
+      fetchPrivate: async () => {
+        throw new TypeError('Failed to fetch');
+      },
+    });
+
+    const report = await drainPrivateNoteBacklog(client);
+
+    expect(report.status).toBe('unavailable');
+    expect(report.retryable).toBe(true);
+  });
+
+  it('reports the pagination convergence guard as a retryable failure, keeping the partial count', async () => {
+    const { client } = stubClient({
+      listLengths: [0, 5],
+      fetchPrivate: async () => {
+        throw new Error(
+          'fetch_all_private_notes did not converge after 1000 iterations — the server cursor is advancing but never returns an empty batch',
+        );
+      },
+    });
+
+    const report = await drainPrivateNoteBacklog(client);
+
+    expect(report.status).toBe('failed');
+    expect(report.retryable).toBe(true);
+    // Batches imported before the failure stay imported and are counted.
+    expect(report.imported).toBe(5);
+  });
+
+  it('reports unrecognized errors as a permanent failure', async () => {
+    const { client } = stubClient({
+      listLengths: [0, 0],
+      fetchPrivate: async () => {
+        throw new Error('deserialization error: invalid note details');
+      },
+    });
+
+    const report = await drainPrivateNoteBacklog(client);
+
+    expect(report.status).toBe('failed');
+    expect(report.retryable).toBe(false);
+    expect(report.reason).toContain('deserialization');
+  });
+
+  it('classifies non-Error throws without crashing', async () => {
+    const { client } = stubClient({
+      listLengths: [0, 0],
+      fetchPrivate: async () => {
+        // eslint-disable-next-line @typescript-eslint/only-throw-error
+        throw 'note transport is disabled';
+      },
+    });
+
+    const report = await drainPrivateNoteBacklog(client);
+
+    expect(report.status).toBe('unavailable');
+    expect(report.reason).toBe('note transport is disabled');
+  });
+
+  it('propagates local store failures instead of misreporting them as transport outcomes', async () => {
+    const client = {
+      notes: {
+        list: vi.fn(async () => {
+          throw new Error('store is corrupted');
+        }),
+        fetchPrivate: vi.fn(),
+      },
+    } as unknown as MidenClient;
+
+    await expect(drainPrivateNoteBacklog(client)).rejects.toThrow('store is corrupted');
+  });
+});
+
+/**
+ * Behavioral tests against the real WASM mock client: the full device-loss
+ * round trip the spike (#412) validated, entirely offline.
+ */
+describe('drainPrivateNoteBacklog (wasm mock client)', () => {
+  it('recovers a transport-delivered private note into a fresh store, idempotently and tag-scoped', async () => {
+    const { MidenClient, Account, createP2IDNote, NoteVisibility } = await import(
+      '@miden-sdk/miden-sdk'
+    );
+
+    // Device A: create the account and relay a private self-addressed note
+    // via the (mock) transport.
+    freshDevice();
+    const deviceA = await MidenClient.createMock();
+    const account = await deviceA.accounts.create();
+    const accountBytes = account.serialize();
+    const note = await createP2IDNote({
+      from: account,
+      to: account,
+      assets: [],
+      type: NoteVisibility.Private,
+    });
+    await deviceA.notes.sendPrivate({ note, to: account });
+    const transportState = await deviceA.serializeMockNoteTransportNode();
+
+    // Device B ("new device after loss"): fresh store sharing the same
+    // transport backlog. Loading the recovered account tracks its note tag
+    // (the load/tag invariant the drain depends on).
+    freshDevice();
+    const deviceB = await MidenClient.createMock({ serializedNoteTransport: transportState });
+    expect(await deviceB.notes.list()).toHaveLength(0);
+    await deviceB.accounts.insert({ account: Account.deserialize(accountBytes), overwrite: true });
+
+    const first = await drainPrivateNoteBacklog(deviceB);
+    expect(first.status).toBe('completed');
+    expect(first.imported).toBe(1);
+    expect(first.retryable).toBe(false);
+
+    // Idempotence: draining again re-fetches the same backlog but imports
+    // nothing new.
+    const second = await drainPrivateNoteBacklog(deviceB);
+    expect(second.status).toBe('completed');
+    expect(second.imported).toBe(0);
+
+    // Cursor sanity: the incremental fetch after a drain is a no-op.
+    await deviceB.notes.fetchPrivate();
+    expect(await deviceB.notes.list()).toHaveLength(1);
+
+    // Tag-scoping: a fresh store that does NOT track the account's tag
+    // drains nothing from the same backlog.
+    freshDevice();
+    const blindDevice = await MidenClient.createMock({ serializedNoteTransport: transportState });
+    const blind = await drainPrivateNoteBacklog(blindDevice);
+    expect(blind.status).toBe('completed');
+    expect(blind.imported).toBe(0);
+  }, 120_000);
+
+  it('tracks the standard note tag when a recovered account is inserted (load path)', async () => {
+    const { MidenClient, Account, NoteTag, AccountId } = await import('@miden-sdk/miden-sdk');
+
+    freshDevice();
+    const deviceA = await MidenClient.createMock();
+    const account = await deviceA.accounts.create();
+    const accountBytes = account.serialize();
+    const accountIdHex = account.id().toString();
+
+    freshDevice();
+    const deviceB = await MidenClient.createMock();
+    expect(await deviceB.tags.list()).toHaveLength(0);
+
+    await deviceB.accounts.insert({ account: Account.deserialize(accountBytes), overwrite: true });
+
+    const expectedTag = NoteTag.withAccountTarget(AccountId.fromHex(accountIdHex)).asU32();
+    expect(await deviceB.tags.list()).toContain(expectedTag);
+
+    // Reload path: inserting the same account again must stay idempotent.
+    await deviceB.accounts.insert({ account: Account.deserialize(accountBytes), overwrite: true });
+    const tags = (await deviceB.tags.list()).filter((tag) => tag === expectedTag);
+    expect(tags).toHaveLength(1);
+  }, 120_000);
+});

--- a/packages/miden-multisig-client/src/recovery.ts
+++ b/packages/miden-multisig-client/src/recovery.ts
@@ -9,7 +9,7 @@
  */
 
 import type { MidenClient } from '@miden-sdk/miden-sdk';
-import { isLikelyNetworkError } from './connectivity.js';
+import { errorMessage, isLikelyNetworkError } from './connectivity.js';
 
 /**
  * Outcome class of a private-note transport backlog drain:
@@ -17,8 +17,10 @@ import { isLikelyNetworkError } from './connectivity.js';
  *   transport still holds for the tracked tags is now in the local store.
  * - `unavailable` — the transport could not be consulted at all: it is
  *   disabled for the injected `MidenClient` (no `noteTransportUrl`
- *   configured) or unreachable. Nothing was scanned; the rest of a recovery
- *   flow should proceed without transport notes.
+ *   configured) or unreachable before anything was imported (`imported` is
+ *   always 0 — a connection lost mid-drain after partial progress reports
+ *   `failed` instead). The rest of a recovery flow should proceed without
+ *   transport notes.
  * - `failed` — the drain started but did not finish; the backlog may be
  *   partially imported. `retryable` distinguishes transient failures (rerun
  *   the drain) from permanent ones.
@@ -56,48 +58,62 @@ export interface TransportRecoveryReport {
  * `connectivity.ts`). These fragments come from miden-client's
  * `NoteTransportError` `Display` impls.
  */
-const TRANSPORT_DISABLED_FRAGMENT = 'note transport is disabled';
-const PAGINATION_GUARD_FRAGMENT = 'did not converge';
+/** Exported for the drift-guard test, which pins them against the shipped WASM binary. */
+export const TRANSPORT_DISABLED_FRAGMENT = 'note transport is disabled';
+/** Exported for the drift-guard test, which pins them against the shipped WASM binary. */
+export const PAGINATION_GUARD_FRAGMENT = 'did not converge';
 
-function classifyDrainFailure(err: unknown): {
+interface DrainFailure {
   status: TransportRecoveryStatus;
   retryable: boolean;
-} {
-  const message = (err as { message?: string } | null | undefined)?.message ?? String(err ?? '');
-  const lower = message.toLowerCase();
+  reason: string;
+  /**
+   * `false` when the failure proves nothing was fetched (disabled transport
+   * throws before any scan), so the store does not need re-counting.
+   */
+  scanned: boolean;
+}
+
+function classifyDrainFailure(err: unknown): DrainFailure {
+  const reason = errorMessage(err);
+  const lower = reason.toLowerCase();
   // No transport configured — retrying cannot help until the MidenClient is
-  // rebuilt with a `noteTransportUrl`.
+  // rebuilt with a `noteTransportUrl`. Thrown before anything is fetched.
   if (lower.includes(TRANSPORT_DISABLED_FRAGMENT)) {
-    return { status: 'unavailable', retryable: false };
+    return { status: 'unavailable', retryable: false, reason, scanned: false };
   }
   // The upstream convergence guard tripped (the server cursor kept advancing
-  // for 1000 iterations without an empty batch). The backlog is partially
-  // imported; a rerun continues making progress because imports are
-  // idempotent.
+  // for 1000 iterations without an empty batch) — a server-side bug, not an
+  // honest backlog. Retryable in the sense that a rerun is safe (imports are
+  // idempotent) and succeeds once the server recovers.
   if (lower.includes(PAGINATION_GUARD_FRAGMENT)) {
-    return { status: 'failed', retryable: true };
+    return { status: 'failed', retryable: true, reason, scanned: true };
   }
-  // The transport exists but could not be reached — same class as disabled
-  // for a recovery flow (nothing was scanned), but worth retrying once
-  // connectivity returns.
+  // Connectivity-shaped wording: the transport (or the node, mid-import —
+  // the message text cannot tell them apart) could not be reached; worth
+  // retrying once connectivity returns.
   if (isLikelyNetworkError(err)) {
-    return { status: 'unavailable', retryable: true };
+    return { status: 'unavailable', retryable: true, reason, scanned: true };
   }
-  return { status: 'failed', retryable: false };
+  return { status: 'failed', retryable: false, reason, scanned: true };
 }
 
 /**
  * Rescans the full private-note transport backlog for every tracked note tag
  * and imports what it finds, regardless of the stored transport cursor
- * (issue #414). Mirrors `MultisigClient::drain_private_note_backlog` in the
- * Rust SDK.
+ * (issue #414). Counterpart of `MultisigClient::drain_private_note_backlog`
+ * in the Rust SDK; note that the WASM boundary exposes only error message
+ * text, so failure classification here is message-based and cannot always
+ * distinguish a node connectivity failure mid-import from a transport
+ * connectivity failure — both classes are reported retryable.
  *
- * Use after account recovery: a fresh store has no transport cursor, and in
- * a shared store another account's sync may have advanced the cursor past
- * this account's notes. The drain is idempotent, tag-scoped (the recovered
- * account must already be in the store so its note tag is tracked —
- * `MultisigClient.load` does this), and never regresses an already-advanced
- * cursor.
+ * Use after account recovery, passing the **same** `MidenClient` instance
+ * that was injected into `MultisigClient`: a fresh store has no transport
+ * cursor, and in a shared store another account's sync may have advanced the
+ * cursor past this account's notes. The drain is idempotent, tag-scoped (the
+ * recovered account must already be in the store so its note tag is tracked
+ * — `MultisigClient.load` does this), and never regresses an
+ * already-advanced cursor.
  *
  * Transport recovery is bounded by the transport service's retention:
  * senders may bypass the transport entirely and relayed blobs are pruned
@@ -110,29 +126,30 @@ export async function drainPrivateNoteBacklog(
   midenClient: MidenClient,
 ): Promise<TransportRecoveryReport> {
   const before = (await midenClient.notes.list()).length;
+  // Records are never removed by a drain, so the length delta is the count
+  // of newly imported records. Caveat: it is a store delta — notes imported
+  // by concurrent activity on the same store (a background sync, another
+  // tab) during the drain are attributed to it.
+  const importedSince = async (): Promise<number> =>
+    Math.max((await midenClient.notes.list()).length - before, 0);
 
-  let failed = false;
-  let failure: unknown;
   try {
     await midenClient.notes.fetchPrivate({ mode: 'all' });
   } catch (err) {
-    failed = true;
-    failure = err;
+    const { status, retryable, reason, scanned } = classifyDrainFailure(err);
+    // Count even when the drain failed: each fetched batch is imported as it
+    // arrives, so notes recovered before the failure stay in the store. A
+    // disabled transport throws before fetching anything, so skip the
+    // re-count entirely.
+    const imported = scanned ? await importedSince() : 0;
+    if (status === 'unavailable' && imported > 0) {
+      // `unavailable` promises "nothing was imported"; a connection lost
+      // mid-drain after partial progress is an interrupted drain, so report
+      // it as a retryable failure instead.
+      return { status: 'failed', imported, retryable: true, reason };
+    }
+    return { status, imported, retryable, reason };
   }
 
-  // Count even when the drain failed: each fetched batch is imported as it
-  // arrives, so notes recovered before the failure stay in the store.
-  // Records are never removed by a drain, so the length delta is the count
-  // of newly imported records.
-  const after = (await midenClient.notes.list()).length;
-  const imported = Math.max(after - before, 0);
-
-  if (!failed) {
-    return { status: 'completed', imported, retryable: false };
-  }
-
-  const { status, retryable } = classifyDrainFailure(failure);
-  const message =
-    (failure as { message?: string } | null | undefined)?.message ?? String(failure ?? '');
-  return { status, imported, retryable, reason: message };
+  return { status: 'completed', imported: await importedSince(), retryable: false };
 }

--- a/packages/miden-multisig-client/src/recovery.ts
+++ b/packages/miden-multisig-client/src/recovery.ts
@@ -1,0 +1,138 @@
+/**
+ * Recovery primitives for restoring note state after device loss.
+ *
+ * After recovery on a fresh device the local store has no note-transport
+ * cursor — and in a shared dirty store another account's sync may have
+ * advanced the cursor past notes belonging to the newly recovered account.
+ * The primitives here rescan sources that normal forward sync would skip
+ * (issue #414, sub-issue of #357).
+ */
+
+import type { MidenClient } from '@miden-sdk/miden-sdk';
+import { isLikelyNetworkError } from './connectivity.js';
+
+/**
+ * Outcome class of a private-note transport backlog drain:
+ * - `completed` — the full transport backlog was scanned; every note the
+ *   transport still holds for the tracked tags is now in the local store.
+ * - `unavailable` — the transport could not be consulted at all: it is
+ *   disabled for the injected `MidenClient` (no `noteTransportUrl`
+ *   configured) or unreachable. Nothing was scanned; the rest of a recovery
+ *   flow should proceed without transport notes.
+ * - `failed` — the drain started but did not finish; the backlog may be
+ *   partially imported. `retryable` distinguishes transient failures (rerun
+ *   the drain) from permanent ones.
+ */
+export type TransportRecoveryStatus = 'completed' | 'unavailable' | 'failed';
+
+/**
+ * Result of {@link drainPrivateNoteBacklog}.
+ *
+ * Transport problems are reported here rather than thrown so a transport
+ * failure never aborts the rest of a recovery flow.
+ */
+export interface TransportRecoveryReport {
+  /** Outcome class of the drain. */
+  status: TransportRecoveryStatus;
+  /**
+   * Number of note records newly imported into the local store by this
+   * drain. Can be non-zero even on `failed`: batches imported before the
+   * failure stay imported.
+   */
+  imported: number;
+  /**
+   * Whether rerunning the drain can plausibly succeed (transient
+   * connectivity failures, the upstream pagination convergence guard).
+   * Always `false` on `completed`.
+   */
+  retryable: boolean;
+  /** Human-readable cause when the drain did not complete. */
+  reason?: string;
+}
+
+/**
+ * The WASM client surfaces the upstream transport errors as plain messages,
+ * so the message text is the only stable join key (same approach as
+ * `connectivity.ts`). These fragments come from miden-client's
+ * `NoteTransportError` `Display` impls.
+ */
+const TRANSPORT_DISABLED_FRAGMENT = 'note transport is disabled';
+const PAGINATION_GUARD_FRAGMENT = 'did not converge';
+
+function classifyDrainFailure(err: unknown): {
+  status: TransportRecoveryStatus;
+  retryable: boolean;
+} {
+  const message = (err as { message?: string } | null | undefined)?.message ?? String(err ?? '');
+  const lower = message.toLowerCase();
+  // No transport configured — retrying cannot help until the MidenClient is
+  // rebuilt with a `noteTransportUrl`.
+  if (lower.includes(TRANSPORT_DISABLED_FRAGMENT)) {
+    return { status: 'unavailable', retryable: false };
+  }
+  // The upstream convergence guard tripped (the server cursor kept advancing
+  // for 1000 iterations without an empty batch). The backlog is partially
+  // imported; a rerun continues making progress because imports are
+  // idempotent.
+  if (lower.includes(PAGINATION_GUARD_FRAGMENT)) {
+    return { status: 'failed', retryable: true };
+  }
+  // The transport exists but could not be reached — same class as disabled
+  // for a recovery flow (nothing was scanned), but worth retrying once
+  // connectivity returns.
+  if (isLikelyNetworkError(err)) {
+    return { status: 'unavailable', retryable: true };
+  }
+  return { status: 'failed', retryable: false };
+}
+
+/**
+ * Rescans the full private-note transport backlog for every tracked note tag
+ * and imports what it finds, regardless of the stored transport cursor
+ * (issue #414). Mirrors `MultisigClient::drain_private_note_backlog` in the
+ * Rust SDK.
+ *
+ * Use after account recovery: a fresh store has no transport cursor, and in
+ * a shared store another account's sync may have advanced the cursor past
+ * this account's notes. The drain is idempotent, tag-scoped (the recovered
+ * account must already be in the store so its note tag is tracked —
+ * `MultisigClient.load` does this), and never regresses an already-advanced
+ * cursor.
+ *
+ * Transport recovery is bounded by the transport service's retention:
+ * senders may bypass the transport entirely and relayed blobs are pruned
+ * after the retention window, so this is a best-effort rescan, **not** a
+ * backup. Transport-disabled and transport-unreachable outcomes are reported
+ * in the {@link TransportRecoveryReport} rather than thrown; this function
+ * only throws when the local store itself fails.
+ */
+export async function drainPrivateNoteBacklog(
+  midenClient: MidenClient,
+): Promise<TransportRecoveryReport> {
+  const before = (await midenClient.notes.list()).length;
+
+  let failed = false;
+  let failure: unknown;
+  try {
+    await midenClient.notes.fetchPrivate({ mode: 'all' });
+  } catch (err) {
+    failed = true;
+    failure = err;
+  }
+
+  // Count even when the drain failed: each fetched batch is imported as it
+  // arrives, so notes recovered before the failure stay in the store.
+  // Records are never removed by a drain, so the length delta is the count
+  // of newly imported records.
+  const after = (await midenClient.notes.list()).length;
+  const imported = Math.max(after - before, 0);
+
+  if (!failed) {
+    return { status: 'completed', imported, retryable: false };
+  }
+
+  const { status, retryable } = classifyDrainFailure(failure);
+  const message =
+    (failure as { message?: string } | null | undefined)?.message ?? String(failure ?? '');
+  return { status, imported, retryable, reason: message };
+}

--- a/packages/miden-multisig-client/src/recovery.ts
+++ b/packages/miden-multisig-client/src/recovery.ts
@@ -62,6 +62,43 @@ export interface TransportRecoveryReport {
 export const TRANSPORT_DISABLED_FRAGMENT = 'note transport is disabled';
 /** Exported for the drift-guard test, which pins them against the shipped WASM binary. */
 export const PAGINATION_GUARD_FRAGMENT = 'did not converge';
+/**
+ * `ClientError::StoreError`'s Display prefix in the WASM error chain.
+ * Exported for the drift-guard test, which pins it against the shipped WASM
+ * binary.
+ */
+export const STORE_ERROR_FRAGMENT = 'storage error';
+
+/**
+ * IndexedDB/Dexie error names that mean the local store itself failed —
+ * these must reject (matching the Rust `StoreError` branch), never be folded
+ * into a transport report.
+ */
+const STORE_ERROR_NAMES = ['QuotaExceededError', 'DatabaseClosedError', 'ReadOnlyError', 'TransactionInactiveError'];
+
+/**
+ * Does this failure mean the local store is broken (as opposed to a
+ * transport/node problem)? Kept deliberately narrow: `AbortError` counts
+ * only when its message points at an IndexedDB transaction/database abort —
+ * network requests also abort, and those stay transport-classified.
+ */
+function isLocalStoreError(err: unknown): boolean {
+  const message = errorMessage(err);
+  const lower = message.toLowerCase();
+  if (lower.includes(STORE_ERROR_FRAGMENT)) return true;
+  const name =
+    typeof err === 'object' && err !== null && 'name' in err && typeof err.name === 'string'
+      ? err.name
+      : undefined;
+  if (name !== undefined && STORE_ERROR_NAMES.includes(name)) return true;
+  // The WASM bridge may stringify the underlying store error into the
+  // message rather than preserving the name.
+  if (STORE_ERROR_NAMES.some((storeName) => message.includes(storeName))) return true;
+  if (name === 'AbortError' && (lower.includes('transaction') || lower.includes('database'))) {
+    return true;
+  }
+  return false;
+}
 
 interface DrainFailure {
   status: TransportRecoveryStatus;
@@ -136,6 +173,13 @@ export async function drainPrivateNoteBacklog(
   try {
     await midenClient.notes.fetchPrivate({ mode: 'all' });
   } catch (err) {
+    // A broken local store is an environment failure, not a transport
+    // outcome: the whole recovery flow needs to know, so it propagates
+    // (matching the Rust `StoreError` branch) instead of being folded into
+    // the report.
+    if (isLocalStoreError(err)) {
+      throw err;
+    }
     const { status, retryable, reason, scanned } = classifyDrainFailure(err);
     // Count even when the drain failed: each fetched batch is imported as it
     // arrives, so notes recovered before the failure stay in the store. A

--- a/packages/miden-multisig-client/src/testing/fake-indexeddb-device.ts
+++ b/packages/miden-multisig-client/src/testing/fake-indexeddb-device.ts
@@ -1,0 +1,33 @@
+/**
+ * In-memory IndexedDB for tests that exercise the real WASM client store,
+ * with per-"device" isolation.
+ *
+ * The SDK's bundled dexie captures `globalThis.indexedDB` once at module
+ * load, so this module must be imported before the SDK (it is the first
+ * import in `tests/setup-wasm.ts`). Every WASM mock client opens the same
+ * database name; to simulate a new device (fresh, empty store) the global
+ * factory is a thin delegate whose backing `IDBFactory` can be swapped at
+ * any time via {@link freshDeviceStore}.
+ *
+ * Lives under `src/` (not `tests/`) only because test files compile with
+ * `rootDir: src` and must be able to import it; it is test-only code, like
+ * the `*.test.ts` files beside it.
+ */
+import 'fake-indexeddb/auto';
+import { IDBFactory } from 'fake-indexeddb';
+
+let currentFactory = new IDBFactory();
+
+/** Swap in a fresh, empty IndexedDB — the next client opened is a "new device". */
+export function freshDeviceStore(): void {
+  currentFactory = new IDBFactory();
+}
+
+const delegatingFactory = {
+  open: (name: string, version?: number) => currentFactory.open(name, version),
+  deleteDatabase: (name: string) => currentFactory.deleteDatabase(name),
+  databases: () => currentFactory.databases(),
+  cmp: (a: unknown, b: unknown) => currentFactory.cmp(a, b),
+};
+
+globalThis.indexedDB = delegatingFactory as unknown as IDBFactory;

--- a/packages/miden-multisig-client/tests/recovery-fragments.test.ts
+++ b/packages/miden-multisig-client/tests/recovery-fragments.test.ts
@@ -15,6 +15,7 @@ import { createRequire } from 'node:module';
 import { describe, it, expect } from 'vitest';
 import {
   PAGINATION_GUARD_FRAGMENT,
+  STORE_ERROR_FRAGMENT,
   TRANSPORT_DISABLED_FRAGMENT,
 } from '../src/recovery.js';
 
@@ -28,5 +29,6 @@ describe('recovery classification fragments', () => {
     const binaryText = wasm.toString('latin1');
     expect(binaryText).toContain(TRANSPORT_DISABLED_FRAGMENT);
     expect(binaryText).toContain(PAGINATION_GUARD_FRAGMENT);
+    expect(binaryText).toContain(STORE_ERROR_FRAGMENT);
   });
 });

--- a/packages/miden-multisig-client/tests/recovery-fragments.test.ts
+++ b/packages/miden-multisig-client/tests/recovery-fragments.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Drift guard for the recovery classifier's message-fragment join key
+ * (issue #414): `drainPrivateNoteBacklog` greps upstream `NoteTransportError`
+ * Display text, which reaches JS only as a stringified error chain from the
+ * WASM client. Pin both fragments against the string table of the shipped
+ * WASM binary, so an SDK bump that rewords either message fails here instead
+ * of silently misclassifying in production.
+ *
+ * Lives in tests/ (not src/) because it needs Node built-ins, which the
+ * package's tsc build does not type for src files.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { createRequire } from 'node:module';
+import { describe, it, expect } from 'vitest';
+import {
+  PAGINATION_GUARD_FRAGMENT,
+  TRANSPORT_DISABLED_FRAGMENT,
+} from '../src/recovery.js';
+
+const require = createRequire(import.meta.url);
+
+describe('recovery classification fragments', () => {
+  it('match the error text shipped in the WASM binary', () => {
+    const sdkRootDir = dirname(require.resolve('@miden-sdk/miden-sdk/package.json'));
+    const wasm = readFileSync(join(sdkRootDir, 'dist', 'st', 'assets', 'miden_client_web.wasm'));
+
+    const binaryText = wasm.toString('latin1');
+    expect(binaryText).toContain(TRANSPORT_DISABLED_FRAGMENT);
+    expect(binaryText).toContain(PAGINATION_GUARD_FRAGMENT);
+  });
+});

--- a/packages/miden-multisig-client/tests/setup-wasm.ts
+++ b/packages/miden-multisig-client/tests/setup-wasm.ts
@@ -1,3 +1,7 @@
+// Must precede the SDK import: the SDK's bundled dexie captures
+// `globalThis.indexedDB` at module load.
+import '../src/testing/fake-indexeddb-device.js';
+
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { createRequire } from 'node:module';


### PR DESCRIPTION
Closes #414 (sub-issue of #357). Productizes the transport-drain mechanics validated by spike #412 as an SDK recovery primitive in both SDKs.

## What

- **TS**: `drainPrivateNoteBacklog(midenClient)` wrapping `fetchPrivate({ mode: 'all' })`, exported from the package root. Pass the same `MidenClient` instance that was injected into `MultisigClient` — the drain only sees note tags tracked in that store.
- **Rust**: `MultisigClient::drain_private_note_backlog()` wrapping `fetch_all_private_notes()`.
- Structured `TransportRecoveryReport { status: completed | unavailable | failed, imported, retryable, reason? }`. Transport problems are reported, never thrown, so a transport failure cannot abort the rest of a recovery flow; an error from the call itself means the local store failed.
- Rename of the misleading `add_or_update_account` argument `imported` → `overwrite` (matches the upstream `add_account` parameter it forwards to; the doc now also notes the flag is currently inert because the existence pre-check routes tracked accounts through the always-overwrite path).
- Docs in `docs/MULTISIG_SDK.md` and both package READMEs, including the retention caveat: transport recovery is **not a backup** (senders may bypass the transport; blobs are pruned).

## Classification semantics

- `unavailable` guarantees `imported == 0`: transport disabled, or unreachable before anything landed. A connection lost mid-drain **after** partial progress reports `failed` + `retryable` with the partial count kept — rerunning continues it (imports are idempotent).
- The `retryable` bit reuses the crate's existing transient/permanent classifiers: `is_transient_note_transport_error` inspects the `Connection` cause chain (endpoint-parse/TLS misconfig is not retryable), `is_transient_rpc_error` decides for node RPC failures mid-import. The upstream `PaginationDidNotTerminate` convergence guard is surfaced as a retryable failure.
- The Rust `NoteTransportError` match is deliberately exhaustive, so a new upstream variant is a compile error rather than a silently wrong default.
- TS classification is message-fragment based (no typed errors cross the WASM boundary). The fragments are pinned against the shipped WASM binary's string table in `tests/recovery-fragments.test.ts`, so an SDK bump that rewords the upstream error text fails CI instead of silently misclassifying.

## Notes

- `imported` is a store-length delta in both SDKs: upstream `fetch_all_private_notes` computes but discards the imported note IDs, so concurrent store activity during a drain is attributed to it (documented). Having upstream return the count would let both wrappers drop the before/after scans — candidate for an upstream issue.
