### PR TITLE
chore(release): v0.17.0-rc.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,18 +321,31 @@ jobs:
         working-directory: .
         run: cargo build --quiet --example procedure_roots --example serialized_account -p miden-multisig-client
 
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Overlay in-repo guardian-client
+      # miden-multisig-client must build against the in-repo guardian-client, not
+      # the published one: a PR that changes both (the default for contract
+      # changes per AGENTS.md) would otherwise test a stale pair, and during a
+      # coordinated release the internal dep is bumped before guardian-client is
+      # published, so the registry cannot satisfy it at all and `npm ci` fails
+      # with ETARGET. Resolving the dep at the sibling fixes both cases: it is
+      # the pair that ships together, and it needs no registry entry.
+      #
+      # The package.json edit is scoped to this checkout. Publishing runs from a
+      # clean tree in publish.yml, so the shipped manifest keeps its semver
+      # range. `npm install` rather than `npm ci` because a `file:` dep cannot
+      # live in the committed lockfile without breaking publish.
+      - name: Build the in-repo guardian-client
         if: matrix.package == 'miden-multisig-client'
         working-directory: packages/guardian-client
+        run: npm ci && npm run build
+
+      - name: Install dependencies
         run: |
-          npm ci
-          npm run build
-          rm -rf ../miden-multisig-client/node_modules/@openzeppelin/guardian-client/dist
-          cp -r dist ../miden-multisig-client/node_modules/@openzeppelin/guardian-client/dist
-          cp package.json ../miden-multisig-client/node_modules/@openzeppelin/guardian-client/package.json
+          if [[ "${{ matrix.package }}" == "miden-multisig-client" ]]; then
+            npm pkg set 'dependencies.@openzeppelin/guardian-client=file:../guardian-client'
+            npm install --no-audit --no-fund
+          else
+            npm ci
+          fi
 
       - name: Build
         run: npm run build
@@ -399,18 +412,18 @@ jobs:
           cache: npm
           cache-dependency-path: packages/miden-multisig-client/package-lock.json
 
+      # Same reason as the ts-packages job: resolve guardian-client at the
+      # sibling so this gate tests the pair that ships together and does not
+      # depend on the internal dep already being published.
+      - name: Build the in-repo guardian-client
+        working-directory: packages/guardian-client
+        run: npm ci && npm run build
+
       - name: Install package dependencies
         working-directory: packages/miden-multisig-client
-        run: npm ci
-
-      - name: Overlay in-repo guardian-client
-        working-directory: packages/guardian-client
         run: |
-          npm ci
-          npm run build
-          rm -rf ../miden-multisig-client/node_modules/@openzeppelin/guardian-client/dist
-          cp -r dist ../miden-multisig-client/node_modules/@openzeppelin/guardian-client/dist
-          cp package.json ../miden-multisig-client/node_modules/@openzeppelin/guardian-client/package.json
+          npm pkg set 'dependencies.@openzeppelin/guardian-client=file:../guardian-client'
+          npm install --no-audit --no-fund
 
       - name: Build package
         working-directory: packages/miden-multisig-client

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -186,17 +186,29 @@ jobs:
               abort "${package_name}" "${package_version}" "❌ Tests failed" "${next_index}"
             fi
 
+            # A prerelease must not take the `latest` dist-tag, or `npm install`
+            # with no version moves every consumer onto it. npm ignores semver
+            # prerelease semantics when assigning tags, so this has to be
+            # explicit. `latest` for a stable version is npm's own default, so
+            # passing it always keeps the two branches identical apart from the
+            # tag itself.
+            if [[ "${package_version}" == *-* ]]; then
+              npm_tag="rc"
+            else
+              npm_tag="latest"
+            fi
+
             if npm view "${package_name}@${package_version}" version 2>/dev/null; then
               echo "⚠️ ${package_name}@${package_version} is already published, skipping."
               summarize "${package_name}" "${package_version}" "⏭️ Already published"
             elif [[ "${DRY_RUN}" == "true" ]]; then
-              if (cd "${package_dir}" && npm publish --provenance --access public --dry-run); then
-                summarize "${package_name}" "${package_version}" "✅ Dry run succeeded"
+              if (cd "${package_dir}" && npm publish --provenance --access public --tag "${npm_tag}" --dry-run); then
+                summarize "${package_name}" "${package_version}" "✅ Dry run succeeded (tag: ${npm_tag})"
               else
                 abort "${package_name}" "${package_version}" "❌ Dry run failed" "${next_index}"
               fi
-            elif (cd "${package_dir}" && npm publish --provenance --access public); then
-              summarize "${package_name}" "${package_version}" "✅ Published"
+            elif (cd "${package_dir}" && npm publish --provenance --access public --tag "${npm_tag}"); then
+              summarize "${package_name}" "${package_version}" "✅ Published (tag: ${npm_tag})"
             else
               abort "${package_name}" "${package_version}" "❌ Publish failed" "${next_index}"
             fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3390,7 +3390,7 @@ dependencies = [
 
 [[package]]
 name = "guardian-client"
-version = "0.16.2"
+version = "0.17.0-rc.1"
 dependencies = [
  "chrono",
  "guardian-shared",
@@ -3471,7 +3471,7 @@ dependencies = [
 
 [[package]]
 name = "guardian-server"
-version = "0.16.2"
+version = "0.17.0-rc.1"
 dependencies = [
  "aes-gcm",
  "alloy",
@@ -3561,7 +3561,7 @@ dependencies = [
 
 [[package]]
 name = "guardian-shared"
-version = "0.16.2"
+version = "0.17.0-rc.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -4844,7 +4844,7 @@ dependencies = [
 
 [[package]]
 name = "miden-confidential-contracts"
-version = "0.16.2"
+version = "0.17.0-rc.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "miden-multisig-client"
-version = "0.16.2"
+version = "0.17.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5342,7 +5342,7 @@ dependencies = [
 
 [[package]]
 name = "miden-rpc-client"
-version = "0.16.2"
+version = "0.17.0-rc.1"
 dependencies = [
  "async-trait",
  "guardian-shared",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.16.2"
+version = "0.17.0-rc.1"
 edition = "2024"
 rust-version = "1.96.1"
 authors = ["OpenZeppelin"]

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -11,7 +11,7 @@ description = "Client library for Guardian"
 include = ["src/**/*", "proto/**/*", "build.rs", "Cargo.toml", "LICENSE", "README.md"]
 
 [dependencies]
-guardian-shared = { version = "=0.16.2", path = "../shared" }
+guardian-shared = { version = "=0.17.0-rc.1", path = "../shared" }
 miden-protocol = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/contracts/Cargo.toml
+++ b/crates/contracts/Cargo.toml
@@ -14,7 +14,7 @@ miden-standards = { workspace = true }
 miden-protocol = { workspace = true }
 
 anyhow = { workspace = true }
-guardian-shared = { version = "=0.16.2", path = "../shared" }
+guardian-shared = { version = "=0.17.0-rc.1", path = "../shared" }
 
 [features]
 testing = ["miden-protocol/testing"]

--- a/crates/miden-multisig-client/Cargo.toml
+++ b/crates/miden-multisig-client/Cargo.toml
@@ -11,9 +11,9 @@ description = "High-level SDK for interacting with multisig accounts on Miden vi
 
 [dependencies]
 # Internal crates
-guardian-client = { version = "=0.16.2", path = "../client" }
-guardian-shared = { version = "=0.16.2", path = "../shared" }
-miden-confidential-contracts = { version = "=0.16.2", path = "../contracts" }
+guardian-client = { version = "=0.17.0-rc.1", path = "../client" }
+guardian-shared = { version = "=0.17.0-rc.1", path = "../shared" }
+miden-confidential-contracts = { version = "=0.17.0-rc.1", path = "../contracts" }
 
 # Miden
 miden-client = { workspace = true, features = ["tonic"] }
@@ -53,6 +53,6 @@ legacy-consume-notes = []
 
 [dev-dependencies]
 tempfile = { workspace = true }
-miden-confidential-contracts = { version = "=0.16.2", path = "../contracts", features = ["testing"] }
+miden-confidential-contracts = { version = "=0.17.0-rc.1", path = "../contracts", features = ["testing"] }
 miden-client = { workspace = true, features = ["tonic", "testing"] }
 miden-rpc-client = { path = "../miden-rpc-client", features = ["scripted-node"] }

--- a/crates/shared/README.md
+++ b/crates/shared/README.md
@@ -8,3 +8,7 @@ This crate contains shared types and utilities for the GUARDIAN project.
 - `hex`: Hex utilities for converting between types and hex strings
 - `retry`: Transient-failure classification, jittered backoff, and the retry
   policy types shared by the Guardian server and the Miden SDK clients
+- `account_delta`: Applying a Miden `AccountDelta` to an account, with or
+  without an additional storage patch, and reconstructing an account from a
+  full-state delta. Shared so the server and the multisig client agree
+  byte-for-byte on the resulting state commitment

--- a/docs/MIDEN_COMPATIBILITY.md
+++ b/docs/MIDEN_COMPATIBILITY.md
@@ -20,12 +20,16 @@ elsewhere and link here:
 
 | Guardian | Miden protocol | `miden-protocol` / `miden-standards` | `miden-client` (Rust) | `@miden-sdk/miden-sdk` (npm) |
 |---|---|---|---|---|
-| 0.17.x (unreleased) | 0.16 (rc) | `=0.16.0-rc.6` | `=0.16.0-rc.2` | `0.16.0-rc.3` (exact) |
+| 0.17.0-rc.1 | 0.16 (rc) | `=0.16.0-rc.6` | `=0.16.0-rc.2` | `0.16.0-rc.3` (exact) |
 | 0.16.x | 0.15 | `0.15.3` | `0.15.0` | `^0.15.8` |
 | 0.15.x | 0.15 | `0.15.x` | `0.15.0` | `^0.15.0` |
 | 0.14.x | 0.14 | n/a | `0.14.x` | `^0.14.0` |
 | 0.13.x | 0.13 | n/a | `0.13.0` | `^0.13.0` |
 | 0.12.x | 0.12 | n/a | `0.12.5` | `^0.12.5` |
+
+The 0.17 line is a release candidate while `miden-standards` itself is still an
+rc, and it is published to npm under the `rc` dist-tag, so `npm install` without
+an explicit version still resolves the 0.16.x line.
 
 Pins are exact on the 0.16 rc line because the rc protocol is still moving. The
 Rust and npm pins must move together: nothing at build time verifies that the npm

--- a/docs/openapi-client.json
+++ b/docs/openapi-client.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0",
       "identifier": "AGPL-3.0"
     },
-    "version": "0.16.2"
+    "version": "0.17.0-rc.1"
   },
   "paths": {
     "/": {

--- a/docs/openapi-dashboard.json
+++ b/docs/openapi-dashboard.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0",
       "identifier": "AGPL-3.0"
     },
-    "version": "0.16.2"
+    "version": "0.17.0-rc.1"
   },
   "paths": {
     "/auth/challenge": {

--- a/docs/openapi-evm.json
+++ b/docs/openapi-evm.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0",
       "identifier": "AGPL-3.0"
     },
-    "version": "0.16.2"
+    "version": "0.17.0-rc.1"
   },
   "paths": {
     "/evm/accounts": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7,7 +7,7 @@
       "name": "AGPL-3.0",
       "identifier": "AGPL-3.0"
     },
-    "version": "0.16.2"
+    "version": "0.17.0-rc.1"
   },
   "paths": {
     "/": {

--- a/packages/guardian-client/package-lock.json
+++ b/packages/guardian-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openzeppelin/guardian-client",
-  "version": "0.16.2",
+  "version": "0.17.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openzeppelin/guardian-client",
-      "version": "0.16.2",
+      "version": "0.17.0-rc.1",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.7.2",

--- a/packages/guardian-client/package.json
+++ b/packages/guardian-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/guardian-client",
-  "version": "0.16.2",
+  "version": "0.17.0-rc.1",
   "description": "TypeScript HTTP client for Guardian server",
   "repository": {
     "type": "git",

--- a/packages/guardian-evm-client/package-lock.json
+++ b/packages/guardian-evm-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openzeppelin/guardian-evm-client",
-  "version": "0.16.2",
+  "version": "0.17.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openzeppelin/guardian-evm-client",
-      "version": "0.16.2",
+      "version": "0.17.0-rc.1",
       "license": "MIT",
       "dependencies": {
         "viem": "^2.47.5"

--- a/packages/guardian-evm-client/package.json
+++ b/packages/guardian-evm-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/guardian-evm-client",
-  "version": "0.16.2",
+  "version": "0.17.0-rc.1",
   "description": "TypeScript EVM client for Guardian server proposal workflows",
   "repository": {
     "type": "git",

--- a/packages/guardian-operator-client/README.md
+++ b/packages/guardian-operator-client/README.md
@@ -163,6 +163,13 @@ console.log('raw bytes (base64):', debug.rawTransactionSummary);
 Single-key Miden accounts and EVM accounts always return an empty
 proposal queue.
 
+Send proposals carry their P2ID fields on the entry metadata. `noteType`
+is the note's visibility, absent meaning public (issue #322).
+`reclaimHeight` and `timelockHeight` are optional P2IDE constraints
+(issue #366): the presence of *either* means the proposal creates a P2IDE
+note rather than a plain P2ID one, so a dashboard should surface them as
+spend conditions rather than hiding them.
+
 ```typescript
 const page = await client.listAccountProposals('0x...', { limit: 50 });
 for (const entry of page.items) {

--- a/packages/guardian-operator-client/package-lock.json
+++ b/packages/guardian-operator-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openzeppelin/guardian-operator-client",
-  "version": "0.16.2",
+  "version": "0.17.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openzeppelin/guardian-operator-client",
-      "version": "0.16.2",
+      "version": "0.17.0-rc.1",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.7.2",

--- a/packages/guardian-operator-client/package.json
+++ b/packages/guardian-operator-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/guardian-operator-client",
-  "version": "0.16.2",
+  "version": "0.17.0-rc.1",
   "description": "TypeScript HTTP client for Guardian operator dashboard endpoints",
   "repository": {
     "type": "git",

--- a/packages/miden-multisig-client/package-lock.json
+++ b/packages/miden-multisig-client/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@openzeppelin/miden-multisig-client",
-  "version": "0.16.2",
+  "version": "0.17.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openzeppelin/miden-multisig-client",
-      "version": "0.16.2",
+      "version": "0.17.0-rc.1",
       "license": "MIT",
       "dependencies": {
         "@miden-sdk/miden-sdk": "0.16.0-rc.3",
         "@noble/curves": "^1.9.7",
         "@noble/hashes": "^2.0.1",
-        "@openzeppelin/guardian-client": "^0.16.2"
+        "@openzeppelin/guardian-client": "^0.17.0-rc.1"
       },
       "devDependencies": {
         "@playwright/test": "^1.60.0",

--- a/packages/miden-multisig-client/package.json
+++ b/packages/miden-multisig-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/miden-multisig-client",
-  "version": "0.16.2",
+  "version": "0.17.0-rc.1",
   "description": "TypeScript SDK for Miden multisig accounts with GUARDIAN integration",
   "repository": {
     "type": "git",
@@ -40,7 +40,7 @@
     "@miden-sdk/miden-sdk": "0.16.0-rc.3",
     "@noble/curves": "^1.9.7",
     "@noble/hashes": "^2.0.1",
-    "@openzeppelin/guardian-client": "^0.16.2"
+    "@openzeppelin/guardian-client": "^0.17.0-rc.1"
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0",


### PR DESCRIPTION
v0.17.0-rc.1 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the project and client packages to version `0.17.0-rc.1`.
  * Prerelease packages are now published under the `rc` tag, while stable releases use `latest`.

* **Documentation**
  * Updated compatibility and API documentation for the 0.17.0 release candidate.
  * Documented account delta utilities and send-proposal metadata fields, including note visibility and spending conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->