### PR TITLE
fix(ci): pre-install pinned Rust toolchain in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -129,6 +129,12 @@ jobs:
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
+      - name: Install pinned Rust toolchain
+        # Package tests spawn `cargo run` from parallel vitest workers; rustup
+        # is not concurrency-safe, so install the rust-toolchain.toml pin here
+        # before those concurrent invocations race to install it themselves.
+        run: rustup toolchain install
+
       - name: Build, test, and publish
         env:
           PACKAGES: ${{ needs.prepare.outputs.packages }}


### PR DESCRIPTION
The package build/test scripts spawn `cargo run` from parallel vitest workers. On a fresh runner the pinned toolchain (1.96.1) is not installed yet, so each concurrent cargo invocation triggers its own rustup install; rustup is not concurrency-safe and the installs corrupt each other ("detected conflict: 'bin/cargo'"), failing the publish deterministically.

Install the rust-toolchain.toml pin serially before the build loop.

Seen as errors here:
- https://github.com/OpenZeppelin/guardian/actions/runs/32751675031/job/97509920937
- https://github.com/OpenZeppelin/guardian/actions/runs/32756869949/job/97526396343