### PR TITLE
perf: build dependencies optimized for tests; run the suite via nextest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,15 +57,31 @@ jobs:
           cache-on-failure: true
 
       - name: Install cargo-llvm-cov
+        if: github.event_name == 'push'
         uses: taiki-e/install-action@4a44d353abec8bd780e47de38e5bc5ea77053391 # cargo-llvm-cov
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@742a3ac9a75553d78e25773da9e6c438fdc5a74a # nextest
 
-      # nextest schedules every binary's tests in one parallel pool (cargo
-      # test parallelizes only within a binary) and prints per-test timings,
-      # so slow tests are visible in the log.
-      - name: Run tests with coverage
+      # Coverage runs on pushes to main only: instrumentation slows test
+      # execution 1.5-2x and forces workspace crates to recompile under
+      # coverage flags, and was the dominant remaining cost on the PR path.
+      # PRs run the same test set uninstrumented; Codecov tracks trends from
+      # main. nextest schedules every binary's tests in one parallel pool
+      # (cargo test parallelizes only within a binary) and prints per-test
+      # timings, so slow tests are visible in the log.
+      - name: Run tests (PRs, uninstrumented)
+        if: github.event_name != 'push'
+        run: >-
+          cargo nextest run
+          --workspace
+          --exclude guardian-prod-benchmarks
+          --exclude guardian-server-bench-loadgen
+          --exclude guardian-demo
+          --exclude guardian-rust-example
+
+      - name: Run tests with coverage (main)
+        if: github.event_name == 'push'
         run: >-
           cargo llvm-cov nextest
           --workspace
@@ -89,6 +105,7 @@ jobs:
           --doc
 
       - name: Upload coverage to Codecov
+        if: github.event_name == 'push'
         uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           files: ./lcov.info
@@ -475,7 +492,11 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'OpenZeppelin'
+    # Main-only: this job proves the reproducible release profile (LTO,
+    # codegen-units=1) compiles with all features — ~5m per run that PR
+    # feedback does not need. A skipped job still reports a check run, so
+    # required-check rules stay satisfied on PRs.
+    if: github.repository_owner == 'OpenZeppelin' && github.event_name == 'push'
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,29 +46,15 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libpq-dev
 
-      - name: Cache cargo registry
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      # rust-cache prunes workspace-member artifacts before saving (they
+      # recompile anyway) and dedupes the target dir, keeping per-job caches
+      # within the repo's 10GB Actions cache quota. Keys automatically include
+      # the job id, toolchain, and all Cargo manifests.
+      - name: Cache cargo (rust-cache)
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
-          path: ~/.cargo/registry/index
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-registry-
-
-      - name: Cache cargo git
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-git-
-
-      - name: Cache cargo build
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock', 'Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-build-target-
+          prefix-key: v1-rust
+          cache-on-failure: true
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@4a44d353abec8bd780e47de38e5bc5ea77053391 # cargo-llvm-cov
@@ -132,16 +118,11 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libpq-dev
 
-      - name: Cache cargo
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - name: Cache cargo (rust-cache)
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
-          path: |
-            ~/.cargo/registry/index
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-authz-test-probe-${{ hashFiles('**/Cargo.lock', 'Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-authz-test-probe-
+          prefix-key: v1-rust
+          cache-on-failure: true
 
       - name: Run authz test probe tests
         run: >-
@@ -175,16 +156,11 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libpq-dev
 
-      - name: Cache cargo
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - name: Cache cargo (rust-cache)
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
-          path: |
-            ~/.cargo/registry/index
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-server-feature-tests-${{ hashFiles('**/Cargo.lock', 'Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-server-feature-tests-
+          prefix-key: v1-rust
+          cache-on-failure: true
 
       - name: Run server integration tests
         run: >-
@@ -240,16 +216,11 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libpq-dev
 
-      - name: Cache cargo
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - name: Cache cargo (rust-cache)
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
-          path: |
-            ~/.cargo/registry/index
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-postgres-test-${{ hashFiles('**/Cargo.lock', 'Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-postgres-test-
+          prefix-key: v1-rust
+          cache-on-failure: true
 
       - name: Run Postgres-backed tests
         env:
@@ -307,24 +278,13 @@ jobs:
         if: matrix.package == 'miden-multisig-client'
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
-      - name: Cache cargo
+      - name: Cache cargo (rust-cache)
         if: matrix.package == 'miden-multisig-client'
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
-          path: |
-            ~/.cargo/registry/index
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-npm-multisig-${{ hashFiles('**/Cargo.lock', 'Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-npm-multisig-
+          prefix-key: v1-rust
+          cache-on-failure: true
 
-      # rust-toolchain.toml pins a toolchain with components that rustup syncs
-      # on first cargo use. Two test files shell out to `cargo run`
-      # concurrently (procedure-roots, account-roundtrip), and concurrent
-      # first-use syncs race each other ("detected conflict: 'bin/cargo'").
-      # Building both example fixtures here syncs once, serially, and turns
-      # the in-test cargo runs into cache hits.
       - name: Sync pinned toolchain and prebuild example fixtures
         if: matrix.package == 'miden-multisig-client'
         working-directory: .
@@ -372,16 +332,11 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libpq-dev
 
-      - name: Cache cargo
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - name: Cache cargo (rust-cache)
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
-          path: |
-            ~/.cargo/registry/index
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-contracts-${{ hashFiles('**/Cargo.lock', 'Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-contracts-
+          prefix-key: v1-rust
+          cache-on-failure: true
 
       - name: Run contract behavior and SDK integration tests
         run: cargo test -p miden-confidential-contracts -p miden-multisig-client --all-targets
@@ -453,16 +408,11 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libpq-dev
 
-      - name: Cache cargo
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - name: Cache cargo (rust-cache)
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
-          path: |
-            ~/.cargo/registry/index
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock', 'Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-clippy-
+          prefix-key: v1-rust
+          cache-on-failure: true
 
       - name: Build (generate protobuf descriptors)
         run: cargo build --package guardian-server
@@ -557,19 +507,11 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libpq-dev
 
-      - name: Cache cargo
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - name: Cache cargo (rust-cache)
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
-          path: |
-            ~/.cargo/registry/index
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-openapi-${{ hashFiles('**/Cargo.lock', 'Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-openapi-
+          prefix-key: v1-rust
+          cache-on-failure: true
 
-      # Fails if the committed docs/openapi*.json files are out of sync
-      # with the utoipa annotations. Regenerate with:
-      #   cargo run --features evm --bin gen-openapi -- docs
       - name: Check OpenAPI spec is up to date
         run: cargo run --features evm --bin gen-openapi -- --check docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,11 +139,11 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           prefix-key: v1-rust
-          # One dependency cache shared by the full-build dev jobs (rust-cache
-          # still splits it per toolchain): their dep artifacts are near-
-          # identical, and per-job copies crowded the 10GB repo cache quota
-          # alongside the docker-publish buildkit layer caches.
-          shared-key: dev-deps
+          # Dependency caches shared by pairs of jobs with near-identical builds
+          # (one shared key would leave feature-specific deltas uncached: only the
+          # first save per key wins). Per-job copies crowded the 10GB repo cache
+          # quota shared with docker-publish buildkit layer caches.
+          shared-key: server-dev
           cache-on-failure: true
 
       - name: Run authz test probe tests
@@ -182,11 +182,11 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           prefix-key: v1-rust
-          # One dependency cache shared by the full-build dev jobs (rust-cache
-          # still splits it per toolchain): their dep artifacts are near-
-          # identical, and per-job copies crowded the 10GB repo cache quota
-          # alongside the docker-publish buildkit layer caches.
-          shared-key: dev-deps
+          # Dependency caches shared by pairs of jobs with near-identical builds
+          # (one shared key would leave feature-specific deltas uncached: only the
+          # first save per key wins). Per-job copies crowded the 10GB repo cache
+          # quota shared with docker-publish buildkit layer caches.
+          shared-key: server-feature-dev
           cache-on-failure: true
 
       - name: Run server integration tests
@@ -247,11 +247,11 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           prefix-key: v1-rust
-          # One dependency cache shared by the full-build dev jobs (rust-cache
-          # still splits it per toolchain): their dep artifacts are near-
-          # identical, and per-job copies crowded the 10GB repo cache quota
-          # alongside the docker-publish buildkit layer caches.
-          shared-key: dev-deps
+          # Dependency caches shared by pairs of jobs with near-identical builds
+          # (one shared key would leave feature-specific deltas uncached: only the
+          # first save per key wins). Per-job copies crowded the 10GB repo cache
+          # quota shared with docker-publish buildkit layer caches.
+          shared-key: server-feature-dev
           cache-on-failure: true
 
       - name: Run Postgres-backed tests
@@ -315,11 +315,11 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           prefix-key: v1-rust
-          # One dependency cache shared by the full-build dev jobs (rust-cache
-          # still splits it per toolchain): their dep artifacts are near-
-          # identical, and per-job copies crowded the 10GB repo cache quota
-          # alongside the docker-publish buildkit layer caches.
-          shared-key: dev-deps
+          # Dependency caches shared by pairs of jobs with near-identical builds
+          # (one shared key would leave feature-specific deltas uncached: only the
+          # first save per key wins). Per-job copies crowded the 10GB repo cache
+          # quota shared with docker-publish buildkit layer caches.
+          shared-key: miden-dev
           cache-on-failure: true
 
       - name: Sync pinned toolchain and prebuild example fixtures
@@ -373,11 +373,11 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           prefix-key: v1-rust
-          # One dependency cache shared by the full-build dev jobs (rust-cache
-          # still splits it per toolchain): their dep artifacts are near-
-          # identical, and per-job copies crowded the 10GB repo cache quota
-          # alongside the docker-publish buildkit layer caches.
-          shared-key: dev-deps
+          # Dependency caches shared by pairs of jobs with near-identical builds
+          # (one shared key would leave feature-specific deltas uncached: only the
+          # first save per key wins). Per-job copies crowded the 10GB repo cache
+          # quota shared with docker-publish buildkit layer caches.
+          shared-key: miden-dev
           cache-on-failure: true
 
       - name: Run contract behavior and SDK integration tests
@@ -557,11 +557,11 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           prefix-key: v1-rust
-          # One dependency cache shared by the full-build dev jobs (rust-cache
-          # still splits it per toolchain): their dep artifacts are near-
-          # identical, and per-job copies crowded the 10GB repo cache quota
-          # alongside the docker-publish buildkit layer caches.
-          shared-key: dev-deps
+          # Dependency caches shared by pairs of jobs with near-identical builds
+          # (one shared key would leave feature-specific deltas uncached: only the
+          # first save per key wins). Per-job copies crowded the 10GB repo cache
+          # quota shared with docker-publish buildkit layer caches.
+          shared-key: server-dev
           cache-on-failure: true
 
       - name: Check OpenAPI spec is up to date

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,11 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           prefix-key: v1-rust
+          # One dependency cache shared by the full-build dev jobs (rust-cache
+          # still splits it per toolchain): their dep artifacts are near-
+          # identical, and per-job copies crowded the 10GB repo cache quota
+          # alongside the docker-publish buildkit layer caches.
+          shared-key: dev-deps
           cache-on-failure: true
 
       - name: Run authz test probe tests
@@ -160,6 +165,11 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           prefix-key: v1-rust
+          # One dependency cache shared by the full-build dev jobs (rust-cache
+          # still splits it per toolchain): their dep artifacts are near-
+          # identical, and per-job copies crowded the 10GB repo cache quota
+          # alongside the docker-publish buildkit layer caches.
+          shared-key: dev-deps
           cache-on-failure: true
 
       - name: Run server integration tests
@@ -220,6 +230,11 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           prefix-key: v1-rust
+          # One dependency cache shared by the full-build dev jobs (rust-cache
+          # still splits it per toolchain): their dep artifacts are near-
+          # identical, and per-job copies crowded the 10GB repo cache quota
+          # alongside the docker-publish buildkit layer caches.
+          shared-key: dev-deps
           cache-on-failure: true
 
       - name: Run Postgres-backed tests
@@ -283,6 +298,11 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           prefix-key: v1-rust
+          # One dependency cache shared by the full-build dev jobs (rust-cache
+          # still splits it per toolchain): their dep artifacts are near-
+          # identical, and per-job copies crowded the 10GB repo cache quota
+          # alongside the docker-publish buildkit layer caches.
+          shared-key: dev-deps
           cache-on-failure: true
 
       - name: Sync pinned toolchain and prebuild example fixtures
@@ -336,6 +356,11 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           prefix-key: v1-rust
+          # One dependency cache shared by the full-build dev jobs (rust-cache
+          # still splits it per toolchain): their dep artifacts are near-
+          # identical, and per-job copies crowded the 10GB repo cache quota
+          # alongside the docker-publish buildkit layer caches.
+          shared-key: dev-deps
           cache-on-failure: true
 
       - name: Run contract behavior and SDK integration tests
@@ -511,6 +536,11 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           prefix-key: v1-rust
+          # One dependency cache shared by the full-build dev jobs (rust-cache
+          # still splits it per toolchain): their dep artifacts are near-
+          # identical, and per-job copies crowded the 10GB repo cache quota
+          # alongside the docker-publish buildkit layer caches.
+          shared-key: dev-deps
           cache-on-failure: true
 
       - name: Check OpenAPI spec is up to date

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock', 'Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-build-target-
 
@@ -136,7 +136,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-authz-test-probe-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-authz-test-probe-${{ hashFiles('**/Cargo.lock', 'Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-authz-test-probe-
 
@@ -179,7 +179,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-server-feature-tests-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-server-feature-tests-${{ hashFiles('**/Cargo.lock', 'Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-server-feature-tests-
 
@@ -244,7 +244,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-postgres-test-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-postgres-test-${{ hashFiles('**/Cargo.lock', 'Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-postgres-test-
 
@@ -312,7 +312,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-npm-multisig-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-npm-multisig-${{ hashFiles('**/Cargo.lock', 'Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-npm-multisig-
 
@@ -376,7 +376,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-contracts-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-contracts-${{ hashFiles('**/Cargo.lock', 'Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-contracts-
 
@@ -457,7 +457,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock', 'Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-clippy-
 
@@ -561,7 +561,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-openapi-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-openapi-${{ hashFiles('**/Cargo.lock', 'Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-openapi-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,9 +70,15 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@4a44d353abec8bd780e47de38e5bc5ea77053391 # cargo-llvm-cov
 
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@742a3ac9a75553d78e25773da9e6c438fdc5a74a # nextest
+
+      # nextest schedules every binary's tests in one parallel pool (cargo
+      # test parallelizes only within a binary) and prints per-test timings,
+      # so slow tests are visible in the log.
       - name: Run tests with coverage
         run: >-
-          cargo llvm-cov
+          cargo llvm-cov nextest
           --workspace
           --exclude guardian-prod-benchmarks
           --exclude guardian-server-bench-loadgen

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,11 +467,11 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    # Main-only: this job proves the reproducible release profile (LTO,
-    # codegen-units=1) compiles with all features — ~5m per run that PR
-    # feedback does not need. A skipped job still reports a check run, so
-    # required-check rules stay satisfied on PRs.
-    if: github.repository_owner == 'OpenZeppelin' && github.event_name == 'push'
+    # Runs on every PR (review feedback): this is the only job compiling
+    # --all-features and the only release-profile (LTO) compile, so it is
+    # the sole pre-merge signal for feature-unification and link-stage
+    # breakage. ~5m warm, fully parallel with the other jobs.
+    if: github.repository_owner == 'OpenZeppelin'
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # Incremental state is dead weight in CI (caches restore whole target dirs)
+  # and inflates every cached target dir against the 10GB repo cache quota.
+  CARGO_INCREMENTAL: "0"
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
   server-feature-tests:
     name: Server Integration and E2E
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 35
     if: github.repository_owner == 'OpenZeppelin'
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -202,7 +202,7 @@ jobs:
   postgres-test:
     name: Postgres Test Suite
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 35
     if: github.repository_owner == 'OpenZeppelin'
     services:
       postgres:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,11 +139,6 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           prefix-key: v1-rust
-          # Dependency caches shared by pairs of jobs with near-identical builds
-          # (one shared key would leave feature-specific deltas uncached: only the
-          # first save per key wins). Per-job copies crowded the 10GB repo cache
-          # quota shared with docker-publish buildkit layer caches.
-          shared-key: server-dev
           cache-on-failure: true
 
       - name: Run authz test probe tests
@@ -182,11 +177,6 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           prefix-key: v1-rust
-          # Dependency caches shared by pairs of jobs with near-identical builds
-          # (one shared key would leave feature-specific deltas uncached: only the
-          # first save per key wins). Per-job copies crowded the 10GB repo cache
-          # quota shared with docker-publish buildkit layer caches.
-          shared-key: server-feature-dev
           cache-on-failure: true
 
       - name: Run server integration tests
@@ -247,11 +237,6 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           prefix-key: v1-rust
-          # Dependency caches shared by pairs of jobs with near-identical builds
-          # (one shared key would leave feature-specific deltas uncached: only the
-          # first save per key wins). Per-job copies crowded the 10GB repo cache
-          # quota shared with docker-publish buildkit layer caches.
-          shared-key: server-feature-dev
           cache-on-failure: true
 
       - name: Run Postgres-backed tests
@@ -315,11 +300,6 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           prefix-key: v1-rust
-          # Dependency caches shared by pairs of jobs with near-identical builds
-          # (one shared key would leave feature-specific deltas uncached: only the
-          # first save per key wins). Per-job copies crowded the 10GB repo cache
-          # quota shared with docker-publish buildkit layer caches.
-          shared-key: miden-dev
           cache-on-failure: true
 
       - name: Sync pinned toolchain and prebuild example fixtures
@@ -373,11 +353,6 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           prefix-key: v1-rust
-          # Dependency caches shared by pairs of jobs with near-identical builds
-          # (one shared key would leave feature-specific deltas uncached: only the
-          # first save per key wins). Per-job copies crowded the 10GB repo cache
-          # quota shared with docker-publish buildkit layer caches.
-          shared-key: miden-dev
           cache-on-failure: true
 
       - name: Run contract behavior and SDK integration tests
@@ -557,11 +532,6 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           prefix-key: v1-rust
-          # Dependency caches shared by pairs of jobs with near-identical builds
-          # (one shared key would leave feature-specific deltas uncached: only the
-          # first save per key wins). Per-job copies crowded the 10GB repo cache
-          # quota shared with docker-publish buildkit layer caches.
-          shared-key: server-dev
           cache-on-failure: true
 
       - name: Check OpenAPI spec is up to date

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -167,7 +167,10 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # mode=min stores only final-stage layers: mode=max held ~2.4GB of the
+          # 10GB repo cache quota that the CI cargo caches need, and this
+          # workflow only runs on releases, where a slower image build is fine.
+          cache-to: type=gha,mode=min
           provenance: mode=max
           sbom: true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,10 @@ incremental = false   # Disable incremental compilation for reproducibility
 # compile once and stay cached, so the extra compile cost is paid rarely.
 [profile.dev.package."*"]
 opt-level = 3
+# No debuginfo for dependencies: nobody steps into them, and dep debuginfo at
+# opt-level 3 is the bulk of target-dir size — which matters because CI's
+# per-repo cache quota is 10GB across all jobs' target caches.
+debug = false
 
 [workspace.dependencies]
 # Core

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,15 @@ lto = true            # Link-time optimization for better optimization and deter
 codegen-units = 1     # Single codegen unit for maximum reproducibility
 incremental = false   # Disable incremental compilation for reproducibility
 
+# Dependencies — the crypto crates especially (Falcon, RPO, Merkle) — are an
+# order of magnitude slower at opt-level 0, which dominated test wall-clock
+# (the CI Test Suite spent ~14 of its 20 minutes executing tests). Build
+# dependencies optimized in dev/test/coverage builds; workspace crates keep
+# opt-level 0 for fast rebuilds, debugging, and coverage. Dependencies
+# compile once and stay cached, so the extra compile cost is paid rarely.
+[profile.dev.package."*"]
+opt-level = 3
+
 [workspace.dependencies]
 # Core
 serde = "1.0.228"


### PR DESCRIPTION
## Problem

CI wall clock was the Test Suite job: 20m42s, of which ~17 minutes was pure test execution, not compilation. The server lib suite alone ran 896 tests in 828s — roughly 3.7 core-seconds per test, which pointed at the crypto dependencies (Falcon, RPO, Merkle) executing at `opt-level 0` under the dev/coverage profile.

## Changes

- **`[profile.dev.package."*"] opt-level = 3, debug = false`** — dependencies build optimized (and without debuginfo, which was the bulk of target-dir size) in dev/test/coverage builds; workspace crates keep `opt-level 0` for fast rebuilds, debugging, and coverage instrumentation. Dependencies compile once per lockfile/manifest change and stay cached. Every dev-profile CI job inherits the speedup.
- **`cargo nextest` for the test suite** — schedules every binary's tests in one parallel pool (plain `cargo test` parallelizes only within a binary) and prints per-test timings, so slow tests stay visible in CI logs.
- **Coverage on main pushes only** — instrumentation slows test execution 1.5–2× and recompiles workspace crates under coverage flags, and was the dominant remaining cost on the PR path. PRs run the identical test set uninstrumented via `cargo nextest run`; `cargo llvm-cov nextest` + the Codecov upload run on pushes to main, so Codecov keeps tracking trends. Doctests still run everywhere. Gating uses step-level `if:`, so skipped steps never leave required checks hanging.
- **Release Build job stays on every PR** (review feedback) — it is the only job compiling `--all-features` and the only release-profile (LTO) compile, so it is the sole pre-merge signal for feature-unification and link-stage breakage.
- **Caching reworked around the 10GB Actions cache quota** — per-job `Swatinem/rust-cache` (prunes workspace artifacts, dedupes target dirs), `CARGO_INCREMENTAL=0` workflow-wide, and docker-publish's buildkit cache moved from `mode=max` to `mode=min` (release-only workflow; frees ~2.4GB of intermediate layers).
- **Integration/Postgres job timeouts raised 20 → 35 minutes** — a cold dependency rebuild (any future `Cargo.lock` bump) must fit inside the timeout, and a timed-out job never runs its cache-save post step, which would otherwise loop cold forever.

## Measured impact

Verified on this PR's own runs with warm caches, all jobs green: **PR wall clock dropped 20m42s → ~5m** (the release Build job is the pole; test and lint feedback lands at ~3m22s). Per job: Test Suite 20m42s → 3m22s, Server Integration and E2E 7m52s → 2m03s, OpenAPI Spec Drift 5m30s → 3m03s, Authz Probe 4m58s → 1m29s, TypeScript multisig tests 4m41s → 1m39s, Contract Behavior 2m34s → 1m34s; Postgres and Clippy hold at ~2m; Build ~5m. Main pushes additionally run coverage (~8m, non-blocking). The cache store sits at ~7GB of the 10GB quota with zero churn across warm runs.

Correctness validation: the full workspace suite (1208 tests, same exclusions as CI) passes under nextest's process-per-test isolation, with the 2 known ignored Postgres tests skipped. The slowest remaining tests are contract-behavior VM executions at 2–4.6s each — genuine work, so no test-level changes were made. The Postgres suite job stays on `cargo test` (shared-database timing assumptions).

## Cache design notes (for future maintainers)

- Per-job rust-cache keys are deliberate: cache *sharing* between jobs loses to cargo feature unification — only the first job to save a shared key wins it, and every other job permanently rebuilds a multi-minute dependency delta (measured 6–12m per run in both a single-shared-key and a pairwise-shared experiment during this PR). Per-job keys were the only configuration observed uniformly warm.
- The first run after any `Cargo.lock`/workspace-manifest change re-primes dependencies for the affected jobs (~15m each, in parallel) before re-saving; subsequent runs are warm. After merge, main's first push pays one prime and saves main-scoped caches that all future PRs then restore from.
- Keep an eye on the cache store if new workflows start caching heavily — LRU eviction at the 10GB quota silently reverts jobs to cold rebuilds, which presents as "CI got slow again".

## Deferred follow-ups

- Skip the Rust jobs on docs-only PRs (needs a change-detector job so required checks report as skipped rather than hang).
- A merge queue would let the Build job run once per merge candidate instead of per commit, and validate PRs against latest main; requires admin enablement and a team process change, so out of scope here.
- Larger runners would roughly halve the remaining test execution if ~5m ever feels slow.
