### PR TITLE
feat(sdk): import proposal-embedded notes as a recovery primitive (#415)

### DIFF
--- a/crates/miden-multisig-client/README.md
+++ b/crates/miden-multisig-client/README.md
@@ -308,6 +308,35 @@ let filter = NoteFilter::by_faucet_min_amount(faucet, 5_000);
 let spendable = client.list_consumable_notes_filtered(filter).await?;
 ```
 
+### Recovering Notes From Pending Proposals
+
+After key-based recovery the local Miden store starts empty. v2
+`consume_notes` proposals embed the serialized notes they consume, and
+`import_notes_from_proposals` turns those embedded bytes back into store
+records: it fetches each note's on-chain inclusion proof and imports the
+note individually, so it works for private notes too.
+
+```rust
+let proposals = client.list_proposals().await?;
+let outcomes = client.import_notes_from_proposals(&proposals).await;
+for outcome in &outcomes {
+    println!("{}: {} {:?}", outcome.identifier, outcome.status, outcome.reason);
+}
+client.sync().await?; // verifies the imported notes
+```
+
+Each unique embedded note gets its own `NoteImportOutcome` (`Imported`,
+`AlreadyPresent`, `AlreadyConsumed`, `NotCommitted`, `Invalid`, or `Failed`);
+duplicates across proposals fold into one outcome, and a malformed or
+failing note never blocks the others, which is why the method returns a
+plain `Vec` instead of `Result`. Notes not yet on chain are recorded in
+`Expected` state (their tag is tracked so a later sync picks them up) and
+reported retryable.
+
+Proposals are opportunistic recovery material, not a backup: v1 proposals
+carry no note bytes, proposals disappear once canonicalized, and embedded
+note bytes are visible to the GUARDIAN operator (existing v2 behavior, not a
+new exposure).
 
 ### Custom Proposal Types
 

--- a/crates/miden-multisig-client/src/client/mod.rs
+++ b/crates/miden-multisig-client/src/client/mod.rs
@@ -9,6 +9,7 @@
 //! - `notes` - Note filtering and listing
 //! - `recovery` - Recovery primitives (transport backlog drain)
 //! - `io` - Export/import functionality
+//! - `proposal_import` - Recovery primitive: proposal-embedded note import
 //! - `helpers` - Internal GUARDIAN client helpers
 
 mod account;
@@ -17,12 +18,14 @@ mod helpers;
 mod io;
 mod notes;
 mod offline;
+mod proposal_import;
 mod proposals;
 mod recovery;
 pub use delta_history::{
     HistoryAssetKind, HistoryDecodeSection, HistoryDecodeWarning, HistoryEntry, HistoryEntryStatus,
     HistoryNote, HistoryNoteAsset, HistoryNoteTag, HistoryNoteVisibility, HistoryPage,
 };
+pub use proposal_import::{NoteImportOutcome, NoteImportSource, NoteImportStatus};
 pub use proposals::{AbandonRequestState, AbandonStatus};
 pub use recovery::{TransportRecoveryReport, TransportRecoveryStatus};
 

--- a/crates/miden-multisig-client/src/client/proposal_import.rs
+++ b/crates/miden-multisig-client/src/client/proposal_import.rs
@@ -1,0 +1,621 @@
+//! Recovery primitives for MultisigClient (issue #415, sub-issue of #357).
+//!
+//! After key-based recovery the local Miden store starts empty, so notes the
+//! account was in the middle of consuming are gone. v2 `consume_notes`
+//! proposals embed the serialized notes they consume (issue #229), which makes
+//! pending proposals opportunistic recovery material: this module rebuilds
+//! importable notes from those embedded bytes plus a node-fetched inclusion
+//! proof, without needing the node to hold the note body — so it works for
+//! private notes too (spike #412).
+
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+
+use miden_client::ClientError;
+use miden_client::note::{NoteFile, NoteSyncHint};
+use miden_client::store::NoteFilter as StoreNoteFilter;
+use miden_protocol::block::BlockNumber;
+use miden_protocol::note::{Note, NoteDetailsCommitment, NoteId, NoteInclusionProof};
+
+use super::MultisigClient;
+use crate::proposal::{Proposal, ProposalMetadata};
+
+/// Where a recovered note's bytes came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NoteImportSource {
+    /// Embedded in a v2 `consume_notes` proposal (`consume_notes_notes`).
+    Proposal,
+}
+
+impl NoteImportSource {
+    /// Stable string form, shared with the TS SDK's `source` union.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Proposal => "proposal",
+        }
+    }
+}
+
+impl std::fmt::Display for NoteImportSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Per-note result of a recovery import attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NoteImportStatus {
+    /// Note imported with its on-chain inclusion proof; it lands in the
+    /// store's `Unverified` state and the next sync verifies it.
+    Imported,
+    /// The local store already tracks this note (not yet consumed).
+    AlreadyPresent,
+    /// The note is already consumed — either the local store tracked it as
+    /// consumed, or the chain had nullified it and the import recorded it as
+    /// consumption history rather than a consumable note.
+    AlreadyConsumed,
+    /// The chain does not know the note yet. Its details were recorded in
+    /// `Expected` state with its tag tracked, so a later sync picks it up
+    /// once it commits.
+    NotCommitted,
+    /// The embedded bytes could not be decoded into a note.
+    Invalid,
+    /// The import attempt failed (store or RPC error).
+    Failed,
+}
+
+impl NoteImportStatus {
+    /// Stable string form, shared with the TS SDK's `status` union.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Imported => "imported",
+            Self::AlreadyPresent => "already-present",
+            Self::AlreadyConsumed => "already-consumed",
+            Self::NotCommitted => "not-committed",
+            Self::Invalid => "invalid",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+impl std::fmt::Display for NoteImportStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Outcome of one unique embedded note's recovery import. A batch of outcomes
+/// is the full report of [`MultisigClient::import_notes_from_proposals`]; no
+/// per-note problem aborts the batch. A note embedded by several proposals is
+/// deduplicated into a single outcome (its first occurrence).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NoteImportOutcome {
+    /// The note ID hex when the bytes decoded, otherwise a positional
+    /// reference into the proposal (`proposal <id> notes[<i>]`).
+    pub identifier: String,
+    /// Where the note bytes came from.
+    pub source: NoteImportSource,
+    /// What happened to this note.
+    pub status: NoteImportStatus,
+    /// Whether retrying the import later can change the status (transient
+    /// RPC failures, notes not yet committed).
+    pub retryable: bool,
+    /// Human-readable detail for non-success statuses — or, on an `Imported`
+    /// outcome, a warning that the post-import consumed-state check failed
+    /// and a sync should confirm the note's status.
+    pub reason: Option<String>,
+}
+
+/// Decodes and deduplicates the embedded notes of v2 `consume_notes`
+/// proposals. Undecodable entries are reported as `Invalid` outcomes with a
+/// positional identifier; a note embedded by several proposals folds into its
+/// first occurrence.
+///
+/// Decoding is deliberately permissive: the strict `note.id() == note_ids[i]`
+/// binding check belongs to the verify/execute path (`execution.rs`), where a
+/// mismatch must block signing. Recovery imports whatever real notes the
+/// bytes decode to — a note is self-validating (its ID derives from its
+/// contents), so importing it is harmless even when the proposal's declared
+/// note IDs disagree.
+fn collect_notes<'a>(
+    proposals: impl IntoIterator<Item = (&'a str, &'a ProposalMetadata)>,
+    outcomes: &mut Vec<NoteImportOutcome>,
+) -> Vec<Note> {
+    let mut seen: HashSet<NoteId> = HashSet::new();
+    let mut decoded = Vec::new();
+    for (proposal_id, metadata) in proposals {
+        if !metadata.is_consume_notes_v2() {
+            continue;
+        }
+        for (index, serialized) in metadata.consume_notes_notes.iter().enumerate() {
+            match serialized.to_note() {
+                Ok(note) => {
+                    if seen.insert(note.id()) {
+                        decoded.push(note);
+                    }
+                }
+                Err(e) => outcomes.push(NoteImportOutcome {
+                    identifier: format!("proposal {} notes[{}]", proposal_id, index),
+                    source: NoteImportSource::Proposal,
+                    status: NoteImportStatus::Invalid,
+                    retryable: false,
+                    reason: Some(format!("failed to decode embedded note: {}", e)),
+                }),
+            }
+        }
+    }
+    decoded
+}
+
+/// Import errors are usually local store problems, but upstream
+/// `import_notes` performs node RPC internally (nullifier checks, block
+/// header fetches), so a transient RPC failure mid-import is retryable.
+fn import_error_retryable(error: &ClientError) -> bool {
+    matches!(error, ClientError::RpcError(rpc) if crate::rpc::is_transient_rpc_error(rpc))
+}
+
+impl MultisigClient {
+    /// Imports the notes embedded in v2 `consume_notes` proposals into the
+    /// local Miden store (issue #415), typically after key-based recovery
+    /// rebuilt the proposal list but left the note store empty.
+    ///
+    /// Proposals are opportunistic recovery material, not a backup: v1
+    /// proposals carry no note bytes, and proposals disappear once
+    /// canonicalized, so only notes still mid-consumption are recoverable
+    /// this way.
+    ///
+    /// Per note: decode the embedded bytes, skip notes the store already
+    /// tracks, fetch the on-chain inclusion proof, and import the note
+    /// individually (upstream `import_notes` batches are atomic, so one bad
+    /// note must not sink the rest). A note the chain does not know yet is
+    /// recorded in `Expected` state with its tag tracked so a later sync
+    /// picks it up, and is reported as `NotCommitted`/retryable. A note the
+    /// chain has already nullified is recorded as consumption history and
+    /// reported `AlreadyConsumed`.
+    ///
+    /// The returned outcomes cover every unique embedded note — a note
+    /// embedded by several proposals yields one outcome, not one per
+    /// embedding — and no per-note problem aborts the batch, which is why
+    /// this returns a plain `Vec` instead of `Result`.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let proposals = client.list_proposals().await?;
+    /// for outcome in client.import_notes_from_proposals(&proposals).await {
+    ///     println!("{}: {}", outcome.identifier, outcome.status);
+    /// }
+    /// client.sync().await?;
+    /// ```
+    pub async fn import_notes_from_proposals(
+        &mut self,
+        proposals: &[Proposal],
+    ) -> Vec<NoteImportOutcome> {
+        let mut outcomes = Vec::new();
+        let decoded = collect_notes(
+            proposals.iter().map(|p| (p.id.as_str(), &p.metadata)),
+            &mut outcomes,
+        );
+        if decoded.is_empty() {
+            return outcomes;
+        }
+
+        // Look up existing records by details commitment, not note ID: records
+        // the store keeps without metadata (a note details import in Expected
+        // state, or a note observed as consumed on chain) have no note ID, and
+        // an ID lookup would keep re-importing them forever.
+        let commitments: Vec<NoteDetailsCommitment> =
+            decoded.iter().map(Note::details_commitment).collect();
+        let existing = match self
+            .miden_client
+            .get_input_notes(StoreNoteFilter::DetailsCommitments(commitments))
+            .await
+        {
+            Ok(records) => records
+                .into_iter()
+                .map(|record| (record.details_commitment(), record))
+                .collect::<BTreeMap<_, _>>(),
+            Err(e) => {
+                let reason = format!("failed to read local store: {}", e);
+                for note in &decoded {
+                    outcomes.push(NoteImportOutcome {
+                        identifier: note.id().to_hex(),
+                        source: NoteImportSource::Proposal,
+                        status: NoteImportStatus::Failed,
+                        retryable: false,
+                        reason: Some(reason.clone()),
+                    });
+                }
+                return outcomes;
+            }
+        };
+
+        let mut pending: Vec<Note> = Vec::new();
+        for note in decoded {
+            match existing.get(&note.details_commitment()) {
+                Some(record) => {
+                    let status = if record.is_consumed() {
+                        NoteImportStatus::AlreadyConsumed
+                    } else {
+                        NoteImportStatus::AlreadyPresent
+                    };
+                    outcomes.push(NoteImportOutcome {
+                        identifier: note.id().to_hex(),
+                        source: NoteImportSource::Proposal,
+                        status,
+                        retryable: false,
+                        reason: None,
+                    });
+                }
+                None => pending.push(note),
+            }
+        }
+
+        if pending.is_empty() {
+            return outcomes;
+        }
+
+        // One round trip for all missing notes; only the import itself is
+        // per-note. The node returns proofs for private notes too, so the
+        // locally-held bytes are the only body this path ever needs.
+        let ids: Vec<NoteId> = pending.iter().map(Note::id).collect();
+        let fetched = match self.node_rpc_client().get_notes_by_id(&ids).await {
+            Ok(fetched) => fetched,
+            Err(e) => {
+                let retryable = crate::rpc::is_transient_rpc_error(&e);
+                let reason = format!("failed to fetch inclusion proofs: {}", e);
+                for note in &pending {
+                    outcomes.push(NoteImportOutcome {
+                        identifier: note.id().to_hex(),
+                        source: NoteImportSource::Proposal,
+                        status: NoteImportStatus::Failed,
+                        retryable,
+                        reason: Some(reason.clone()),
+                    });
+                }
+                return outcomes;
+            }
+        };
+        let mut proofs: BTreeMap<NoteId, NoteInclusionProof> = fetched
+            .iter()
+            .map(|f| (f.id(), f.inclusion_proof().clone()))
+            .collect();
+
+        // Provisionally `Imported` outcomes, re-classified in one batched
+        // consumed-state check below.
+        let mut imported: Vec<(usize, NoteDetailsCommitment)> = Vec::new();
+
+        for note in pending {
+            let identifier = note.id().to_hex();
+            let outcome = match proofs.remove(&note.id()) {
+                Some(proof) => {
+                    let details_commitment = note.details_commitment();
+                    let file = NoteFile::Committed { note, proof };
+                    match self
+                        .miden_client
+                        .import_notes(std::slice::from_ref(&file))
+                        .await
+                    {
+                        Ok(_) => {
+                            imported.push((outcomes.len(), details_commitment));
+                            NoteImportOutcome {
+                                identifier,
+                                source: NoteImportSource::Proposal,
+                                status: NoteImportStatus::Imported,
+                                retryable: false,
+                                reason: None,
+                            }
+                        }
+                        Err(e) => NoteImportOutcome {
+                            identifier,
+                            source: NoteImportSource::Proposal,
+                            status: NoteImportStatus::Failed,
+                            retryable: import_error_retryable(&e),
+                            reason: Some(format!("failed to import note: {}", e)),
+                        },
+                    }
+                }
+                None => {
+                    // The sync hint's tag makes the resulting `Expected`
+                    // record reachable by sync (upstream registers a
+                    // note-source tag record from it).
+                    let tag = note.metadata().tag();
+                    let file = NoteFile::ExpectedNote {
+                        details: note.into(),
+                        sync_hint: NoteSyncHint::new(BlockNumber::from(0u32), tag),
+                    };
+                    match self
+                        .miden_client
+                        .import_notes(std::slice::from_ref(&file))
+                        .await
+                    {
+                        Ok(_) => NoteImportOutcome {
+                            identifier,
+                            source: NoteImportSource::Proposal,
+                            status: NoteImportStatus::NotCommitted,
+                            retryable: true,
+                            reason: Some(
+                                "note not yet committed on chain; recorded as expected so a \
+                                 later sync picks it up"
+                                    .to_string(),
+                            ),
+                        },
+                        Err(e) => NoteImportOutcome {
+                            identifier,
+                            source: NoteImportSource::Proposal,
+                            status: NoteImportStatus::Failed,
+                            retryable: import_error_retryable(&e),
+                            reason: Some(format!("failed to record expected note: {}", e)),
+                        },
+                    }
+                }
+            };
+            outcomes.push(outcome);
+        }
+
+        // A note the chain already nullified is stored as consumption history,
+        // not as a consumable note — report that honestly instead of
+        // `Imported`. One batched store read covers every imported note.
+        if !imported.is_empty() {
+            let check = self
+                .miden_client
+                .get_input_notes(StoreNoteFilter::DetailsCommitments(
+                    imported.iter().map(|(_, commitment)| *commitment).collect(),
+                ))
+                .await;
+            match check {
+                Ok(records) => {
+                    let consumed: BTreeSet<NoteDetailsCommitment> = records
+                        .iter()
+                        .filter(|record| record.is_consumed())
+                        .map(|record| record.details_commitment())
+                        .collect();
+                    for (index, commitment) in &imported {
+                        if consumed.contains(commitment) {
+                            outcomes[*index].status = NoteImportStatus::AlreadyConsumed;
+                            outcomes[*index].reason = Some(
+                                "note was already consumed on chain; recorded as consumption \
+                                 history"
+                                    .to_string(),
+                            );
+                        }
+                    }
+                }
+                Err(e) => {
+                    // The imports themselves succeeded; stay `Imported` but
+                    // flag that the consumed-state classification is unknown.
+                    for (index, _) in &imported {
+                        outcomes[*index].reason = Some(format!(
+                            "imported, but the consumed-state check failed ({}); run sync to \
+                             confirm the note's status",
+                            e
+                        ));
+                    }
+                }
+            }
+        }
+
+        outcomes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use miden_protocol::account::delta::{AccountDelta, AccountVaultDelta};
+    use miden_protocol::account::{AccountId, AccountStoragePatch};
+    use miden_protocol::asset::FungibleAsset;
+    use miden_protocol::crypto::rand::RandomCoin;
+    use miden_protocol::note::NoteType;
+    use miden_protocol::{Felt, Word};
+    use miden_standards::note::P2idNote;
+
+    use super::*;
+    use crate::proposal::SerializedNote;
+
+    fn build_test_note(seed: u64) -> Note {
+        let sender = AccountId::from_hex("0x7b7b7b7a7b7b7b017b7b7b7b7b7b7b").unwrap();
+        let target = AccountId::from_hex("0x1b1b1b1a1b1b1b011b1b1b1b1b1b1b").unwrap();
+        let mut rng = RandomCoin::new(Word::from([Felt::new_unchecked(seed); 4]));
+        P2idNote::builder()
+            .sender(sender)
+            .target(target)
+            .asset(FungibleAsset::mock(1))
+            .note_type(NoteType::Private)
+            .generate_serial_number(&mut rng)
+            .build()
+            .unwrap()
+            .into()
+    }
+
+    fn v2_metadata(notes: Vec<SerializedNote>) -> ProposalMetadata {
+        ProposalMetadata {
+            consume_notes_metadata_version: Some(
+                crate::proposal::CONSUME_NOTES_METADATA_VERSION_V2,
+            ),
+            consume_notes_notes: notes,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn collects_decoded_notes_from_v2_metadata() {
+        let note = build_test_note(1);
+        let expected_id = note.id();
+        let metadata = v2_metadata(vec![SerializedNote::from_note(&note)]);
+
+        let mut outcomes = Vec::new();
+        let decoded = collect_notes([("p-1", &metadata)], &mut outcomes);
+        assert!(outcomes.is_empty());
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0].id(), expected_id);
+    }
+
+    #[test]
+    fn skips_v1_metadata() {
+        let note = build_test_note(1);
+        // v1 wire shape never carries notes, but even a malformed hybrid must
+        // not be treated as recovery material.
+        let metadata = ProposalMetadata {
+            consume_notes_metadata_version: None,
+            consume_notes_notes: vec![SerializedNote::from_note(&note)],
+            ..Default::default()
+        };
+
+        let mut outcomes = Vec::new();
+        assert!(collect_notes([("p-1", &metadata)], &mut outcomes).is_empty());
+        assert!(outcomes.is_empty());
+    }
+
+    #[test]
+    fn malformed_note_is_isolated_with_positional_identifier() {
+        let good = build_test_note(1);
+        let metadata = v2_metadata(vec![
+            SerializedNote::from_base64("!!! not base64 !!!".to_string()),
+            SerializedNote::from_note(&good),
+        ]);
+
+        let mut outcomes = Vec::new();
+        let decoded = collect_notes([("p-9", &metadata)], &mut outcomes);
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0].id(), good.id());
+        assert_eq!(outcomes.len(), 1);
+        assert_eq!(outcomes[0].identifier, "proposal p-9 notes[0]");
+        assert_eq!(outcomes[0].status, NoteImportStatus::Invalid);
+        assert!(!outcomes[0].retryable);
+        assert!(
+            outcomes[0]
+                .reason
+                .as_deref()
+                .unwrap()
+                .contains("failed to decode")
+        );
+    }
+
+    #[test]
+    fn duplicate_notes_across_proposals_are_deduplicated() {
+        let shared = build_test_note(1);
+        let other = build_test_note(2);
+        let first = v2_metadata(vec![SerializedNote::from_note(&shared)]);
+        let second = v2_metadata(vec![
+            SerializedNote::from_note(&shared),
+            SerializedNote::from_note(&other),
+        ]);
+
+        let mut outcomes = Vec::new();
+        let decoded = collect_notes([("p-1", &first), ("p-2", &second)], &mut outcomes);
+        assert!(outcomes.is_empty());
+        let ids: Vec<_> = decoded.iter().map(Note::id).collect();
+        assert_eq!(ids, vec![shared.id(), other.id()]);
+    }
+
+    fn v2_proposal(id: &str, notes: Vec<SerializedNote>) -> Proposal {
+        let account_id = AccountId::from_hex("0x7b7b7b7a7b7b7b017b7b7b7b7b7b7b").unwrap();
+        let delta = AccountDelta::new(
+            account_id,
+            AccountStoragePatch::default(),
+            AccountVaultDelta::default(),
+            None,
+            miden_protocol::Felt::ZERO,
+        )
+        .unwrap();
+        let tx_summary = miden_protocol::transaction::TransactionSummary::new(
+            delta,
+            miden_protocol::transaction::InputNotes::new(Vec::new()).unwrap(),
+            miden_protocol::transaction::RawOutputNotes::new(Vec::new()).unwrap(),
+            Word::default(),
+            0,
+            miden_protocol::transaction::TransactionSummaryUserParams::new(
+                [miden_protocol::Felt::ZERO; 7],
+            ),
+        );
+        Proposal {
+            id: id.to_string(),
+            nonce: 1,
+            transaction_type: crate::proposal::TransactionType::ConsumeNotes {
+                note_ids: vec![],
+                metadata_version: Some(crate::proposal::CONSUME_NOTES_METADATA_VERSION_V2),
+                notes: notes.clone(),
+            },
+            status: crate::proposal::ProposalStatus::Pending,
+            tx_summary,
+            signatures: vec![],
+            metadata: v2_metadata(notes),
+        }
+    }
+
+    /// Exercises the public method end to end against an unreachable node:
+    /// decoding, deduplication, and invalid isolation must all happen before
+    /// any network access, and the proof-fetch failure must surface as
+    /// per-note retryable outcomes instead of aborting the batch. (The
+    /// success-path branches are covered by the TS unit twin and were
+    /// validated live against testnet; the in-repo scripted node cannot yet
+    /// serve successful note responses.)
+    #[tokio::test]
+    async fn unreachable_node_reports_per_note_failures_without_aborting() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut client = crate::MultisigClient::builder()
+            .miden_endpoint(miden_client::rpc::Endpoint::try_from("http://127.0.0.1:1").unwrap())
+            .guardian_endpoint("http://127.0.0.1:1")
+            .account_dir(dir.path())
+            .generate_key()
+            .build()
+            .await
+            .unwrap();
+
+        let note = build_test_note(1);
+        let proposals = vec![
+            v2_proposal(
+                "p-1",
+                vec![
+                    SerializedNote::from_note(&note),
+                    SerializedNote::from_base64("!!! corrupt !!!".to_string()),
+                ],
+            ),
+            // Duplicate embedding of the same note -> deduplicated.
+            v2_proposal("p-2", vec![SerializedNote::from_note(&note)]),
+        ];
+
+        let outcomes = client.import_notes_from_proposals(&proposals).await;
+
+        assert_eq!(outcomes.len(), 2, "dedup folds the duplicate embedding");
+        let invalid = outcomes
+            .iter()
+            .find(|o| o.status == NoteImportStatus::Invalid)
+            .expect("malformed note reported");
+        assert_eq!(invalid.identifier, "proposal p-1 notes[1]");
+        assert!(!invalid.retryable);
+
+        let failed = outcomes
+            .iter()
+            .find(|o| o.identifier == note.id().to_hex())
+            .expect("decodable note reported");
+        assert_eq!(failed.status, NoteImportStatus::Failed);
+        assert!(
+            failed.retryable,
+            "connection failure must classify retryable"
+        );
+        assert!(
+            failed
+                .reason
+                .as_deref()
+                .unwrap()
+                .contains("failed to fetch inclusion proofs"),
+            "failure must point at the proof fetch"
+        );
+    }
+
+    #[test]
+    fn status_and_source_render_stable_strings() {
+        assert_eq!(NoteImportSource::Proposal.to_string(), "proposal");
+        let expected = [
+            (NoteImportStatus::Imported, "imported"),
+            (NoteImportStatus::AlreadyPresent, "already-present"),
+            (NoteImportStatus::AlreadyConsumed, "already-consumed"),
+            (NoteImportStatus::NotCommitted, "not-committed"),
+            (NoteImportStatus::Invalid, "invalid"),
+            (NoteImportStatus::Failed, "failed"),
+        ];
+        for (status, s) in expected {
+            assert_eq!(status.to_string(), s);
+        }
+    }
+}

--- a/crates/miden-multisig-client/src/lib.rs
+++ b/crates/miden-multisig-client/src/lib.rs
@@ -66,8 +66,9 @@ pub use client::{AbandonRequestState, AbandonStatus};
 pub use client::{
     ConsumableNote, HistoryAssetKind, HistoryDecodeSection, HistoryDecodeWarning, HistoryEntry,
     HistoryEntryStatus, HistoryNote, HistoryNoteAsset, HistoryNoteTag, HistoryNoteVisibility,
-    HistoryPage, MultisigClient, NoteFilter, ProposalResult, RecoveredAccount,
-    StateVerificationResult, TransportRecoveryReport, TransportRecoveryStatus,
+    HistoryPage, MultisigClient, NoteFilter, NoteImportOutcome, NoteImportSource, NoteImportStatus,
+    ProposalResult, RecoveredAccount, StateVerificationResult, TransportRecoveryReport,
+    TransportRecoveryStatus,
 };
 
 // Procedures

--- a/docs/MULTISIG_SDK.md
+++ b/docs/MULTISIG_SDK.md
@@ -631,27 +631,28 @@ export/import helpers).
 
 After key-based recovery the local Miden store starts empty, so notes the
 account was in the middle of consuming are gone. v2 `consume_notes` proposals
-embed the serialized notes they consume (issue #229), and the standalone
-`importNotesFromProposals` helper turns those embedded bytes back into store
-records (issue #415): it fetches each note's on-chain inclusion proof and
-imports the note individually, so it works for private notes too — the node
-never needs to hold the note body.
+embed the serialized notes they consume (issue #229), and
+`multisig.importNotesFromProposals()` turns those embedded bytes back into
+store records (issue #415): it fetches each note's on-chain inclusion proof
+and imports the note individually, so it works for private notes too — the
+node never needs to hold the note body. The method reuses the client's Miden
+RPC endpoint and retry configuration, and syncs pending proposals from
+GUARDIAN when none are passed.
 
 ```typescript
-import { importNotesFromProposals } from '@openzeppelin/miden-multisig-client';
-
 const multisig = await client.load(accountId, signer);
-const proposals = await multisig.syncProposals();
 
-const outcomes = await importNotesFromProposals(midenClient, proposals, {
-  midenRpcEndpoint: 'https://rpc.testnet.miden.io',
-});
+const outcomes = await multisig.importNotesFromProposals();
 for (const outcome of outcomes) {
   console.log(outcome.identifier, outcome.status, outcome.reason ?? '');
 }
 
 await multisig.syncState(); // verifies the imported notes
 ```
+
+A standalone `importNotesFromProposals(midenClient, proposals, {
+midenRpcEndpoint, rpc? })` export backs the method for callers holding a raw
+WASM client or proposals from another source.
 
 Each unique embedded note gets its own `NoteImportOutcome` with a `status` of
 `imported`, `already-present`, `already-consumed`, `not-committed`, `invalid`,
@@ -902,6 +903,7 @@ Standalone functions:
 | `exportNoteToFile(noteId, filename?)` | Browser-only: download the note file |
 | `importNoteFromBytes(noteBytes)` | Import a note file received out-of-band |
 | `importNoteFromFile(file)` | Import a note file from a browser `File`/`Blob` |
+| `importNotesFromProposals(proposals?)` | Import notes embedded in pending v2 consume-notes proposals, reusing the client's RPC settings; syncs proposals when none are passed (issue #415) |
 | `createAddSignerProposal(commitment, { nonce, newThreshold }?)` | Create add signer proposal (`newThreshold` defaults to the current threshold) |
 | `createRemoveSignerProposal(commitment, { nonce, newThreshold }?)` | Create remove signer proposal (`newThreshold` defaults to min of current threshold and remaining signer count) |
 | `createChangeThresholdProposal(threshold, { nonce }?)` | Create threshold change proposal |

--- a/docs/MULTISIG_SDK.md
+++ b/docs/MULTISIG_SDK.md
@@ -627,6 +627,46 @@ transport, and relayed blobs are pruned after the retention window. Notes
 outside both are recoverable only from their sender (see the note
 export/import helpers).
 
+### Recovering Notes From Pending Proposals
+
+After key-based recovery the local Miden store starts empty, so notes the
+account was in the middle of consuming are gone. v2 `consume_notes` proposals
+embed the serialized notes they consume (issue #229), and the standalone
+`importNotesFromProposals` helper turns those embedded bytes back into store
+records (issue #415): it fetches each note's on-chain inclusion proof and
+imports the note individually, so it works for private notes too — the node
+never needs to hold the note body.
+
+```typescript
+import { importNotesFromProposals } from '@openzeppelin/miden-multisig-client';
+
+const multisig = await client.load(accountId, signer);
+const proposals = await multisig.syncProposals();
+
+const outcomes = await importNotesFromProposals(midenClient, proposals, {
+  midenRpcEndpoint: 'https://rpc.testnet.miden.io',
+});
+for (const outcome of outcomes) {
+  console.log(outcome.identifier, outcome.status, outcome.reason ?? '');
+}
+
+await multisig.syncState(); // verifies the imported notes
+```
+
+Each unique embedded note gets its own `NoteImportOutcome` with a `status` of
+`imported`, `already-present`, `already-consumed`, `not-committed`, `invalid`,
+or `failed` — duplicates across proposals fold into one outcome, and a
+malformed or failing note never blocks the others (the helper never throws
+for per-note problems). A `not-committed` note (not yet on chain) is recorded
+as expected with its tag tracked so a later sync picks it up;
+`retryable: true` marks outcomes worth retrying (transient RPC failures
+included).
+
+Proposals are opportunistic recovery material, not a backup: v1 proposals
+carry no note bytes, proposals disappear once canonicalized, and the embedded
+bytes are visible to the Guardian operator (existing v2 behavior, not a new
+exposure). Only notes still mid-consumption are recoverable this way.
+
 ### Proposal Operations
 
 Every `create*Proposal` method takes a single trailing options object (issue
@@ -839,6 +879,7 @@ Standalone functions:
 | Function | Description |
 |----------|-------------|
 | `drainPrivateNoteBacklog(midenClient)` | Rescan the full private-note transport backlog for tracked tags after recovery; returns a `TransportRecoveryReport` (`completed` / `unavailable` / `failed`) instead of throwing on transport problems |
+| `importNotesFromProposals(midenClient, proposals, { midenRpcEndpoint, rpc? })` | Import notes embedded in v2 consume-notes proposals into the local store; returns per-note `NoteImportOutcome`s (issue #415) |
 
 #### Multisig
 
@@ -1088,6 +1129,39 @@ transport, and relayed blobs are pruned after the retention window. Notes
 outside both are recoverable only from their sender (see
 `import_note_from_file`).
 
+### Recovering Notes From Pending Proposals
+
+After key-based recovery the local Miden store starts empty, so notes the
+account was in the middle of consuming are gone. v2 `consume_notes` proposals
+embed the serialized notes they consume (issue #229), and
+`import_notes_from_proposals` turns those embedded bytes back into store
+records (issue #415): it fetches each note's on-chain inclusion proof and
+imports the note individually, so it works for private notes too — the node
+never needs to hold the note body.
+
+```rust
+let proposals = client.list_proposals().await?;
+let outcomes = client.import_notes_from_proposals(&proposals).await;
+for outcome in &outcomes {
+    println!("{}: {} {:?}", outcome.identifier, outcome.status, outcome.reason);
+}
+client.sync().await?; // verifies the imported notes
+```
+
+Each unique embedded note gets its own `NoteImportOutcome` with a
+`NoteImportStatus` of `Imported`, `AlreadyPresent`, `AlreadyConsumed`,
+`NotCommitted`, `Invalid`, or `Failed` — duplicates across proposals fold
+into one outcome, and a malformed or failing note never blocks the others,
+which is why the method returns a plain `Vec` instead of `Result`. A
+`NotCommitted` note (not yet on chain) is recorded in `Expected` state with
+its tag tracked so a later sync picks it up; `retryable: true` marks
+outcomes worth retrying (transient RPC failures included).
+
+Proposals are opportunistic recovery material, not a backup: v1 proposals
+carry no note bytes, proposals disappear once canonicalized, and the embedded
+bytes are visible to the Guardian operator (existing v2 behavior, not a new
+exposure). Only notes still mid-consumption are recoverable this way.
+
 ### Transaction Types
 
 ```rust
@@ -1289,6 +1363,7 @@ full note, so a post-commit sync is enough.
 | `export_note_to_bytes(note_id)` | Export a created note as note-file bytes |
 | `import_note_from_file(path)` | Import a note file received out-of-band |
 | `import_note_from_bytes(bytes)` | Import a note from note-file bytes |
+| `import_notes_from_proposals(&proposals)` | Import notes embedded in v2 consume-notes proposals; returns per-note `NoteImportOutcome`s (issue #415) |
 
 #### MultisigAccount
 

--- a/packages/miden-multisig-client/README.md
+++ b/packages/miden-multisig-client/README.md
@@ -268,20 +268,21 @@ window.
 ### Recover Notes From Pending Proposals
 
 After key-based recovery the local Miden store starts empty. v2
-`consume_notes` proposals embed the serialized notes they consume, and the
-standalone `importNotesFromProposals` helper turns those embedded bytes back
-into store records: it fetches each note's on-chain inclusion proof and
-imports the note individually, so it works for private notes too.
+`consume_notes` proposals embed the serialized notes they consume, and
+`multisig.importNotesFromProposals()` turns those embedded bytes back into
+store records: it fetches each note's on-chain inclusion proof and imports
+the note individually, so it works for private notes too. The method reuses
+the client's Miden RPC endpoint and retry configuration, and syncs pending
+proposals from GUARDIAN when none are passed.
 
 ```typescript
-import { importNotesFromProposals } from '@openzeppelin/miden-multisig-client';
-
-const proposals = await multisig.syncProposals();
-const outcomes = await importNotesFromProposals(midenClient, proposals, {
-  midenRpcEndpoint: 'https://rpc.testnet.miden.io',
-});
+const outcomes = await multisig.importNotesFromProposals();
 await multisig.syncState(); // verifies the imported notes
 ```
+
+(A standalone `importNotesFromProposals(midenClient, proposals, {
+midenRpcEndpoint, rpc? })` export backs the method for callers holding a raw
+WASM client or proposals from another source.)
 
 Each unique embedded note gets its own `NoteImportOutcome` (`imported`,
 `already-present`, `already-consumed`, `not-committed`, `invalid`, or
@@ -294,43 +295,6 @@ Proposals are opportunistic recovery material, not a backup: v1 proposals
 carry no note bytes, proposals disappear once canonicalized, and embedded
 note bytes are visible to the Guardian operator (existing v2 behavior, not a
 new exposure).
-
-### Backfill Historical Public Notes By Tag
-
-Normal forward sync starts from the store's **global** cursor, so in a store
-shared with other accounts the cursor may already be past blocks containing
-a recovered account's notes. `backfillPublicNotesByTag` scans a historical
-block range (genesis to tip by default) for public notes addressed at the
-account's standard note tag and imports them with their on-chain inclusion
-proofs — without ever touching the global sync height. The scan's cost grows
-with the number of matching notes, not the range length, so a full
-genesis-to-tip scan is fast on an ordinary account.
-
-```typescript
-import { backfillPublicNotesByTag } from '@openzeppelin/miden-multisig-client';
-
-const multisig = await client.load(accountId, signer);
-const report = await backfillPublicNotesByTag(midenClient, {
-  accountId: multisig.accountId,
-  midenRpcEndpoint: 'https://rpc.testnet.miden.io',
-});
-// report.discovered, report.skippedPrivate, report.outcomes (per public note)
-await multisig.syncState(); // verifies the imported notes
-```
-
-Each unique public note gets its own `NoteImportOutcome` (source
-`'backfill'`), with the same statuses and duplicate tolerance as the
-proposal import. Tags are best-effort filters: notes sent with unrelated
-custom tags are outside this scan's guarantee, and unrelated notes whose tag
-collides with the account's are imported harmlessly. Private matches are
-counted as `skippedPrivate` — the chain holds no body for them; recover
-those with the transport drain or the proposal import instead.
-
-Scan problems are reported, never thrown: a range dense enough to trip the
-node's pagination cap is split client-side and rescanned, and any sub-range
-that still cannot be covered lands in `report.uncovered` with
-`retryable`/`reason` set, so a partial scan never aborts the rest of a
-recovery flow.
 
 ### Fetch Account State
 

--- a/packages/miden-multisig-client/README.md
+++ b/packages/miden-multisig-client/README.md
@@ -265,6 +265,73 @@ service's retention. Senders may deliver private notes out-of-band without
 using the transport, and relayed blobs are pruned after the retention
 window.
 
+### Recover Notes From Pending Proposals
+
+After key-based recovery the local Miden store starts empty. v2
+`consume_notes` proposals embed the serialized notes they consume, and the
+standalone `importNotesFromProposals` helper turns those embedded bytes back
+into store records: it fetches each note's on-chain inclusion proof and
+imports the note individually, so it works for private notes too.
+
+```typescript
+import { importNotesFromProposals } from '@openzeppelin/miden-multisig-client';
+
+const proposals = await multisig.syncProposals();
+const outcomes = await importNotesFromProposals(midenClient, proposals, {
+  midenRpcEndpoint: 'https://rpc.testnet.miden.io',
+});
+await multisig.syncState(); // verifies the imported notes
+```
+
+Each unique embedded note gets its own `NoteImportOutcome` (`imported`,
+`already-present`, `already-consumed`, `not-committed`, `invalid`, or
+`failed`); duplicates across proposals fold into one outcome, a malformed or
+failing note never blocks the others, and the helper never throws for
+per-note problems. Notes not yet on chain are recorded as expected (their
+tag is tracked so a later sync picks them up) and reported retryable.
+
+Proposals are opportunistic recovery material, not a backup: v1 proposals
+carry no note bytes, proposals disappear once canonicalized, and embedded
+note bytes are visible to the Guardian operator (existing v2 behavior, not a
+new exposure).
+
+### Backfill Historical Public Notes By Tag
+
+Normal forward sync starts from the store's **global** cursor, so in a store
+shared with other accounts the cursor may already be past blocks containing
+a recovered account's notes. `backfillPublicNotesByTag` scans a historical
+block range (genesis to tip by default) for public notes addressed at the
+account's standard note tag and imports them with their on-chain inclusion
+proofs — without ever touching the global sync height. The scan's cost grows
+with the number of matching notes, not the range length, so a full
+genesis-to-tip scan is fast on an ordinary account.
+
+```typescript
+import { backfillPublicNotesByTag } from '@openzeppelin/miden-multisig-client';
+
+const multisig = await client.load(accountId, signer);
+const report = await backfillPublicNotesByTag(midenClient, {
+  accountId: multisig.accountId,
+  midenRpcEndpoint: 'https://rpc.testnet.miden.io',
+});
+// report.discovered, report.skippedPrivate, report.outcomes (per public note)
+await multisig.syncState(); // verifies the imported notes
+```
+
+Each unique public note gets its own `NoteImportOutcome` (source
+`'backfill'`), with the same statuses and duplicate tolerance as the
+proposal import. Tags are best-effort filters: notes sent with unrelated
+custom tags are outside this scan's guarantee, and unrelated notes whose tag
+collides with the account's are imported harmlessly. Private matches are
+counted as `skippedPrivate` — the chain holds no body for them; recover
+those with the transport drain or the proposal import instead.
+
+Scan problems are reported, never thrown: a range dense enough to trip the
+node's pagination cap is split client-side and rescanned, and any sub-range
+that still cannot be covered lands in `report.uncovered` with
+`retryable`/`reason` set, so a partial scan never aborts the rest of a
+recovery flow.
+
 ### Fetch Account State
 
 ```typescript

--- a/packages/miden-multisig-client/src/index.ts
+++ b/packages/miden-multisig-client/src/index.ts
@@ -109,6 +109,15 @@ export type {
 export { isLikelyNetworkError, toUserFacingError } from './connectivity.js';
 export type { ConnectivityCategory, UserFacingError } from './connectivity.js';
 
+// Recovery primitives (issue #415).
+export { importNotesFromProposals } from './proposalNoteImport.js';
+export type {
+  ImportNotesFromProposalsOptions,
+  NoteImportOutcome,
+  NoteImportSource,
+  NoteImportStatus,
+} from './proposalNoteImport.js';
+
 export {
   FalconSigner,
   EcdsaSigner,

--- a/packages/miden-multisig-client/src/multisig.test.ts
+++ b/packages/miden-multisig-client/src/multisig.test.ts
@@ -17,6 +17,7 @@ const {
   mockNoteFileDeserialize,
   mockGetSignerCommitments,
   mockGetGuardianCommitment,
+  mockImportNotesFromProposals,
 } = vi.hoisted(() => ({
   mockRpcGetAccountDetails: vi.fn(),
   mockAccountDeserialize: vi.fn(),
@@ -24,6 +25,11 @@ const {
   mockNoteFileDeserialize: vi.fn(),
   mockGetSignerCommitments: vi.fn(),
   mockGetGuardianCommitment: vi.fn(),
+  mockImportNotesFromProposals: vi.fn(),
+}));
+
+vi.mock('./proposalNoteImport.js', () => ({
+  importNotesFromProposals: mockImportNotesFromProposals,
 }));
 
 const { MOCK_CHAIN_ANCHOR_B64, createMockChainAnchor } = vi.hoisted(() => {
@@ -427,6 +433,47 @@ describe('Multisig', () => {
 
       expect(result).toBe(page);
       expect(spy).toHaveBeenCalledWith('0x' + 'a'.repeat(30), { limit: 5, cursor: 'prev' });
+    });
+  });
+
+  describe('importNotesFromProposals (issue #415)', () => {
+    const config = {
+      threshold: 1,
+      signerCommitments: ['0x' + 'a'.repeat(64)],
+      guardianCommitment: '0x' + 'c'.repeat(64),
+    };
+
+    it("delegates to the standalone helper with this client's endpoint and rpc settings", async () => {
+      const multisig = createTestMultisig(config);
+      const outcomes = [{ identifier: '0x1', source: 'proposal', status: 'imported' }];
+      mockImportNotesFromProposals.mockResolvedValue(outcomes);
+      const proposals = [
+        { id: 'p-1', metadata: { proposalType: 'consume_notes', description: '', noteIds: [] } },
+      ];
+
+      const result = await multisig.importNotesFromProposals(proposals as never);
+
+      expect(result).toBe(outcomes);
+      expect(mockImportNotesFromProposals).toHaveBeenCalledWith(mockWebClient, proposals, {
+        midenRpcEndpoint: MIDEN_RPC_ENDPOINT,
+        // Reuses the client's resolved retry budget (default: 2 attempts).
+        rpc: { retry: { maxAttempts: 2 } },
+      });
+    });
+
+    it('syncs proposals from GUARDIAN when none are passed', async () => {
+      const multisig = createTestMultisig(config);
+      mockImportNotesFromProposals.mockResolvedValue([]);
+      const spy = vi.spyOn(guardian, 'getDeltaProposals').mockResolvedValue([]);
+
+      await multisig.importNotesFromProposals();
+
+      expect(spy).toHaveBeenCalledWith('0x' + 'a'.repeat(30));
+      expect(mockImportNotesFromProposals).toHaveBeenCalledWith(
+        mockWebClient,
+        [],
+        expect.objectContaining({ midenRpcEndpoint: MIDEN_RPC_ENDPOINT }),
+      );
     });
   });
 

--- a/packages/miden-multisig-client/src/multisig.ts
+++ b/packages/miden-multisig-client/src/multisig.ts
@@ -86,6 +86,10 @@ import { ProposalFactory } from './proposal/factory.js';
 import { ProposalMetadataCodec } from './proposal/metadata.js';
 import { ProposalSignatures } from './proposal/signatures.js';
 import {
+  importNotesFromProposals as importNotesFromProposalsStandalone,
+  type NoteImportOutcome,
+} from './proposalNoteImport.js';
+import {
   getRawMidenClient,
   getTransactionProver,
   requireMidenRpcEndpoint,
@@ -1229,6 +1233,28 @@ export class Multisig {
   async importNoteFromFile(file: Blob): Promise<string> {
     const noteBytes = new Uint8Array(await file.arrayBuffer());
     return this.importNoteFromBytes(noteBytes);
+  }
+
+  /**
+   * Import the notes embedded in this account's pending v2 consume-notes
+   * proposals into the local Miden store (issue #415) — the recovery
+   * convenience over the standalone
+   * {@link importNotesFromProposalsStandalone | importNotesFromProposals},
+   * reusing this client's Miden RPC endpoint and retry configuration
+   * instead of taking them as parameters.
+   *
+   * When `proposals` is omitted, the pending proposals are synced from
+   * GUARDIAN first. See the standalone function for per-note outcome
+   * semantics; run a sync afterwards so imported notes are verified.
+   */
+  async importNotesFromProposals(
+    proposals?: ReadonlyArray<Pick<Proposal, 'id' | 'metadata'>>,
+  ): Promise<NoteImportOutcome[]> {
+    const source = proposals ?? (await this.syncProposals());
+    return importNotesFromProposalsStandalone(this.midenClient, source, {
+      midenRpcEndpoint: this.getMidenRpcEndpoint(),
+      rpc: { retry: { maxAttempts: this.rpcConfig.maxAttempts } },
+    });
   }
 
   /**

--- a/packages/miden-multisig-client/src/proposalNoteImport.test.ts
+++ b/packages/miden-multisig-client/src/proposalNoteImport.test.ts
@@ -1,0 +1,452 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { importNotesFromProposals } from './proposalNoteImport.js';
+import type { Proposal } from './types/proposal.js';
+import { uint8ArrayToBase64 } from './utils/encoding.js';
+
+const { mockNoteDeserialize, mockGetNotesById } = vi.hoisted(() => ({
+  mockNoteDeserialize: vi.fn(),
+  mockGetNotesById: vi.fn(),
+}));
+
+vi.mock('@miden-sdk/miden-sdk', () => ({
+  Note: {
+    deserialize: mockNoteDeserialize,
+  },
+  NoteFile: {
+    fromInputNote: vi.fn((inputNote: unknown) => ({ kind: 'with-proof', inputNote })),
+    fromNoteDetails: vi.fn((details: unknown) => ({ kind: 'details', details })),
+  },
+  NoteFilter: vi.fn().mockImplementation((noteType: number) => ({ noteType })),
+  NoteFilterTypes: {
+    All: 0,
+    Consumed: 1,
+    Committed: 2,
+    Expected: 3,
+    Processing: 4,
+    List: 5,
+    Unique: 6,
+    Nullifiers: 7,
+    Unverified: 8,
+  },
+  InputNote: {
+    authenticated: vi.fn((note: unknown, proof: unknown) => ({ note, proof })),
+  },
+  NoteDetails: vi.fn().mockImplementation((assets: unknown, recipient: unknown) => ({
+    assets,
+    recipient,
+  })),
+  Endpoint: vi.fn().mockImplementation((url: string) => ({ url })),
+  RpcClient: vi.fn().mockImplementation(() => ({
+    getNotesById: mockGetNotesById,
+  })),
+}));
+
+const FILTER_ALL = 0;
+const FILTER_CONSUMED = 1;
+
+const MIDEN_RPC_ENDPOINT = 'https://rpc.devnet.miden.io';
+
+const NOTE_ID_1 = `0x${'11'.repeat(32)}`;
+const NOTE_ID_2 = `0x${'22'.repeat(32)}`;
+const NOTE_ID_3 = `0x${'33'.repeat(32)}`;
+
+/** Base64 whose decoded bytes name the note the mocked `Note.deserialize`
+ * should return; unknown names throw, simulating corrupt bytes. */
+function noteBase64(name: string): string {
+  return uint8ArrayToBase64(new TextEncoder().encode(name));
+}
+
+/** Deterministic fake recipient digest for a note id. */
+function recipientDigestFor(idHex: string): string {
+  return `0xdd${idHex.slice(4)}`;
+}
+
+/** Deterministic fake tag (u32) for a note id. */
+function tagFor(idHex: string): number {
+  return parseInt(idHex.slice(2, 6), 16);
+}
+
+/** Deterministic fake fungible-asset list keyed by a note id. */
+function noteAssets(idHex: string) {
+  const faucetHex = `0xfa${idHex.slice(4, 34)}`;
+  return {
+    fungibleAssets: () => [
+      { faucetId: () => ({ toString: () => faucetHex }), amount: () => 100n },
+    ],
+  };
+}
+
+function makeNote(idHex: string) {
+  const assets = noteAssets(idHex);
+  return {
+    id: () => ({ toString: () => idHex }),
+    recipient: () => ({ digest: () => ({ toHex: () => recipientDigestFor(idHex) }) }),
+    metadata: () => ({ tag: () => ({ asU32: () => tagFor(idHex) }) }),
+    assets: () => assets,
+  };
+}
+
+/** A store record as returned by `getInputNotes`. `idHex: undefined` models a
+ * metadata-less record (expected-state details import or consumed-external),
+ * which still exposes its details (recipient digest + assets). `detailsOf`
+ * names the note whose details the record shares; `assetsOf` overrides the
+ * asset half to model recipient-digest collisions between distinct notes. */
+function makeRecord(options: {
+  idHex?: string;
+  detailsOf?: string;
+  assetsOf?: string;
+  consumed?: boolean;
+}) {
+  const detailsSource = options.detailsOf ?? `0x${'ab'.repeat(32)}`;
+  const assets = noteAssets(options.assetsOf ?? detailsSource);
+  return {
+    id: () => (options.idHex ? { toString: () => options.idHex } : undefined),
+    details: () => ({
+      recipient: () => ({ digest: () => ({ toHex: () => recipientDigestFor(detailsSource) }) }),
+      assets: () => assets,
+    }),
+    isConsumed: () => options.consumed ?? false,
+  };
+}
+
+function makeFetchedNote(idHex: string, options: { withBody?: boolean } = {}) {
+  return {
+    noteId: { toString: () => idHex },
+    inclusionProof: `proof:${idHex}`,
+    // Private notes come back without a body; the import path must never
+    // read it.
+    note: options.withBody ? makeNote(idHex) : undefined,
+  };
+}
+
+function makeProposal(
+  id: string,
+  notes: string[],
+  metadataVersion: 1 | 2 = 2,
+): Pick<Proposal, 'id' | 'metadata'> {
+  return {
+    id,
+    metadata: {
+      proposalType: 'consume_notes',
+      description: 'test',
+      noteIds: notes.map((_, i) => `0x${String(i).repeat(2)}`),
+      ...(metadataVersion === 2 ? { metadataVersion: 2 as const, notes } : {}),
+    },
+  };
+}
+
+describe('importNotesFromProposals', () => {
+  let storeRecords: Array<ReturnType<typeof makeRecord>>;
+  let consumedRecords: Array<ReturnType<typeof makeRecord>>;
+  let mockWebClient: {
+    getInputNotes: ReturnType<typeof vi.fn>;
+    importNoteFile: ReturnType<typeof vi.fn>;
+    addTag: ReturnType<typeof vi.fn>;
+  };
+  const noteRegistry = new Map<string, ReturnType<typeof makeNote>>();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    noteRegistry.clear();
+    noteRegistry.set('note-1', makeNote(NOTE_ID_1));
+    noteRegistry.set('note-2', makeNote(NOTE_ID_2));
+    noteRegistry.set('note-3', makeNote(NOTE_ID_3));
+    mockNoteDeserialize.mockImplementation((bytes: Uint8Array) => {
+      const name = new TextDecoder().decode(bytes);
+      const note = noteRegistry.get(name);
+      if (!note) {
+        throw new Error(`corrupt note bytes: ${name}`);
+      }
+      return note;
+    });
+    storeRecords = [];
+    consumedRecords = [];
+    mockWebClient = {
+      getInputNotes: vi.fn().mockImplementation(async (filter: { noteType: number }) => {
+        if (filter.noteType === FILTER_ALL) return storeRecords;
+        if (filter.noteType === FILTER_CONSUMED) return consumedRecords;
+        return [];
+      }),
+      importNoteFile: vi.fn().mockResolvedValue(NOTE_ID_1),
+      addTag: vi.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  function run(proposals: Array<Pick<Proposal, 'id' | 'metadata'>>) {
+    return importNotesFromProposals(mockWebClient as never, proposals, {
+      midenRpcEndpoint: MIDEN_RPC_ENDPOINT,
+    });
+  }
+
+  it('imports a committed public note with its fetched proof', async () => {
+    mockGetNotesById.mockResolvedValue([makeFetchedNote(NOTE_ID_1, { withBody: true })]);
+
+    const outcomes = await run([makeProposal('p-1', [noteBase64('note-1')])]);
+
+    expect(outcomes).toEqual([
+      { identifier: NOTE_ID_1, source: 'proposal', status: 'imported' },
+    ]);
+    expect(mockWebClient.importNoteFile).toHaveBeenCalledWith({
+      kind: 'with-proof',
+      inputNote: { note: noteRegistry.get('note-1'), proof: `proof:${NOTE_ID_1}` },
+    });
+  });
+
+  it('imports a committed private note from local bytes only (node has no body)', async () => {
+    mockGetNotesById.mockResolvedValue([makeFetchedNote(NOTE_ID_1, { withBody: false })]);
+
+    const outcomes = await run([makeProposal('p-1', [noteBase64('note-1')])]);
+
+    expect(outcomes[0].status).toBe('imported');
+    // The imported note is the one decoded from the proposal bytes, never
+    // the (absent) node-returned body.
+    expect(mockWebClient.importNoteFile).toHaveBeenCalledWith({
+      kind: 'with-proof',
+      inputNote: { note: noteRegistry.get('note-1'), proof: `proof:${NOTE_ID_1}` },
+    });
+  });
+
+  it('tracks the tag and parks an uncommitted note as expected details, reported retryable', async () => {
+    mockGetNotesById.mockResolvedValue([]);
+
+    const outcomes = await run([makeProposal('p-1', [noteBase64('note-1')])]);
+
+    expect(outcomes).toEqual([
+      {
+        identifier: NOTE_ID_1,
+        source: 'proposal',
+        status: 'not-committed',
+        retryable: true,
+        reason: expect.stringContaining('not yet committed'),
+      },
+    ]);
+    // The tag must be tracked (before the import) or sync can never discover
+    // the note's commitment — the WASM details file cannot carry a tag.
+    expect(mockWebClient.addTag).toHaveBeenCalledWith(String(tagFor(NOTE_ID_1)));
+    expect(mockWebClient.addTag.mock.invocationCallOrder[0]).toBeLessThan(
+      mockWebClient.importNoteFile.mock.invocationCallOrder[0],
+    );
+    const detailsFile = mockWebClient.importNoteFile.mock.calls[0][0] as {
+      kind: string;
+      details: { assets: string; recipient: { digest: () => { toHex: () => string } } };
+    };
+    expect(detailsFile.kind).toBe('details');
+    expect(detailsFile.details.assets).toBe(noteRegistry.get('note-1')!.assets());
+    expect(detailsFile.details.recipient.digest().toHex()).toBe(recipientDigestFor(NOTE_ID_1));
+  });
+
+  it('isolates a malformed note without blocking the rest', async () => {
+    mockGetNotesById.mockResolvedValue([makeFetchedNote(NOTE_ID_2)]);
+
+    const outcomes = await run([
+      makeProposal('p-9', [noteBase64('garbage'), noteBase64('note-2')]),
+    ]);
+
+    expect(outcomes).toEqual([
+      {
+        identifier: 'proposal p-9 notes[0]',
+        source: 'proposal',
+        status: 'invalid',
+        reason: expect.stringContaining('failed to decode embedded note'),
+      },
+      { identifier: NOTE_ID_2, source: 'proposal', status: 'imported' },
+    ]);
+  });
+
+  it('classifies notes the store already tracks, including metadata-less records', async () => {
+    storeRecords = [
+      // Normal record, matched by note ID.
+      makeRecord({ idHex: NOTE_ID_1 }),
+      // Metadata-less record (no note ID — e.g. consumed-external or an
+      // expected-state details import), matched by recipient digest.
+      makeRecord({ detailsOf: NOTE_ID_2, consumed: true }),
+    ];
+    mockGetNotesById.mockResolvedValue([makeFetchedNote(NOTE_ID_3)]);
+
+    const outcomes = await run([
+      makeProposal('p-1', [noteBase64('note-1'), noteBase64('note-2'), noteBase64('note-3')]),
+    ]);
+
+    expect(outcomes).toEqual([
+      { identifier: NOTE_ID_1, source: 'proposal', status: 'already-present' },
+      { identifier: NOTE_ID_2, source: 'proposal', status: 'already-consumed' },
+      { identifier: NOTE_ID_3, source: 'proposal', status: 'imported' },
+    ]);
+    // Already-tracked notes are never re-imported.
+    expect(mockWebClient.importNoteFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not mistake a same-recipient record with different assets for the candidate', async () => {
+    // Two distinct notes can share a recipient while carrying different
+    // assets — recipient digest alone is not collision-safe, so the record
+    // must NOT match and the candidate must still be recovered.
+    storeRecords = [makeRecord({ detailsOf: NOTE_ID_1, assetsOf: NOTE_ID_2, consumed: true })];
+    mockGetNotesById.mockResolvedValue([makeFetchedNote(NOTE_ID_1)]);
+
+    const outcomes = await run([makeProposal('p-1', [noteBase64('note-1')])]);
+
+    expect(outcomes).toEqual([
+      { identifier: NOTE_ID_1, source: 'proposal', status: 'imported' },
+    ]);
+    expect(mockWebClient.importNoteFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not relabel an import as consumed for a same-recipient record with different assets', async () => {
+    mockGetNotesById.mockResolvedValue([makeFetchedNote(NOTE_ID_1)]);
+    // An unrelated consumed note sharing the recipient but not the assets
+    // must not flip the fresh import to already-consumed.
+    consumedRecords = [makeRecord({ detailsOf: NOTE_ID_1, assetsOf: NOTE_ID_2, consumed: true })];
+
+    const outcomes = await run([makeProposal('p-1', [noteBase64('note-1')])]);
+
+    expect(outcomes).toEqual([
+      { identifier: NOTE_ID_1, source: 'proposal', status: 'imported' },
+    ]);
+  });
+
+  it('reports a chain-consumed note as already-consumed after importing its history', async () => {
+    mockGetNotesById.mockResolvedValue([makeFetchedNote(NOTE_ID_1)]);
+    // The upstream import stores a chain-nullified note as a metadata-less
+    // consumed record; the batched post-import check sees it by recipient
+    // digest.
+    consumedRecords = [
+      makeRecord({ detailsOf: NOTE_ID_1, consumed: true }),
+    ];
+
+    const outcomes = await run([makeProposal('p-1', [noteBase64('note-1')])]);
+
+    expect(outcomes).toEqual([
+      {
+        identifier: NOTE_ID_1,
+        source: 'proposal',
+        status: 'already-consumed',
+        reason: expect.stringContaining('already consumed on chain'),
+      },
+    ]);
+    expect(mockWebClient.importNoteFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a successful import as imported when the consumed-state check fails', async () => {
+    mockGetNotesById.mockResolvedValue([makeFetchedNote(NOTE_ID_1)]);
+    mockWebClient.getInputNotes.mockImplementation(async (filter: { noteType: number }) => {
+      if (filter.noteType === FILTER_ALL) return [];
+      throw new Error('store busy');
+    });
+
+    const outcomes = await run([makeProposal('p-1', [noteBase64('note-1')])]);
+
+    expect(outcomes).toEqual([
+      {
+        identifier: NOTE_ID_1,
+        source: 'proposal',
+        status: 'imported',
+        reason: expect.stringContaining('consumed-state check failed'),
+      },
+    ]);
+  });
+
+  it('fails every decoded note when the store scan itself fails', async () => {
+    mockWebClient.getInputNotes.mockRejectedValue(new Error('store locked'));
+
+    const outcomes = await run([makeProposal('p-1', [noteBase64('note-1')])]);
+
+    expect(outcomes).toEqual([
+      {
+        identifier: NOTE_ID_1,
+        source: 'proposal',
+        status: 'failed',
+        reason: expect.stringContaining('failed to read local store'),
+      },
+    ]);
+    expect(mockWebClient.importNoteFile).not.toHaveBeenCalled();
+  });
+
+  it('reports a transient proof-fetch failure as retryable for every pending note', async () => {
+    mockGetNotesById.mockRejectedValue(Object.assign(new Error('node down'), { code: 14 }));
+
+    const outcomes = await run([
+      makeProposal('p-1', [noteBase64('note-1'), noteBase64('note-2')]),
+    ]);
+
+    expect(outcomes).toEqual([
+      {
+        identifier: NOTE_ID_1,
+        source: 'proposal',
+        status: 'failed',
+        retryable: true,
+        reason: expect.stringContaining('failed to fetch inclusion proofs'),
+      },
+      {
+        identifier: NOTE_ID_2,
+        source: 'proposal',
+        status: 'failed',
+        retryable: true,
+        reason: expect.stringContaining('failed to fetch inclusion proofs'),
+      },
+    ]);
+    expect(mockWebClient.importNoteFile).not.toHaveBeenCalled();
+  });
+
+  it('isolates an import failure without blocking the rest, classifying retryability', async () => {
+    mockGetNotesById.mockResolvedValue([makeFetchedNote(NOTE_ID_1), makeFetchedNote(NOTE_ID_2)]);
+    mockWebClient.importNoteFile.mockImplementation(
+      async (file: { inputNote: { note: unknown } }) => {
+        if (file.inputNote.note === noteRegistry.get('note-1')) {
+          // Transient node failure surfaced through the import's internal RPC.
+          throw Object.assign(new Error('import blip'), { code: 14 });
+        }
+        return NOTE_ID_2;
+      },
+    );
+
+    const outcomes = await run([
+      makeProposal('p-1', [noteBase64('note-1'), noteBase64('note-2')]),
+    ]);
+
+    expect(outcomes).toEqual([
+      {
+        identifier: NOTE_ID_1,
+        source: 'proposal',
+        status: 'failed',
+        retryable: true,
+        reason: expect.stringContaining('failed to import note'),
+      },
+      { identifier: NOTE_ID_2, source: 'proposal', status: 'imported' },
+    ]);
+  });
+
+  it('skips v1 proposals and non-consume proposal types', async () => {
+    const v1 = makeProposal('p-1', [noteBase64('note-1')], 1);
+    const p2id: Pick<Proposal, 'id' | 'metadata'> = {
+      id: 'p-2',
+      metadata: {
+        proposalType: 'p2id',
+        description: 'test',
+        recipientId: '0xaa',
+        faucetId: '0xbb',
+        amount: '1',
+      },
+    };
+
+    const outcomes = await run([v1, p2id]);
+
+    expect(outcomes).toEqual([]);
+    expect(mockGetNotesById).not.toHaveBeenCalled();
+    expect(mockWebClient.importNoteFile).not.toHaveBeenCalled();
+  });
+
+  it('deduplicates the same note embedded by several proposals', async () => {
+    mockGetNotesById.mockResolvedValue([makeFetchedNote(NOTE_ID_1)]);
+
+    const outcomes = await run([
+      makeProposal('p-1', [noteBase64('note-1')]),
+      makeProposal('p-2', [noteBase64('note-1')]),
+    ]);
+
+    expect(outcomes).toEqual([
+      { identifier: NOTE_ID_1, source: 'proposal', status: 'imported' },
+    ]);
+    expect(mockWebClient.importNoteFile).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/miden-multisig-client/src/proposalNoteImport.ts
+++ b/packages/miden-multisig-client/src/proposalNoteImport.ts
@@ -1,0 +1,393 @@
+/**
+ * Recovery primitives (issue #415, sub-issue of #357).
+ *
+ * After key-based recovery the local Miden store starts empty, so notes the
+ * account was in the middle of consuming are gone. v2 `consume_notes`
+ * proposals embed the serialized notes they consume (issue #229), which makes
+ * pending proposals opportunistic recovery material: this module rebuilds
+ * importable notes from those embedded bytes plus a node-fetched inclusion
+ * proof, without needing the node to hold the note body — so it works for
+ * private notes too (spike #412).
+ */
+
+import {
+  Endpoint,
+  InputNote,
+  type InputNoteRecord,
+  Note,
+  type NoteAssets,
+  NoteDetails,
+  NoteFile,
+  NoteFilter,
+  NoteFilterTypes,
+  type NoteInclusionProof,
+  RpcClient,
+} from '@miden-sdk/miden-sdk';
+
+import { getRawMidenClient, requireMidenRpcEndpoint, type RawClientSource } from './raw-client.js';
+import { resolveRpcConfig, type RpcConfig } from './rpc/config.js';
+import { isTransientRpcError } from './rpc/errors.js';
+import { retryRpcRead } from './rpc/retry.js';
+import { isConsumeNotesV2 } from './types/proposal.js';
+import type { Proposal } from './types/proposal.js';
+import { noteFromBase64, normalizeHexWord } from './utils/encoding.js';
+
+/** Where a recovered note's bytes came from. */
+export type NoteImportSource = 'proposal';
+
+/** Per-note result of a recovery import attempt. */
+export type NoteImportStatus =
+  /** Note imported with its on-chain inclusion proof; it lands in the store's
+   * unverified state and the next sync verifies it. */
+  | 'imported'
+  /** The local store already tracks this note (not yet consumed). */
+  | 'already-present'
+  /** The note is already consumed — either the local store tracked it as
+   * consumed, or the chain had nullified it and the import recorded it as
+   * consumption history rather than a consumable note. */
+  | 'already-consumed'
+  /** The chain does not know the note yet. Its details were recorded as
+   * expected with its tag tracked, so a later sync picks it up once it
+   * commits. */
+  | 'not-committed'
+  /** The embedded bytes could not be decoded into a note. */
+  | 'invalid'
+  /** The import attempt failed (store or RPC error). */
+  | 'failed';
+
+/**
+ * Outcome of one unique embedded note's recovery import. A batch of outcomes
+ * is the full report of {@link importNotesFromProposals}; no per-note problem
+ * aborts the batch. A note embedded by several proposals is deduplicated into
+ * a single outcome (its first occurrence).
+ */
+export interface NoteImportOutcome {
+  /** The note ID hex when the bytes decoded, otherwise a positional reference
+   * into the proposal (`proposal <id> notes[<i>]`). */
+  identifier: string;
+  /** Where the note bytes came from. */
+  source: NoteImportSource;
+  /** What happened to this note. */
+  status: NoteImportStatus;
+  /** Whether retrying the import later can change the status (transient RPC
+   * failures, notes not yet committed). Absent means not retryable. */
+  retryable?: boolean;
+  /** Human-readable detail for non-success statuses — or, on an `imported`
+   * outcome, a warning that the post-import consumed-state check failed and a
+   * sync should confirm the note's status. */
+  reason?: string;
+}
+
+export interface ImportNotesFromProposalsOptions {
+  /** Miden node RPC endpoint used to fetch inclusion proofs. Must point at
+   * the same network as the injected Miden client. */
+  midenRpcEndpoint: string;
+  /** Node RPC read-retry configuration (defaults match the rest of the SDK). */
+  rpc?: RpcConfig;
+}
+
+function errorDetail(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+interface DecodedCandidate {
+  note: Note;
+  idHex: string;
+  /** Metadata-independent identifier: metadata-less store records (details
+   * imports in expected state, chain-consumed history) expose neither a note
+   * ID nor a nullifier, so records are matched by their details — recipient
+   * digest plus asset fingerprint, together equivalent to the details
+   * commitment (recipient alone is not collision-safe: two distinct notes
+   * can share a recipient while carrying different assets). */
+  detailsKey: string;
+  /** Decimal string of the note's tag, for `addTag`. */
+  tagString: string;
+}
+
+/** Collision-safe key over full note details: recipient digest + canonical
+ * asset list. Mirrors what the details commitment covers, which the WASM
+ * record surface does not expose directly. */
+function detailsKeyOf(recipientDigestHex: string, assets: NoteAssets): string {
+  const fingerprint = assets
+    .fungibleAssets()
+    .map((asset) => `${normalizeHexWord(asset.faucetId().toString())}:${asset.amount()}`)
+    .sort()
+    .join(',');
+  return `${recipientDigestHex}|${fingerprint}`;
+}
+
+function recordKeys(record: InputNoteRecord): string[] {
+  const keys: string[] = [];
+  const recordId = record.id();
+  if (recordId) {
+    keys.push(normalizeHexWord(recordId.toString()));
+  }
+  const details = record.details();
+  keys.push(
+    detailsKeyOf(normalizeHexWord(details.recipient().digest().toHex()), details.assets()),
+  );
+  return keys;
+}
+
+/**
+ * Imports the notes embedded in v2 `consume_notes` proposals into the local
+ * Miden store (issue #415), typically after key-based recovery rebuilt the
+ * proposal list (`syncProposals`) but left the note store empty.
+ *
+ * Proposals are opportunistic recovery material, not a backup: v1 proposals
+ * carry no note bytes, and proposals disappear once canonicalized, so only
+ * notes still mid-consumption are recoverable this way.
+ *
+ * Per note: decode the embedded bytes, skip notes the store already tracks,
+ * fetch the on-chain inclusion proof, and import the note individually
+ * (upstream note-import batches are atomic, so one bad note must not sink the
+ * rest). A note the chain does not know yet is recorded as expected with its
+ * tag tracked so a later sync picks it up, and is reported as
+ * `not-committed`/retryable. A note the chain has already nullified is
+ * recorded as consumption history and reported `already-consumed`.
+ *
+ * The returned outcomes cover every unique embedded note — a note embedded by
+ * several proposals yields one outcome, not one per embedding — and this
+ * function does not throw for per-note problems.
+ *
+ * @example
+ * ```typescript
+ * const proposals = await multisig.syncProposals();
+ * const outcomes = await importNotesFromProposals(midenClient, proposals, {
+ *   midenRpcEndpoint: 'https://rpc.testnet.miden.io',
+ * });
+ * await multisig.syncState();
+ * ```
+ */
+export async function importNotesFromProposals(
+  midenClient: RawClientSource,
+  proposals: ReadonlyArray<Pick<Proposal, 'id' | 'metadata'>>,
+  options: ImportNotesFromProposalsOptions,
+): Promise<NoteImportOutcome[]> {
+  const midenRpcEndpoint = requireMidenRpcEndpoint(options.midenRpcEndpoint);
+  const rpcConfig = resolveRpcConfig(options.rpc);
+  const webClient = await getRawMidenClient(midenClient, midenRpcEndpoint);
+
+  const outcomes: NoteImportOutcome[] = [];
+
+  // Decode and deduplicate embedded notes (the same note may be embedded by
+  // several proposals); undecodable entries become isolated `invalid`
+  // outcomes with a positional identifier. Decoding is deliberately
+  // permissive: the strict note-ID binding check belongs to the
+  // verify/execute path — a note is self-validating (its ID derives from its
+  // contents), so importing it is harmless even when the proposal's declared
+  // note IDs disagree.
+  const decoded: DecodedCandidate[] = [];
+  const seen = new Set<string>();
+  for (const proposal of proposals) {
+    const metadata = proposal.metadata;
+    if (metadata.proposalType !== 'consume_notes' || !isConsumeNotesV2(metadata)) {
+      continue;
+    }
+    const embedded = metadata.notes ?? [];
+    for (let index = 0; index < embedded.length; index += 1) {
+      // The try covers every per-note WASM accessor, so a payload that
+      // deserializes but traps on use is isolated like any other bad note.
+      let candidate: DecodedCandidate;
+      try {
+        const note = noteFromBase64(embedded[index], Note);
+        candidate = {
+          note,
+          idHex: normalizeHexWord(note.id().toString()),
+          detailsKey: detailsKeyOf(
+            normalizeHexWord(note.recipient().digest().toHex()),
+            note.assets(),
+          ),
+          tagString: String(note.metadata().tag().asU32()),
+        };
+      } catch (error) {
+        outcomes.push({
+          identifier: `proposal ${proposal.id} notes[${index}]`,
+          source: 'proposal',
+          status: 'invalid',
+          reason: `failed to decode embedded note: ${errorDetail(error)}`,
+        });
+        continue;
+      }
+      if (seen.has(candidate.idHex)) {
+        continue;
+      }
+      seen.add(candidate.idHex);
+      decoded.push(candidate);
+    }
+  }
+
+  if (decoded.length === 0) {
+    return outcomes;
+  }
+
+  // Look up existing records by note ID *and* recipient digest: records the
+  // store keeps without metadata (a note details import in expected state, or
+  // a note observed as consumed on chain) expose neither a note ID nor a
+  // nullifier, and an ID-only lookup would keep re-importing them forever.
+  // (The WASM NoteFilter has no details-commitment variant, unlike the Rust
+  // SDK, so this scans the store once and keys records both ways.)
+  const existing = new Map<string, InputNoteRecord>();
+  try {
+    const records = await webClient.getInputNotes(new NoteFilter(NoteFilterTypes.All));
+    for (const record of records) {
+      for (const key of recordKeys(record)) {
+        existing.set(key, record);
+      }
+    }
+  } catch (error) {
+    const reason = `failed to read local store: ${errorDetail(error)}`;
+    for (const candidate of decoded) {
+      outcomes.push({
+        identifier: candidate.idHex,
+        source: 'proposal',
+        status: 'failed',
+        reason,
+      });
+    }
+    return outcomes;
+  }
+
+  // Skip notes the store already tracks.
+  const pending: DecodedCandidate[] = [];
+  for (const candidate of decoded) {
+    const record = existing.get(candidate.idHex) ?? existing.get(candidate.detailsKey);
+    if (record) {
+      outcomes.push({
+        identifier: candidate.idHex,
+        source: 'proposal',
+        status: record.isConsumed() ? 'already-consumed' : 'already-present',
+      });
+      continue;
+    }
+    pending.push(candidate);
+  }
+
+  if (pending.length === 0) {
+    return outcomes;
+  }
+
+  // One round trip for all missing notes; only the import itself is per-note.
+  // The node returns proofs for private notes too, so the locally-held bytes
+  // are the only body this path ever needs.
+  const proofs = new Map<string, NoteInclusionProof>();
+  try {
+    const rpcClient = new RpcClient(new Endpoint(midenRpcEndpoint));
+    const fetchedNotes = await retryRpcRead(
+      () => rpcClient.getNotesById(pending.map((candidate) => candidate.note.id())),
+      rpcConfig,
+    );
+    for (const fetched of fetchedNotes) {
+      proofs.set(normalizeHexWord(fetched.noteId.toString()), fetched.inclusionProof);
+    }
+  } catch (error) {
+    const retryable = isTransientRpcError(error);
+    const reason = `failed to fetch inclusion proofs: ${errorDetail(error)}`;
+    for (const candidate of pending) {
+      outcomes.push({
+        identifier: candidate.idHex,
+        source: 'proposal',
+        status: 'failed',
+        retryable,
+        reason,
+      });
+    }
+    return outcomes;
+  }
+
+  // Provisionally `imported` outcomes, re-classified in one batched
+  // consumed-state check below.
+  const imported: Array<{ index: number; detailsKey: string }> = [];
+
+  for (const candidate of pending) {
+    const proof = proofs.get(candidate.idHex);
+    if (proof) {
+      try {
+        const inputNote = InputNote.authenticated(candidate.note, proof);
+        await webClient.importNoteFile(NoteFile.fromInputNote(inputNote));
+        imported.push({ index: outcomes.length, detailsKey: candidate.detailsKey });
+        outcomes.push({
+          identifier: candidate.idHex,
+          source: 'proposal',
+          status: 'imported',
+        });
+      } catch (error) {
+        outcomes.push({
+          identifier: candidate.idHex,
+          source: 'proposal',
+          status: 'failed',
+          retryable: isTransientRpcError(error),
+          reason: `failed to import note: ${errorDetail(error)}`,
+        });
+      }
+    } else {
+      try {
+        // Track the tag FIRST so the resulting expected record can never
+        // exist untagged: the WASM details import cannot carry a tag (unlike
+        // the Rust SDK's note file), and sync only discovers the note's
+        // commitment through a tracked tag. Tag first also means a failure
+        // here leaves no dead record behind.
+        await webClient.addTag(candidate.tagString);
+        const details = new NoteDetails(candidate.note.assets(), candidate.note.recipient());
+        await webClient.importNoteFile(NoteFile.fromNoteDetails(details));
+        outcomes.push({
+          identifier: candidate.idHex,
+          source: 'proposal',
+          status: 'not-committed',
+          retryable: true,
+          reason: 'note not yet committed on chain; recorded as expected so a later sync picks it up',
+        });
+      } catch (error) {
+        outcomes.push({
+          identifier: candidate.idHex,
+          source: 'proposal',
+          status: 'failed',
+          retryable: isTransientRpcError(error),
+          reason: `failed to record expected note: ${errorDetail(error)}`,
+        });
+      }
+    }
+  }
+
+  // A note the chain already nullified is stored as consumption history, not
+  // as a consumable note — report that honestly instead of `imported`. One
+  // batched store read covers every imported note.
+  if (imported.length > 0) {
+    try {
+      const consumedRecords = await webClient.getInputNotes(
+        new NoteFilter(NoteFilterTypes.Consumed),
+      );
+      const consumed = new Set(
+        consumedRecords.map((record) => {
+          const details = record.details();
+          return detailsKeyOf(
+            normalizeHexWord(details.recipient().digest().toHex()),
+            details.assets(),
+          );
+        }),
+      );
+      for (const entry of imported) {
+        if (consumed.has(entry.detailsKey)) {
+          outcomes[entry.index] = {
+            ...outcomes[entry.index],
+            status: 'already-consumed',
+            reason: 'note was already consumed on chain; recorded as consumption history',
+          };
+        }
+      }
+    } catch (error) {
+      // The imports themselves succeeded; stay `imported` but flag that the
+      // consumed-state classification is unknown.
+      for (const entry of imported) {
+        outcomes[entry.index] = {
+          ...outcomes[entry.index],
+          reason: `imported, but the consumed-state check failed (${errorDetail(
+            error,
+          )}); run sync to confirm the note's status`,
+        };
+      }
+    }
+  }
+
+  return outcomes;
+}


### PR DESCRIPTION
Closes #415 (sub-issue of #357). Productizes the reconstruction path validated by spike #412.

## What

Adds a recovery primitive to both SDKs that rebuilds Miden store records from the note bytes embedded in v2 `consume_notes` proposals (#229), plus a node-fetched inclusion proof — so it works for private notes without the node ever holding the body.

- Rust: `MultisigClient::import_notes_from_proposals(&[Proposal]) -> Vec<NoteImportOutcome>` (new `client/recovery.rs`)
- TS: standalone `importNotesFromProposals(midenClient, proposals, { midenRpcEndpoint, rpc? })` (new `src/recovery.ts`)

Per unique embedded note (duplicates across proposals fold into one outcome): decode → skip notes the store already tracks → one batched inclusion-proof fetch → import individually (upstream `import_notes` batches are atomic, so one bad note must not sink the rest) → per-note `NoteImportOutcome` with `status` ∈ `imported | already-present | already-consumed | not-committed | invalid | failed` and a `retryable` flag. No per-note problem aborts the batch; the Rust method returns a plain `Vec` because nothing can fail the whole call.

## Key behaviors (live-tested against testnet)

- **Not-committed notes** are recorded in `Expected` state *with their tag tracked* so a later sync picks them up once they commit; reported `not-committed`/retryable. On the TS side the WASM details file cannot carry a tag, so the tag is registered via `addTag` before the import — tag-first so a failure never leaves an untagged dead record.
- **Chain-nullified notes**: miden-client stores these as metadata-less consumption-history records; the primitive reports them `already-consumed` instead of pretending they were recovered.
- **Metadata-less store records** (details-only expected imports, consumed-external history) expose neither a note ID nor a nullifier, so existing-record matching uses details commitments (Rust) / recipient digests (TS — the WASM `NoteFilter` has no details-commitment variant); an ID-only lookup would re-import them forever.
- **Retryability** is classified, not assumed: transient RPC failures during the proof fetch or the import's internal node calls are `retryable: true`.
- Decoding is deliberately permissive: the strict `note.id() == note_ids[i]` binding check stays in the verify/execute path; embedded notes are self-validating, so recovery imports whatever real notes the bytes decode to.

## Docs

`docs/MULTISIG_SDK.md` (both language sections + API tables) and both package READMEs, per AGENTS.md §9. Example wiring (demo/smoke-web) is deferred to the #357 recovery-flow orchestration, where the three primitives (#414/#415/#416) compose.

## Notes for reviewers

- The TS entry point is a standalone function because the issue specifies that signature; a `Multisig` convenience method delegating to it would be a natural follow-up.
- The TS pre-import store scan reads all input notes once (WASM filter surface limitation, commented in code); extracting a shared matching helper is planned with #416.
